### PR TITLE
feat: Implement NARS3 machine integration with Polyglot using refeeding atoms and channelized reactor jobs

### DIFF
--- a/libs/kursive/src/commonMain/kotlin/borg/trikeshed/parse/kursive/nars3/Nars3Machine.kt
+++ b/libs/kursive/src/commonMain/kotlin/borg/trikeshed/parse/kursive/nars3/Nars3Machine.kt
@@ -1,0 +1,119 @@
+package borg.trikeshed.parse.kursive.nars3
+
+import borg.trikeshed.lib.*
+import borg.trikeshed.collections.s_
+import borg.trikeshed.parse.kursive.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+
+// NARS3 Machine and Context
+
+/**
+ * NARS3 IKR Resource Budget.
+ */
+data class Nars3Budget(
+    val priority: Float,
+    val durability: Float,
+    val quality: Float
+)
+
+/**
+ * An item of knowledge, potentially incomplete, processed by atoms.
+ */
+data class Nars3Message(
+    val content: String,
+    val budget: Nars3Budget,
+    val elements: Series<NarsiveElement> = Join.emptySeriesOf()
+)
+
+/**
+ * A NARS3 Atom: The fundamental unit of execution in the NARS3 Machine.
+ * Atoms are refeeding, meaning they can process inputs and produce outputs,
+ * exploring IKR (Incomplete Knowledge and Resources) via channels.
+ */
+abstract class Nars3Atom(
+    val id: String,
+    val knowledge: Series<NarsiveElement>,
+    var resources: Nars3Budget
+) {
+    abstract suspend fun process(input: Channel<Nars3Message>, output: Channel<Nars3Message>)
+}
+
+class LocalAtom(id: String, knowledge: Series<NarsiveElement>, resources: Nars3Budget) : Nars3Atom(id, knowledge, resources) {
+    override suspend fun process(input: Channel<Nars3Message>, output: Channel<Nars3Message>) {
+        for (msg in input) {
+            // Local processing, deduct from budget
+            val newBudget = Nars3Budget(msg.budget.priority * 0.9f, msg.budget.durability * 0.9f, msg.budget.quality)
+            if (newBudget.priority > 0.1f) {
+                output.send(msg.copy(content = "Local($id) -> ${msg.content}", budget = newBudget))
+            }
+        }
+        output.close()
+    }
+}
+
+class ChannelizedAtom(id: String, knowledge: Series<NarsiveElement>, resources: Nars3Budget) : Nars3Atom(id, knowledge, resources) {
+    override suspend fun process(input: Channel<Nars3Message>, output: Channel<Nars3Message>) {
+        for (msg in input) {
+            // Channelized processing, deduct from budget
+            val newBudget = Nars3Budget(msg.budget.priority * 0.9f, msg.budget.durability * 0.9f, msg.budget.quality)
+            if (newBudget.priority > 0.1f) {
+                output.send(msg.copy(content = "Channelized($id) -> ${msg.content}", budget = newBudget))
+            }
+        }
+        output.close()
+    }
+}
+
+
+/**
+ * The NARS3 Machine: Constructs arbitrary ephemeral arena chains of bottom-to-top
+ * refeeding atoms. It uses a reactor SupervisorJob assembly to manage channelized
+ * and local atoms for exploring IKR.
+ */
+class Nars3Machine(private val scope: CoroutineScope) {
+
+    private val supervisor = SupervisorJob(scope.coroutineContext[Job])
+    private val machineScope = CoroutineScope(scope.coroutineContext + supervisor)
+
+    fun createArenaChain(atoms: Series<Nars3Atom>, initialKnowledge: Nars3Message) {
+        machineScope.launch {
+            if (atoms.isEmpty()) return@launch
+
+            var currentInput = Channel<Nars3Message>()
+            val initialInput = currentInput
+
+            for (i in 0 until atoms.size) {
+                val atom = atoms[i]
+                val currentOutput = Channel<Nars3Message>()
+
+                launch {
+                    atom.process(currentInput, currentOutput)
+                }
+
+                currentInput = currentOutput
+            }
+
+            // Final output handling - bottom to top refeeding
+            launch {
+                for (msg in currentInput) {
+                    if (msg.budget.priority > 0.2f) {
+                        // Refeed to the bottom
+                        initialInput.send(msg.copy(budget = Nars3Budget(msg.budget.priority * 0.8f, msg.budget.durability, msg.budget.quality)))
+                    }
+                }
+                initialInput.close()
+            }
+
+            // Feed initial input
+            launch {
+                initialInput.send(initialKnowledge)
+                initialInput.close()
+            }
+        }
+    }
+
+    fun shutdown() {
+        supervisor.cancel()
+    }
+}

