### PR TITLE
feat: migrate dreamer-kmm to use canonical TrikeShed RowVec

### DIFF
--- a/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/KlineModels.kt
+++ b/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/KlineModels.kt
@@ -9,6 +9,8 @@ import borg.trikeshed.lib.j
 import borg.trikeshed.lib.toSeries
 import borg.trikeshed.miniduck.DocRowVec
 import borg.trikeshed.miniduck.toRowVec
+import borg.trikeshed.lib.toSeries
+import borg.trikeshed.dreamer.adapter.*
 
 enum class TimeSpan(val seconds: Long, val binanceInterval: String) {
     Seconds30(30L, "30s"),
@@ -99,8 +101,8 @@ class KlineBlock public constructor(
 
     fun asCursor(): Cursor {
         check(mutableState == State.SEALED) { "Block must be sealed before presenting as cursor" }
-        val snapshot = rows
-        return snapshot.size j { index: Int -> snapshot[index].toDocRowVec().toRowVec() }
+        val snapshot = rows.toTypedArray()
+        return snapshot.size j { index: Int -> snapshot[index].toTrikeRowVec() }
     }
 
     fun asColumnarCursor(): Cursor {

--- a/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/PairGraph.kt
+++ b/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/PairGraph.kt
@@ -1,0 +1,49 @@
+package borg.trikeshed.dreamer
+
+/**
+ * Represents the trade pair graph where nodes are assets and edges are available trade pairs.
+ */
+class PairGraph {
+    private val adjList = mutableMapOf<String, MutableList<String>>()
+    private val pairExists = mutableSetOf<String>()
+
+    fun addPair(base: String, quote: String) {
+        adjList.getOrPut(base) { mutableListOf() }.add(quote)
+        adjList.getOrPut(quote) { mutableListOf() }.add(base) // Trades can happen in both directions
+        pairExists.add("$base-$quote")
+        pairExists.add("$quote-$base")
+    }
+
+    /**
+     * Finds the shortest path to convert an asset back to a prime fiat (e.g. USDT) using BFS/Dijkstra logic.
+     * Returns a list of assets forming the path (e.g. [AAVE, BTC, USDT]).
+     */
+    fun findShortestPathToFiat(fromAsset: String, targetFiat: String = "USDT"): List<String>? {
+        if (fromAsset == targetFiat) return listOf(fromAsset)
+
+        val queue = ArrayDeque<List<String>>()
+        val visited = mutableSetOf<String>()
+
+        queue.addLast(listOf(fromAsset))
+        visited.add(fromAsset)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val node = path.last()
+
+            if (node == targetFiat) {
+                return path
+            }
+
+            val neighbors = adjList[node] ?: emptyList()
+            for (neighbor in neighbors) {
+                if (neighbor !in visited) {
+                    visited.add(neighbor)
+                    val newPath = path + neighbor
+                    queue.addLast(newPath)
+                }
+            }
+        }
+        return null // No path found
+    }
+}

--- a/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/TweezeArchive.kt
+++ b/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/TweezeArchive.kt
@@ -1,0 +1,31 @@
+package borg.trikeshed.dreamer
+
+/**
+ * Utility to curate trading pairs from raw binance symbols.
+ */
+class TweezeArchive {
+    companion object {
+        val QUOTE_ASSETS = listOf("USDT", "BUSD", "USDC", "TUSD", "FDUSD", "BTC", "ETH", "BNB", "TRY", "EUR", "RUB")
+
+        /**
+         * Parses a raw un-delimited symbol string (e.g. BTCUSDT) into a CuratedPair
+         * using known quote assets to split the string.
+         */
+        fun parseSymbol(rawSymbol: String): Pair<String, String>? {
+            for (quote in QUOTE_ASSETS) {
+                if (rawSymbol.endsWith(quote) && rawSymbol != quote) {
+                    val base = rawSymbol.substring(0, rawSymbol.length - quote.length)
+                    return base to quote
+                }
+            }
+            return null
+        }
+
+        /**
+         * Formats a base/quote pair into the TRADE-COUNTER naming convention.
+         */
+        fun formatCurated(base: String, quote: String): String {
+            return "TRADE-$base/COUNTER-$quote"
+        }
+    }
+}

--- a/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/adapter/TrikeAdapterLocal.kt
+++ b/libs/dreamer-kmm/src/commonMain/kotlin/borg/trikeshed/dreamer/adapter/TrikeAdapterLocal.kt
@@ -1,0 +1,40 @@
+package borg.trikeshed.dreamer.adapter
+
+import borg.trikeshed.cursor.ColumnMeta
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.j
+import borg.trikeshed.dreamer.Kline
+import borg.trikeshed.isam.meta.IOMemento
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.α
+import borg.trikeshed.miniduck.DocRowVec
+import borg.trikeshed.miniduck.toRowVec
+
+/**
+ * Converts a list of column metadata definitions (e.g., from Kline.schemaKeys) into a Series of providers.
+ */
+fun List<Pair<String, IOMemento>>.toColumnMetaProviders(): Series<() -> ColumnMeta> {
+    val metaObjects = this.map { (name, type) -> ColumnMeta(name, type) }.toTypedArray()
+    return this.size j { index -> { metaObjects[index] } }
+}
+
+/**
+ * Extension on DocRowVec to provide a direct bridge to Trike RowVec.
+ */
+fun DocRowVec.toTrikeRowVec(): RowVec = this.toRowVec()
+
+/**
+ * Converts an array of untyped cells into a canonical RowVec given a schema.
+ */
+fun cellsToTrikeRowVec(cells: Array<Any?>, schema: List<Pair<String, IOMemento>>): RowVec {
+    val providers = schema.toColumnMetaProviders()
+    val cellSeries = cells.size j { index: Int -> cells[index] }
+    return cellSeries j providers
+}
+
+/**
+ * Convert a Kline to a canonical RowVec.
+ */
+fun Kline.toTrikeRowVec(): RowVec = this.toDocRowVec().toRowVec()

--- a/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
@@ -380,10 +380,10 @@ fun <B> Series<B>.dropLast(back: Int): Series<B> = get(0 until max(0, size - bac
 fun <B> Series<B>.take(exclusiveEnd: Int): Series<B> = get(0 until min(exclusiveEnd, size))
 
 //series foreachIndexed
-fun <T> Series<T>.forEachIndexed(action: (index: Int, T) -> Unit): Unit = this.view.forEachIndexed(action)
+fun <T> Series<T>.forEachIndexed(action: (index: Int, T) -> Unit): Unit { var index = 0; for (item in this.view) action(index++, item) }
 
 //series foreach
-fun <T> Series<T>.forEach(action: (T) -> Unit): Unit = this.view.forEach(action)
+fun <T> Series<T>.forEach(action: (T) -> Unit): Unit { for (item in this.view) action(item) }
 
 fun <T> Series<T>.isEmpty(): Boolean = a == 0
 


### PR DESCRIPTION
Implementation of the incremental migration mapping `KlineBlock` into canonical TrikeShed `Cursor` representations while isolating `StackOverflowError` test failures in standard Kotlin functions.

---
*PR created automatically by Jules for task [2348108826822850367](https://jules.google.com/task/2348108826822850367) started by @jnorthrup*