### PR TITLE
Refactor polyglot pipeline and taxonomy boundaries

### DIFF
--- a/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/LinguaPipeline.kt
+++ b/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/LinguaPipeline.kt
@@ -8,10 +8,10 @@ import borg.trikeshed.parse.interop.DescriptorFragment
 import borg.trikeshed.parse.interop.rowVecTree
 
 /* ═══════════════════════════════════════════════════════════════════════════
- *  Polyglot pipeline — five-stage funnel from source text to MLIR-ready blocks.
+ *  Polyglot pipeline — four-stage funnel from source text to MLIR-ready blocks.
  *
- *  Stage 0: DETECT       Speculative language classification via SupervisorJob fanout.
- *                         All N LangClassifiers run concurrently. Winner selected by
+ *  Stage 0: DETECT       Speculative language classification.
+ *                         All N LangClassifiers run sequentially. Winner selected by
  *                         TypeEvidence confidence score.
  *  Stage 1: PARSE         Winning LangParser → UniversalAst → SourceFragment tree.
  *  Stage 2: CLASSIFY      TypeEvidence scan per fragment → classified SourceFragment tree.
@@ -21,21 +21,20 @@ import borg.trikeshed.parse.interop.rowVecTree
  *
  *  Each stage runs in a ParseScope under SupervisorJob. Stages fan out
  *  concurrently where span independence allows. Classification (stage 0)
- *  is the first fanout — all languages race, best confidence wins.
+ *  runs sequentially across languages, best confidence wins.
  * ═══════════════════════════════════════════════════════════════════════════ */
 
 /**
  * Stage 0: Speculative language detection.
  *
- * Feeds source text to all registered [LangClassifier] instances concurrently.
- * Under ParseScope.fanoutParsers(), each classifier runs in a child scope.
+ * Feeds source text to all registered [LangClassifier] instances sequentially.
  * Results are ranked by TypeEvidence confidence against each language's
  * reference fingerprint. The top result selects the parser for stage 1.
  *
  * Returns the best ClassificationResult, or null if registry is empty.
  */
-fun detect(source: Series<Char>): ClassificationResult? =
-    LangRegistry.bestMatch(source)
+fun detect(registry: LangRegistry, source: Series<Char>): ClassificationResult? =
+    registry.bestMatch(source)
 
 /**
  * Stage 0b: Detect with a confidence floor.
@@ -43,8 +42,8 @@ fun detect(source: Series<Char>): ClassificationResult? =
  * Returns null if no language exceeds [minConfidence], preventing
  * false-positive parses on unrecognized input.
  */
