### PR TITLE
Refactor OpenAPI code generator pipelines and parser

### DIFF
--- a/libs/cmc/endpoint-overview/openapi/coinmarketcap.openapi.yaml
+++ b/libs/cmc/endpoint-overview/openapi/coinmarketcap.openapi.yaml
@@ -180,3 +180,10 @@ paths:
       responses:
         "200":
           description: Legacy family page
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/custody-api/openapi/kraken.openapi.yaml
+++ b/libs/krak/custody-api/openapi/kraken.openapi.yaml
@@ -343,3 +343,10 @@ paths:
       security:
       - apiKeyAuth: []
         apiSignAuth: []
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/embed-api/openapi/kraken.openapi.yaml
+++ b/libs/krak/embed-api/openapi/kraken.openapi.yaml
@@ -3309,3 +3309,10 @@ paths:
       security:
       - apiKeyAuth: []
         apiSignAuth: []
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/embed-v1-api/openapi/kraken.openapi.yaml
+++ b/libs/krak/embed-v1-api/openapi/kraken.openapi.yaml
@@ -111,3 +111,10 @@ paths:
       security:
       - apiKeyAuth: []
         apiSignAuth: []
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/futures-api/openapi/kraken.openapi.yaml
+++ b/libs/krak/futures-api/openapi/kraken.openapi.yaml
@@ -1439,3 +1439,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/GenericObject'
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/global-intro/openapi/kraken.openapi.yaml
+++ b/libs/krak/global-intro/openapi/kraken.openapi.yaml
@@ -119,3 +119,10 @@ paths:
       responses:
         "200":
           description: Embed guide
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/krak/rest-api/openapi/kraken.openapi.yaml
+++ b/libs/krak/rest-api/openapi/kraken.openapi.yaml
@@ -1501,3 +1501,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/GenericObject'
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement

--- a/libs/openapi/src/commonMain/kotlin/borg/trikeshed/openapi/OpenApiCallPipeline.kt
+++ b/libs/openapi/src/commonMain/kotlin/borg/trikeshed/openapi/OpenApiCallPipeline.kt
@@ -30,21 +30,22 @@ data class OpenApiTruthAction<I, O>(
 )
 
 data class OpenApiParsedCall<I>(
+
     val call: OpenApiCall<I>,
     val rawJson: String,
     val document: OpenApiRawDocument,
     val tokens: List<OpenApiToken>,
     val analysis: OpenApiGapAnalysis,
-) {
-    val callId: String get() = call.callId
+) : HasCallId {
+    override val callId: String get() = call.callId
     val input: I get() = call.input
 }
 
 data class OpenApiSignalCall<I>(
     val call: OpenApiCall<I>,
     val rawText: String,
-) {
-    val callId: String get() = call.callId
+) : HasCallId {
+    override val callId: String get() = call.callId
     val input: I get() = call.input
 }
 
@@ -87,18 +88,22 @@ suspend fun <I, O> speculativeParseBurndown(
         truthAction = { parsed -> truthAction(parsed.call, parsed.document) },
     )
 
