### PR TITLE
Reuse and verify existing metadata in IsamDataFile.append

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/isam/IsamDataFile.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/isam/IsamDataFile.kt
@@ -128,37 +128,61 @@ actual class IsamDataFile actual constructor(
         ): Unit {
             val metafilename = "$datafilename.meta"
 
-            // TODO("not assume we have to write this file for this call.  if it exists, verify it and use it")
             lateinit var meta0: Series<RecordMeta>
+            var rowLen = 0
+            lateinit var rowBuffer: ByteArray
+            var first = true
+
+            if (fileOps.exists(metafilename)) {
+                meta0 = IsamMetaFileReader(metafilename, fileOps).constraints
+                rowLen = meta0.last().end
+                rowBuffer = ByteArray(rowLen) { 0 }
+                first = false
+
+                if (fileOps.exists(datafilename)) {
+                    val fileSize = Files.size(Paths.get(datafilename))
+                    val alignment = fileSize % rowLen
+                    if (alignment != 0L) {
+                        println("WARN: file $datafilename is not aligned to recordlen $rowLen")
+                    } else {
+                        println("DEBUG: file $datafilename is aligned to recordlen $rowLen")
+                    }
+                }
+            }
 
             // open RandomAccessDataFile
-            val data =
-                Files.newOutputStream(Paths.get(datafilename), APPEND, WRITE, CREATE)
+            Files.newOutputStream(Paths.get(datafilename), APPEND, WRITE, CREATE).use { data ->
+                var fibLog: FibonacciReporter? = null
+                debug { fibLog = FibonacciReporter(size = null, noun = "appends") }
 
+                // write rows
+                msf.forEach { rowVec1: RowVec ->
+                    val rowVec = transform?.let { it(rowVec1) } ?: rowVec1
+                    if (first) {
+                        meta0 = IsamMetaFileReader.write(metafilename, rowVec.right.α { it() }, varChars, fileOps)
+                        rowLen = meta0.last().end
+                        rowBuffer = ByteArray(rowLen) { 0 }
+                        debug { logDebug { "toIsam: " + meta0.toList() } }
+                        first = false
+                    } else {
+                        // Verify schema matches
+                        val incomingMeta = rowVec.right.α { it() }
+                        if (incomingMeta.size != meta0.size) {
+                            throw IllegalArgumentException("Schema mismatch: incoming row has ${incomingMeta.size} columns, but file has ${meta0.size}")
+                        }
+                        for (i in 0 until meta0.size) {
+                            val inc = incomingMeta[i]
+                            val m0 = meta0[i]
+                            if (inc.name != m0.name || inc.type != m0.type) {
+                                throw IllegalArgumentException("Schema mismatch at column $i: expected ${m0.name}:${m0.type}, got ${inc.name}:${inc.type}")
+                            }
+                        }
+                    }
 
-            var last: RecordMeta
-
-            var rowLen = 0
-
-            lateinit var rowBuffer: ByteArray
-            var fibLog: FibonacciReporter? = null
-            debug { fibLog = FibonacciReporter(size = null, noun = "appends") }
-            var first = true
-            // write rows
-            msf.forEach { rowVec1: RowVec ->
-                val rowVec = transform?.let { it(rowVec1) } ?: rowVec1
-                if (first) {
-                    meta0 = IsamMetaFileReader.write(metafilename, rowVec.right.α { it() }, varChars, fileOps)
-                    last = meta0.last()
-                    rowLen = last.end
-                    rowBuffer = ByteArray(rowLen) { 0 }
-                    debug { logDebug { "toIsam: " + meta0.toList() } }
-                    first = false
+                    WireProto.writeToBuffer(rowVec, rowBuffer, meta0)
+                    data.write(rowBuffer)
+                    debug { fibLog?.report()?.let { println(it) } }
                 }
-
-                WireProto.writeToBuffer(rowVec, rowBuffer, meta0)
-                data.write(rowBuffer)
-                debug { fibLog?.report()?.let { println(it) } }
             }
         }
     }

--- a/src/jvmTest/kotlin/borg/trikeshed/isam/IsamDataFileTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/isam/IsamDataFileTest.kt
@@ -1,0 +1,90 @@
+package borg.trikeshed.isam
+
+import borg.trikeshed.cursor.*
+import borg.trikeshed.isam.meta.IOMemento
+import borg.trikeshed.lib.*
+import borg.trikeshed.userspace.nio.file.spi.JvmFileOperations
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class IsamDataFileTest {
+
+    @Test
+    fun testAppendExisting() {
+        val datafilename = "test_append.isam"
+        val metafilename = "$datafilename.meta"
+        val fileOps = JvmFileOperations()
+
+        // Cleanup
+        File(datafilename).delete()
+        File(metafilename).delete()
+
+        try {
+            // 1. Initial write (via append)
+            val row1 = s_[10, 20.0] j s_[ { ColumnMeta("int_col", IOMemento.IoInt) }, { ColumnMeta("double_col", IOMemento.IoDouble) } ]
+            val row2 = s_[30, 40.0] j s_[ { ColumnMeta("int_col", IOMemento.IoInt) }, { ColumnMeta("double_col", IOMemento.IoDouble) } ]
+
+            IsamDataFile.append(listOf(row1, row2), datafilename, emptyMap(), null, fileOps)
+
+            assertEquals(true, fileOps.exists(datafilename))
+            assertEquals(true, fileOps.exists(metafilename))
+
+            val initialSize = Files.size(Paths.get(datafilename))
+            assertEquals(24, initialSize.toInt()) // 2 rows * (4 for int + 8 for double)
+
+            // 2. Append more records
+            val row3 = s_[50, 60.0] j s_[ { ColumnMeta("int_col", IOMemento.IoInt) }, { ColumnMeta("double_col", IOMemento.IoDouble) } ]
+            IsamDataFile.append(listOf(row3), datafilename, emptyMap(), null, fileOps)
+
+            val finalSize = Files.size(Paths.get(datafilename))
+            assertEquals(36, finalSize.toInt()) // 3 rows * 12 bytes
+
+            // 3. Verify reading
+            val metaReader = IsamMetaFileReader(metafilename, fileOps)
+            val isamFile = IsamDataFile(datafilename, metafilename, metaReader, fileOps)
+            isamFile.open()
+
+            assertEquals(3, isamFile.a) // 3 records
+
+            val readRow1 = isamFile.b(0)
+            assertEquals(10, readRow1[0].a)
+            assertEquals(20.0, readRow1[1].a)
+
+            val readRow3 = isamFile.b(2)
+            assertEquals(50, readRow3[0].a)
+            assertEquals(60.0, readRow3[1].a)
+
+            isamFile.close()
+
+        } finally {
+            File(datafilename).delete()
+            File(metafilename).delete()
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSchemaMismatch() {
+        val datafilename = "test_mismatch.isam"
+        val metafilename = "$datafilename.meta"
+        val fileOps = JvmFileOperations()
+
+        // Cleanup
+        File(datafilename).delete()
+        File(metafilename).delete()
+
+        try {
+            val row1 = s_[10] j s_[ { ColumnMeta("int_col", IOMemento.IoInt) } ]
+            IsamDataFile.append(listOf(row1), datafilename, emptyMap(), null, fileOps)
+
+            // Append with different schema
+            val row2 = s_[20.0] j s_[ { ColumnMeta("double_col", IOMemento.IoDouble) } ]
+            IsamDataFile.append(listOf(row2), datafilename, emptyMap(), null, fileOps)
+        } finally {
+            File(datafilename).delete()
+            File(metafilename).delete()
+        }
+    }
+}


### PR DESCRIPTION
This change addresses the requirement to reuse existing metadata files in `IsamDataFile.append` instead of unconditionally recreating them. It also adds schema verification to prevent appending inconsistent data and improves resource management by ensuring the output stream is correctly closed. A new unit test suite has been added to verify these behaviors.

---
*PR created automatically by Jules for task [17922847435679841537](https://jules.google.com/task/17922847435679841537) started by @jnorthrup*