--- a/libs/polyglot/build.gradle.kts
+++ b/libs/polyglot/build.gradle.kts
@@ -1,1 +1,5 @@
 apply(from = "../../gradle/macros/trikeshed-lib.gradle")
+
+dependencies {
+    "commonMainImplementation"(project(":libs:kursive"))
+}

--- a/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/nars3/Nars3PolyglotBridge.kt
+++ b/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/nars3/Nars3PolyglotBridge.kt
@@ -1,0 +1,48 @@
+package borg.trikeshed.polyglot.nars3
+
+import borg.trikeshed.lib.*
+import borg.trikeshed.collections.s_
+import borg.trikeshed.polyglot.*
+import borg.trikeshed.parse.kursive.NarsiveElement
+import borg.trikeshed.parse.kursive.NarsiveElementKind
+import borg.trikeshed.parse.kursive.nars3.*
+
+/**
+ * Bridges Polyglot UniversalAst fragments with NARS3 Machine Atoms.
+ * This allows syntax trees to be processed as part of the NARS3 exploration.
+ */
+object Nars3PolyglotBridge {
+
+    fun fragmentToAtom(fragment: SourceFragment, budget: Nars3Budget): Nars3Atom {
+        val kindLabel = fragment.kind.name
+        val element = NarsiveElement(NarsiveElementKind.UNKNOWN, 0 j 0, kindLabel.toSeries())
+        val isChannelized = fragment.children.size > 0
+
+        return if (isChannelized) {
+             ChannelizedAtom(
+                id = "polyglot-${fragment.kind.name}-${fragment.span.a}",
+                knowledge = s_[element],
+                resources = budget
+            )
+        } else {
+             LocalAtom(
+                id = "polyglot-${fragment.kind.name}-${fragment.span.a}",
+                knowledge = s_[element],
+                resources = budget
+            )
+        }
+    }
+
+    fun astToArenaChain(ast: UniversalAst): Series<Nars3Atom> {
+        val atoms = mutableListOf<Nars3Atom>()
+        val defaultBudget = Nars3Budget(0.5f, 0.5f, 0.5f)
+
+        fun walk(node: SourceFragment) {
+            atoms.add(fragmentToAtom(node, defaultBudget))
+            node.children.view.forEach { walk(it) }
+        }
+
+        walk(ast.root)
+        return atoms.toSeries()
+    }
+}


### PR DESCRIPTION
This PR implements the requested NARS3 production machine. It establishes an ephemeral arena chain architecture that uses bottom-to-top refeeding atoms connected by asynchronous coroutine channels. 

Key changes:
- Created `Nars3Machine`, `Nars3Atom`, `LocalAtom`, and `ChannelizedAtom` in the `kursive` library to handle Incomplete Knowledge and Resources (IKR).
- Connected these concepts to the Polyglot library using `Nars3PolyglotBridge`, turning polyglot fragments into functional NARS3 Atoms.
- Handled coroutine leakage by explicitly closing channelized outputs in `LocalAtom` and `ChannelizedAtom`.
- Addressed string interpolation issues reported in earlier code review where dollar signs where escaped preventing variables from correctly evaluating.

---
*PR created automatically by Jules for task [16513629014604645552](https://jules.google.com/task/16513629014604645552) started by @jnorthrup*