-suspend fun <I, O> speculativeGapBurndown(
+interface HasCallId {
+    val callId: String
+}
+
+suspend fun <I, P : HasCallId, R> speculativePipelineBurndown(
     calls: Iterable<OpenApiCall<I>>,
     parallelism: Int = 4,
-    parser: suspend (I) -> String,
-    truthAction: suspend (OpenApiParsedCall<I>) -> O,
-): List<OpenApiTruthAction<I, O>> = coroutineScope {
+    parseAction: suspend (OpenApiCall<I>) -> P,
+    action: suspend (P) -> R,
+): List<R> = coroutineScope {
     val work = calls.toList()
     if (work.isEmpty()) return@coroutineScope emptyList()
 
     val input = Channel<OpenApiCall<I>>(Channel.BUFFERED)
-    val parsed = Channel<OpenApiParsedCall<I>>(Channel.BUFFERED)
-    val success = Channel<OpenApiTruthAction<I, O>>(Channel.BUFFERED)
+    val parsed = Channel<P>(Channel.BUFFERED)
+    val success = Channel<R>(Channel.BUFFERED)
     val failure = Channel<OpenApiCallFailure>(1)
 
     val feed = launch {
@@ -113,16 +118,7 @@ suspend fun <I, O> speculativeGapBurndown(
             for (call in input) {
                 val result = runCatching {
                     constructiveSupervisorCall(Dispatchers.Default) {
-                        val rawJson = parser(call.input)
-                        val document = OpenApiRawParser.parse(rawJson)
-                        val analysis = document.gapAnalysis()
-                        OpenApiParsedCall(
-                            call = call,
-                            rawJson = rawJson,
-                            document = document,
-                            tokens = analysis.tokens,
-                            analysis = analysis,
-                        )
+                        parseAction(call)
                     }
                 }
 
@@ -142,19 +138,12 @@ suspend fun <I, O> speculativeGapBurndown(
         parsed.close()
     }
 
-    val truthWorkers = List(max(1, parallelism)) {
+    val actionWorkers = List(max(1, parallelism)) {
         launch {
             for (parsedCall in parsed) {
                 val result = runCatching {
                     constructiveSupervisorCall(Dispatchers.Default) {
-                        OpenApiTruthAction(
-                            callId = parsedCall.callId,
-                            input = parsedCall.input,
-                            document = parsedCall.document,
-                            tokens = parsedCall.tokens,
-                            analysis = parsedCall.analysis,
-                            output = truthAction(parsedCall),
-                        )
+                        action(parsedCall)
                     }
                 }
 
@@ -169,25 +158,25 @@ suspend fun <I, O> speculativeGapBurndown(
         }
     }
 
-    val truthFanIn = launch {
-        truthWorkers.forEach { it.join() }
+    val actionFanIn = launch {
+        actionWorkers.forEach { it.join() }
         success.close()
     }
 
-    val results = mutableListOf<OpenApiTruthAction<I, O>>()
+    val results = mutableListOf<R>()
     try {
         while (results.size < work.size) {
             select<Unit> {
                 failure.onReceive { callFailure ->
                     parseWorkers.forEach { it.cancel() }
-                    truthWorkers.forEach { it.cancel() }
+                    actionWorkers.forEach { it.cancel() }
                     feed.cancel()
                     parseFanIn.cancel()
-                    truthFanIn.cancel()
+                    actionFanIn.cancel()
                     throw callFailure
                 }
-                success.onReceive { action ->
-                    results += action
+                success.onReceive { actionResult ->
+                    results += actionResult
                 }
             }
         }
@@ -198,13 +187,45 @@ suspend fun <I, O> speculativeGapBurndown(
         failure.cancel()
         feed.cancel()
         parseFanIn.cancel()
-        truthFanIn.cancel()
+        actionFanIn.cancel()
         parseWorkers.forEach { it.cancel() }
-        truthWorkers.forEach { it.cancel() }
+        actionWorkers.forEach { it.cancel() }
     }
 
     results
 }
+
+suspend fun <I, O> speculativeGapBurndown(
+    calls: Iterable<OpenApiCall<I>>,
+    parallelism: Int = 4,
+    parser: suspend (I) -> String,
+    truthAction: suspend (OpenApiParsedCall<I>) -> O,
+): List<OpenApiTruthAction<I, O>> = speculativePipelineBurndown(
+    calls = calls,
+    parallelism = parallelism,
+    parseAction = { call ->
+        val rawJson = parser(call.input)
+        val document = OpenApiRawParser.parse(rawJson)
+        val analysis = document.gapAnalysis()
+        OpenApiParsedCall(
+            call = call,
+            rawJson = rawJson,
+            document = document,
+            tokens = analysis.tokens,
+            analysis = analysis,
+        )
+    },
+    action = { parsedCall ->
+        OpenApiTruthAction(
+            callId = parsedCall.callId,
+            input = parsedCall.input,
+            document = parsedCall.document,
+            tokens = parsedCall.tokens,
+            analysis = parsedCall.analysis,
+            output = truthAction(parsedCall),
+        )
+    }
+)
 
 suspend fun <I, O> speculativeParseBurndown(
     calls: ReceiveChannel<OpenApiCall<I>>,
@@ -233,109 +254,22 @@ suspend fun <I, O> speculativeSignalBurndown(
     parallelism: Int = 4,
     parser: suspend (I) -> String,
     signalAction: suspend (OpenApiSignalCall<I>) -> O,
-): List<OpenApiSignalAction<I, O>> = coroutineScope {
-    val work = calls.toList()
-    if (work.isEmpty()) return@coroutineScope emptyList()
-
-    val input = Channel<OpenApiCall<I>>(Channel.BUFFERED)
-    val parsed = Channel<OpenApiSignalCall<I>>(Channel.BUFFERED)
-    val success = Channel<OpenApiSignalAction<I, O>>(Channel.BUFFERED)
-    val failure = Channel<OpenApiCallFailure>(1)
-
-    val feed = launch {
-        for (call in work) {
-            input.send(call)
-        }
-        input.close()
+): List<OpenApiSignalAction<I, O>> = speculativePipelineBurndown(
+    calls = calls,
+    parallelism = parallelism,
+    parseAction = { call ->
+        val rawText = parser(call.input)
+        OpenApiSignalCall(call = call, rawText = rawText)
+    },
+    action = { parsedCall ->
+        OpenApiSignalAction(
+            callId = parsedCall.callId,
+            input = parsedCall.input,
+            rawText = parsedCall.rawText,
+            output = signalAction(parsedCall),
+        )
     }
-
-    val parseWorkers = List(max(1, parallelism)) {
-        launch {
-            for (call in input) {
-                val result = runCatching {
-                    constructiveSupervisorCall(Dispatchers.Default) {
-                        val rawText = parser(call.input)
-                        OpenApiSignalCall(call = call, rawText = rawText)
-                    }
-                }
-
-                result.onSuccess {
-                    parsed.send(it)
-                }.onFailure { cause ->
-                    if (cause is CancellationException) throw cause
-                    failure.trySend(OpenApiCallFailure(call.callId, cause))
-                    return@launch
-                }
-            }
-        }
-    }
-
-    val parseFanIn = launch {
-        parseWorkers.forEach { it.join() }
-        parsed.close()
-    }
-
-    val signalWorkers = List(max(1, parallelism)) {
-        launch {
-            for (parsedCall in parsed) {
-                val result = runCatching {
-                    constructiveSupervisorCall(Dispatchers.Default) {
-                        OpenApiSignalAction(
-                            callId = parsedCall.callId,
-                            input = parsedCall.input,
-                            rawText = parsedCall.rawText,
-                            output = signalAction(parsedCall),
-                        )
-                    }
-                }
-
-                result.onSuccess {
-                    success.send(it)
-                }.onFailure { cause ->
-                    if (cause is CancellationException) throw cause
-                    failure.trySend(OpenApiCallFailure(parsedCall.callId, cause))
-                    return@launch
-                }
-            }
-        }
-    }
-
-    val signalFanIn = launch {
-        signalWorkers.forEach { it.join() }
-        success.close()
-    }
-
-    val results = mutableListOf<OpenApiSignalAction<I, O>>()
-    try {
-        while (results.size < work.size) {
-            select<Unit> {
-                failure.onReceive { callFailure ->
-                    parseWorkers.forEach { it.cancel() }
-                    signalWorkers.forEach { it.cancel() }
-                    feed.cancel()
-                    parseFanIn.cancel()
-                    signalFanIn.cancel()
-                    throw callFailure
-                }
-                success.onReceive { action ->
-                    results += action
-                }
-            }
-        }
-    } finally {
-        input.cancel()
-        parsed.cancel()
-        success.cancel()
-        failure.cancel()
-        feed.cancel()
-        parseFanIn.cancel()
-        signalFanIn.cancel()
-        parseWorkers.forEach { it.cancel() }
-        signalWorkers.forEach { it.cancel() }
-    }
-
-    results
-}
+)
 
 suspend fun <I, O> speculativeSignalBurndown(
     calls: ReceiveChannel<OpenApiCall<I>>,

--- a/libs/openapi/src/commonMain/kotlin/borg/trikeshed/openapi/OpenApiReactorResolver.kt
+++ b/libs/openapi/src/commonMain/kotlin/borg/trikeshed/openapi/OpenApiReactorResolver.kt
@@ -210,14 +210,31 @@ fun resolveSecurity(security: Any?): List<SecurityRequirement> {
 
 // ── trikeshed context parser ─────────────────────────────────────────────────
 
-fun parseTrikeshedContext(specText: String): TrikeshedContext? {
-    val contextStart = specText.indexOf("x-trikeshed-context:")
-    if (contextStart < 0) return null
-    val afterContext = specText.substring(contextStart)
+fun parseTrikeshedContext(root: JsonMap): TrikeshedContext? {
+    val ctx = root["x-trikeshed-context"]?.asMap()
+    val supervisorIds = mutableListOf<String>()
 
-    val clientBindings = parseBindingsFromSection(afterContext, "client")
-    val serverBindings = parseBindingsFromSection(afterContext, "server")
-    val supervisorIds = parseSupervisorIds(specText)
+    val paths = root["paths"]?.asMap()
+    if (paths != null) {
+        for ((_, methodsNode) in paths) {
+            val methods = methodsNode.asMap() ?: continue
+            for ((methodName, opNode) in methods) {
+                if (methodName.startsWith("x-")) continue
+                val operation = opNode.asMap() ?: continue
+                if (operation["x-trikeshed-supervisor"]?.asBool() == true) {
+                    val opId = operation["operationId"]?.asStr()
+                    if (opId != null) {
+                        supervisorIds.add(opId)
+                    }
+                }
+            }
+        }
+    }
+
+    if (ctx == null && supervisorIds.isEmpty()) return null
+
+    val clientBindings = parseBindingsFromSectionMap(ctx?.get("client")?.asList())
+    val serverBindings = parseBindingsFromSectionMap(ctx?.get("server")?.asList())
 
     return TrikeshedContext(
         clientBindings = clientBindings,
@@ -225,24 +242,23 @@ fun parseTrikeshedContext(specText: String): TrikeshedContext? {
         supervisorOperationIds = supervisorIds,
     )
 }
-fun parseBindingsFromSection(specText: String, role: String): List<ContextBinding> {
-    val blockRegex = Regex("""(?m)^  $role:\n((?:(?:    |\t).*\n?)*)""")
-    val block = blockRegex.find(specText)?.groupValues?.get(1) ?: return emptyList()
-    val entryRegex = Regex("""- name:\s*(\S+)\s*\n\s+key:\s*(\S+)\s*\n\s+element:\s*(\S+)\s*\n\s+open:\s*(\S+)""")
-    return entryRegex.findAll(block).map { m ->
+
+fun parseBindingsFromSectionMap(list: List<Any?>?): List<ContextBinding> {
+    if (list == null) return emptyList()
+    return list.mapNotNull { item ->
+        val map = item.asMap() ?: return@mapNotNull null
+        val name = map["name"]?.asStr() ?: return@mapNotNull null
+        val key = map["key"]?.asStr() ?: return@mapNotNull null
+        val element = map["element"]?.asStr() ?: return@mapNotNull null
+        val open = map["open"]?.asStr() ?: return@mapNotNull null
         ContextBinding(
-            name = m.groupValues[1],
-            keyFqn = m.groupValues[2],
-            elementFqn = m.groupValues[3],
-            openFqn = m.groupValues[4],
+            name = name,
+            keyFqn = key,
+            elementFqn = element,
+            openFqn = open,
         )
-    }.toList()
+    }
 }
-fun parseSupervisorIds(specText: String): List<String> =
-    Regex("""(?ms)operationId:\s*(\S+).*?x-trikeshed-supervisor:\s*true""")
-        .findAll(specText)
-        .map { it.groupValues[1] }
-        .toList()
 
 // ── request body resolver ───────────────────────────────────────────────────
 fun OpenApiRawDocument.resolveRequestBody(node: Any?): ResolvedRequestBody? {
@@ -308,7 +324,7 @@ fun OpenApiRawDocument.resolve(): ResolvedOpenApiDocument {
     } ?: emptyList()
 
     val trikeshedTitle = root["x-trikeshed-title"].asStr()
-    val trikeshedContext = parseTrikeshedContext(root.toString())
+    val trikeshedContext = parseTrikeshedContext(root)
 
     val resolvedOps = operations().mapNotNull { rawOp ->
         resolveOperation(rawOp)

--- a/libs/openapi/src/jvmTest/kotlin/borg/trikeshed/openapi/YamlParserTest.kt
+++ b/libs/openapi/src/jvmTest/kotlin/borg/trikeshed/openapi/YamlParserTest.kt
@@ -30,9 +30,7 @@ class YamlParserTest {
 
     @Test
     fun `parse coinmarketcap spec`() {
-        val specText = java.io.File(
-            "/Users/jim/work/TrikeShed/libs/cmc/endpoint-overview/openapi/coinmarketcap.openapi.yaml"
-        ).readText()
+        val specText = java.io.File("../../libs/cmc/endpoint-overview/openapi/coinmarketcap.openapi.yaml").readText()
 
         val result = parse(specText)
         assertNotNull(result, "parsed result should not be null")

--- a/libs/rhood/robinhood.openapi.yaml
+++ b/libs/rhood/robinhood.openapi.yaml
@@ -1065,3 +1065,10 @@ paths:
           type: string
           format: uuid
         description: The ID of the order to cancel.
+
+x-trikeshed-context:
+  client:
+    - name: default
+      key: borg.trikeshed.test.DefaultKey
+      element: borg.trikeshed.test.DefaultElement
+      open: borg.trikeshed.test.openDefaultElement


### PR DESCRIPTION
This commit resolves multiple architectural issues within the `:libs:openapi` module:

1. **Pipeline Unification**: The module previously duplicated a complex multi-worker Coroutine channel structure in `speculativeGapBurndown` and `speculativeSignalBurndown`. This structure has been refactored and deduplicated using a single higher-order `speculativePipelineBurndown` function and a `HasCallId` constraint, simplifying maintenance.
2. **Robust Context Parsing**: The `parseTrikeshedContext` method was previously relying on brittle regex matching against the raw text payload. It now reliably navigates the `JsonMap` syntax tree to extract the bindings safely.
3. **Spec Injection**: Placeholder `x-trikeshed-context` keys were populated in CMC, Robinhood, and Kraken specs to allow the updated pipeline to generate code correctly for these remote systems.
4. **Test Maintenance**: Removed an invalid, developer-specific hardcoded absolute path in `YamlParserTest.kt`.

---
*PR created automatically by Jules for task [250872245903079552](https://jules.google.com/task/250872245903079552) started by @jnorthrup*