### PR TITLE
🧪 [testing improvement] Wasm localStorage setItem exception handling test

### DIFF
--- a/src/wasmJsTest/kotlin/borg/trikeshed/lib/WasmStorageTest.kt
+++ b/src/wasmJsTest/kotlin/borg/trikeshed/lib/WasmStorageTest.kt
@@ -1,0 +1,38 @@
+package borg.trikeshed.lib
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.js.JsAny
+
+class WasmStorageTest {
+
+    @Test
+    fun testStorageSetExceptionHandling() {
+        val original = backupAndMock()
+        try {
+            // This should trigger the catch block in storageSet and return false
+            val result = storageSet("testFailKey", "testValue")
+            assertFalse(result, "storageSet should return false when localStorage.setItem throws an exception")
+        } finally {
+            restore(original)
+        }
+    }
+}
+
+@JsFun("""
+    () => {
+        var original = localStorage.setItem;
+        localStorage.setItem = function() {
+            throw new Error('Mock Storage Error');
+        };
+        return original;
+    }
+""")
+private external fun backupAndMock(): JsAny
+
+@JsFun("""
+    (orig) => {
+        localStorage.setItem = orig;
+    }
+""")
+private external fun restore(original: JsAny)


### PR DESCRIPTION
### 🎯 What
Addressed the missing test coverage for exception handling in the Wasm `localStorage.setItem` implementation within `storageSet`.

### 📊 Coverage
Implemented a new test case `testStorageSetExceptionHandling` in `src/wasmJsTest/kotlin/borg/trikeshed/lib/WasmStorageTest.kt`. This test:
- Backs up the original `localStorage.setItem` function.
- Mocks it to throw an `Error` using Kotlin/Wasm JS interop (`@JsFun`).
- Verifies that the `storageSet` function correctly catches the exception and returns `false`.
- Ensures the original `localStorage.setItem` is restored in a `finally` block.

### ✨ Result
Improved reliability and test coverage for the Wasm target by ensuring that edge cases in browser storage operations are correctly handled and verified.

---
*PR created automatically by Jules for task [11812788547305565222](https://jules.google.com/task/11812788547305565222) started by @jnorthrup*