-fun detectOrNull(source: Series<Char>, minConfidence: Double = 0.3): ClassificationResult? {
-    val best = LangRegistry.bestMatch(source) ?: return null
+fun detectOrNull(registry: LangRegistry, source: Series<Char>, minConfidence: Double = 0.3): ClassificationResult? {
+    val best = registry.bestMatch(source) ?: return null
     return if (best.confidence >= minConfidence) best else null
 }
 
@@ -82,9 +81,9 @@ fun parse(lang: LangId, source: Series<Char>): Result<UniversalAst> {
  * populating [SourceFragment.evidence]. This is the character-class
  * fingerprint layer — XOR bitmask extraction from CHAR_CATEGORY[128].
  */
-fun classify(ast: UniversalAst): UniversalAst {
+fun classify(ast: UniversalAst, source: Series<Char>): UniversalAst {
     fun rec(sf: SourceFragment): SourceFragment {
-        val sample = (sf.name ?: "").toSeries()
+        val sample = source[sf.span.a until sf.span.b]
         val ev = TypeEvidence.sample(sample)
         val children = sf.children α { rec(it) }
         return sf.copy(evidence = ev, children = children)
@@ -122,37 +121,27 @@ fun mapRegions(fragment: DescriptorFragment): Cursor {
 }
 
 /**
- * Stage 5: Lower region blocks to MLIR operations.
+ * End-to-end pipeline: source text → Region Blocks (Cursor).
  *
- * Each SourceFragment with a mlir-relevant NodeKind maps through [nodeToMlir].
- * The resulting [MlirOp] sequence is emitted as MLIR IR, then compiled via
- * [borg.trikeshed.userspace.tensor.MlirOrcBuilder] and ORC JIT.
- *
- * Only [mlirRelevantKinds] survive lowering — IMPORTS, COMMENTS, TYPE_ANNOTATIONS
- * are discarded. STRUCT/CLASS/TRAIT nodes are lowered to memref + function tables.
- */
-fun lower(cursor: Cursor): Unit = Unit
-
-/**
- * End-to-end pipeline: source text → MLIR ops.
- *
- * Five stages, each a suspend function participating in ParseScope fanout.
+ * Four stages, each a suspend function participating in ParseScope fanout.
  * The entire pipeline runs under a single root SupervisorJob scope.
+ *
+ * Note: Stage 5 (MLIR lowering) has been moved out of this pipeline.
  *
  * Stage 0 (detect) fans out to all N languages. The winner's parser
  * drives stages 1–5. If detection confidence is below [minConfidence],
  * the pipeline returns null (unrecognized input).
  */
 suspend fun pipeline(
+    registry: LangRegistry,
     source: Series<Char>,
     minConfidence: Double = 0.3,
 ) {
-    val detection = detectOrNull(source, minConfidence)
+    val detection = detectOrNull(registry, source, minConfidence)
         ?: return // unrecognized input — no language matched
 
     parse(detection.lang, source)
-        .map { ast -> classify(ast) }
+        .map { ast -> classify(ast, source) }
         .map { ast -> unify(ast) }
         .map { frag -> mapRegions(frag) }
-        .map { cursor -> lower(cursor) }
 }

--- a/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/LinguaTaxonomy.kt
+++ b/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/LinguaTaxonomy.kt
@@ -10,15 +10,15 @@ import borg.trikeshed.lib.*
 import kotlin.math.abs
 
 /* ═══════════════════════════════════════════════════════════════════════════
- *  Polyglot taxonomy — speculative language classification via SupervisorJob fanout.
+ *  Polyglot taxonomy — speculative language classification.
  *
  *  Every registered language carries:
  *    - a reference [LangFingerprint] — TypeEvidence row over its keyword corpus
  *    - a [LangClassifier] — scanner that produces a TypeEvidence row from live source
  *
- *  Classification is speculative: all N classifiers run concurrently under
- *  ParseScope.fanoutParsers(). Each emits a [ClassificationResult] with a
- *  confidence score. The highest-scoring result selects the parser.
+ *  Classification is speculative: all N classifiers run sequentially. Each emits
+ *  a [ClassificationResult] with a confidence score. The highest-scoring result
+ *  selects the parser.
  *
  *  The registry emits Series<RowVec> so it participates in Cursor algebra
  *  directly. Fingerprints are additive TypeEvidence rows, not scalar scores.
@@ -166,6 +166,11 @@ fun confidence(live: TypeEvidence, ref: TypeEvidence): Double {
         live.maxColumnLength.toDouble(),
         if (live.minColumnLength == UShort.MAX_VALUE) 0.0 else live.minColumnLength.toDouble()
     ]
+
+    var liveSum = 0.0
+    liveVals.view.forEach { liveSum += it }
+    if (liveSum == 0.0) return 0.0
+
     val refVals: Series<Double> = s_[
         ref.digits.toDouble(),
         ref.periods.toDouble(),
@@ -227,47 +232,73 @@ data class LangEntry(
     }
 }
 
-/** Thread-safe append-only language registry. */
-object LangRegistry {
-    private val entries = mutableListOf<LangEntry>()
-
+interface LangRegistry {
     fun register(
         id: LangId,
         fingerprint: LangFingerprint,
         classifier: LangClassifier,
         extensions: Series<String>,
         shebang: String? = null,
-    ): LangEntry = LangEntry(id, fingerprint, classifier, extensions, shebang).also { entries.add(it) }
+    ): LangEntry
 
-    fun all(): Series<LangEntry> = entries.toSeries()
+    fun all(): Series<LangEntry>
+    fun reset()
+    fun series(): Series<LangEntry>
+    fun byExtension(ext: String): LangEntry?
+    fun byId(id: LangId): LangEntry?
+    fun classifyAll(source: Series<Char>): Series<ClassificationResult>
+    fun bestMatch(source: Series<Char>): ClassificationResult?
+}
+
+/** Thread-safe append-only language registry implementation. */
+class ConcurrentLangRegistry : LangRegistry {
+    private val entries = mutableListOf<LangEntry>()
+    private var sealed = false
+
+    fun seal() {
+        sealed = true
+    }
+
+    override fun register(
+        id: LangId,
+        fingerprint: LangFingerprint,
+        classifier: LangClassifier,
+        extensions: Series<String>,
+        shebang: String?,
+    ): LangEntry {
+        if (sealed) throw IllegalStateException("LangRegistry is sealed and cannot be modified")
+        return LangEntry(id, fingerprint, classifier, extensions, shebang).also { entries.add(it) }
+    }
+
+    override fun all(): Series<LangEntry> = entries.toSeries()
 
     /** Reset for test isolation. */
-    fun reset() {
+    override fun reset() {
+        if (sealed) throw IllegalStateException("LangRegistry is sealed and cannot be reset")
         entries.clear()
     }
 
-    fun series(): Series<LangEntry> = entries.size j { i: Int -> entries[i] }
+    override fun series(): Series<LangEntry> = entries.size j { i: Int -> entries[i] }
 
-    fun byExtension(ext: String): LangEntry? = entries.find { entry ->
+    override fun byExtension(ext: String): LangEntry? = entries.find { entry ->
         entry.extensions.view.contains(ext)
     }
 
-    fun byId(id: LangId): LangEntry? = entries.find { it.id == id }
+    override fun byId(id: LangId): LangEntry? = entries.find { it.id == id }
 
     /**
-     * Speculative classification: run all registered classifiers concurrently.
+     * Speculative classification: run all registered classifiers sequentially.
      *
-     * Under ParseScope.fanoutParsers(), each classifier gets a child scope.
      * Results are collected and ranked by confidence. The top result wins.
      *
      * Returns ClassificationResults sorted by confidence descending.
      */
-    fun classifyAll(source: Series<Char>): Series<ClassificationResult> {
+    override fun classifyAll(source: Series<Char>): Series<ClassificationResult> {
         val results = entries.map { it.classify(source) }.sortedByDescending { it.confidence }
         return results.toSeries()
     }
 
     /** Top-ranked classification, or null if registry is empty. */
-    fun bestMatch(source: Series<Char>): ClassificationResult? =
+    override fun bestMatch(source: Series<Char>): ClassificationResult? =
         classifyAll(source).firstOrNull()
 }

--- a/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/SourceFragment.kt
+++ b/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/SourceFragment.kt
@@ -102,7 +102,13 @@ data class SourceFragment(
             span.b,
             kind.name,
             name ?: "",
-            TypeEvidence.deduceMemento(evidence).label
+            TypeEvidence.deduceMemento(evidence).label,
+            meta.visibility ?: "",
+            meta.mutability ?: "",
+            meta.lifetime ?: "",
+            meta.async,
+            meta.generic,
+            meta.extern
         ]
         val metas: Series<`ColumnMeta↻`> = s_[
             ColumnMeta("lang", IOMemento.IoString),
@@ -111,6 +117,12 @@ data class SourceFragment(
             ColumnMeta("kind", IOMemento.IoString),
             ColumnMeta("name", IOMemento.IoString),
             ColumnMeta("deducedType", IOMemento.IoString),
+            ColumnMeta("meta_visibility", IOMemento.IoString),
+            ColumnMeta("meta_mutability", IOMemento.IoString),
+            ColumnMeta("meta_lifetime", IOMemento.IoString),
+            ColumnMeta("meta_async", IOMemento.IoBoolean),
+            ColumnMeta("meta_generic", IOMemento.IoBoolean),
+            ColumnMeta("meta_extern", IOMemento.IoBoolean),
         ] α { it.leftIdentity }
         return values joins metas
     }

--- a/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/nars3/Nars3PolyglotBridge.kt
+++ b/libs/polyglot/src/commonMain/kotlin/borg/trikeshed/polyglot/nars3/Nars3PolyglotBridge.kt
@@ -13,9 +13,47 @@ import borg.trikeshed.parse.kursive.nars3.*
  */
 object Nars3PolyglotBridge {
 
+    fun nodeKindToNarsiveElementKind(kind: NodeKind): NarsiveElementKind = when (kind) {
+        NodeKind.MODULE -> NarsiveElementKind.TASK
+        NodeKind.NAMESPACE -> NarsiveElementKind.TASK
+        NodeKind.CLASS -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.INTERFACE -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.FUNCTION -> NarsiveElementKind.OPERATION
+        NodeKind.METHOD -> NarsiveElementKind.OPERATION
+        NodeKind.VARIABLE -> NarsiveElementKind.VARIABLE
+        NodeKind.PARAMETER -> NarsiveElementKind.VARIABLE
+        NodeKind.FIELD -> NarsiveElementKind.VARIABLE
+        NodeKind.ENUM -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.STRUCT -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.TRAIT -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.IMPL -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.BLOCK -> NarsiveElementKind.COMPOUND_TERM
+        NodeKind.RETURN -> NarsiveElementKind.STATEMENT
+        NodeKind.IF -> NarsiveElementKind.STATEMENT
+        NodeKind.LOOP -> NarsiveElementKind.STATEMENT
+        NodeKind.WHILE -> NarsiveElementKind.STATEMENT
+        NodeKind.FOR -> NarsiveElementKind.STATEMENT
+        NodeKind.MATCH -> NarsiveElementKind.STATEMENT
+        NodeKind.TRY -> NarsiveElementKind.STATEMENT
+        NodeKind.THROW -> NarsiveElementKind.STATEMENT
+        NodeKind.ASSIGN -> NarsiveElementKind.STATEMENT
+        NodeKind.STATEMENT -> NarsiveElementKind.STATEMENT
+        NodeKind.EXPRESSION -> NarsiveElementKind.TERM
+        NodeKind.CALL -> NarsiveElementKind.OPERATION
+        NodeKind.LITERAL -> NarsiveElementKind.TERM
+        NodeKind.BINARY_OP -> NarsiveElementKind.OPERATION
+        NodeKind.UNARY_OP -> NarsiveElementKind.OPERATION
+        NodeKind.TYPE_ANNOTATION -> NarsiveElementKind.TERM
+        NodeKind.TYPE_DECL -> NarsiveElementKind.TERM
+        NodeKind.IMPORT -> NarsiveElementKind.STATEMENT
+        NodeKind.EXPORT -> NarsiveElementKind.STATEMENT
+        NodeKind.COMMENT -> NarsiveElementKind.UNKNOWN
+        NodeKind.UNKNOWN -> NarsiveElementKind.UNKNOWN
+    }
+
     fun fragmentToAtom(fragment: SourceFragment, budget: Nars3Budget): Nars3Atom {
         val kindLabel = fragment.kind.name
-        val element = NarsiveElement(NarsiveElementKind.UNKNOWN, 0 j 0, kindLabel.toSeries())
+        val element = NarsiveElement(nodeKindToNarsiveElementKind(fragment.kind), 0 j 0, kindLabel.toSeries())
         val isChannelized = fragment.children.size > 0
 
         return if (isChannelized) {

--- a/libs/polyglot/src/commonTest/kotlin/borg/trikeshed/polyglot/ConfidenceEdgeCaseTest.kt
+++ b/libs/polyglot/src/commonTest/kotlin/borg/trikeshed/polyglot/ConfidenceEdgeCaseTest.kt
@@ -1,0 +1,17 @@
+package borg.trikeshed.polyglot
+
+import borg.trikeshed.common.TypeEvidence
+import borg.trikeshed.lib.toSeries
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConfidenceEdgeCaseTest {
+    @Test
+    fun testEmptySourceConfidence() {
+        val emptyEvidence = TypeEvidence.sample("".toSeries())
+        val refEvidence = TypeEvidence.sample("fun fun fun class class fun".toSeries())
+        val conf = confidence(emptyEvidence, refEvidence)
+        println("Actual confidence for empty source is: $conf")
+        assertEquals(0.0, conf, "Empty source should have 0.0 confidence")
+    }
+}

--- a/libs/polyglot/src/commonTest/kotlin/borg/trikeshed/polyglot/ConfidenceIntegrationTest.kt
+++ b/libs/polyglot/src/commonTest/kotlin/borg/trikeshed/polyglot/ConfidenceIntegrationTest.kt
@@ -1,0 +1,32 @@
+package borg.trikeshed.polyglot
+
+import borg.trikeshed.common.TypeEvidence
+import borg.trikeshed.lib.toSeries
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConfidenceIntegrationTest {
+
+    @Test
+    fun testRealSourceSamples() {
+        // Dummy classifiers that just echo what we give them to simulate real matching
+        // Actually, the real TypeEvidence is generated based on text. So we should test against dummy LangFingerprints.
+        val kotlinText = "fun main() { println(\"Hello\") }".toSeries()
+        val rustText = "fn main() { println!(\"Hello\"); }".toSeries()
+
+        val kotlinEv = TypeEvidence.sample(kotlinText)
+        val rustEv = TypeEvidence.sample(rustText)
+
+        // Let's check confidence between identical things
+        val confKotlinSelf = confidence(kotlinEv, kotlinEv)
+        assertEquals(1.0, confKotlinSelf, "Confidence of identical TypeEvidence should be 1.0")
+
+        val confRustSelf = confidence(rustEv, rustEv)
+        assertEquals(1.0, confRustSelf, "Confidence of identical TypeEvidence should be 1.0")
+
+        // Let's check confidence between different things
+        val confKotlinRust = confidence(kotlinEv, rustEv)
+        assertTrue(confKotlinRust < 1.0, "Confidence between different sources should be < 1.0")
+    }
+}


### PR DESCRIPTION
- Extracted LangRegistry into an interface and added ConcurrentLangRegistry implementation.
- Refactored LinguaPipeline to use dependency injection for LangRegistry instead of global singleton.
- Updated documentation to reflect a four-stage sequential pipeline and removed the unused lower() stub for MLIR.
- Handled the division-by-zero/empty-source edge case in LinguaTaxonomy confidence calculation.
- Fixed classify() to sample TypeEvidence using actual source text spans instead of ast node names.
- Added exhaustive semantic mapping from NodeKind to NarsiveElementKind in Nars3PolyglotBridge.
- Expanded SourceFragment toRowVec schema to export NodeMeta configurations (visibility, mutability, lifetime, etc.).
- Wrote and passed real source integration tests to validate confidence metric logic.

---
*PR created automatically by Jules for task [12657469155333498374](https://jules.google.com/task/12657469155333498374) started by @jnorthrup*