### PR TITLE
🧹 Implement iterateLines for JVM

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/lib/Files.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/lib/Files.kt
@@ -72,7 +72,8 @@ actual object Files {
         }
     }
 
-    actual fun iterateLines(fileName: String, bufsize: Int): Iterable<Join<Long, Series<Byte>>> = TODO("iterateLines JVM")
+    actual fun iterateLines(fileName: String, bufsize: Int): Iterable<Join<Long, Series<Byte>>> =
+        streamLines(fileName, bufsize).map { (off, arr) -> off j arr.toSeries() }.asIterable()
 
     actual fun listDir(path: String): List<String> =
         File(path).listFiles()?.map { it.name } ?: emptyList()


### PR DESCRIPTION
🎯 **What:** 
Implemented `iterateLines` in `src/jvmMain/kotlin/borg/trikeshed/lib/Files.kt` which previously threw a `TODO("iterateLines JVM")`. 

💡 **Why:** 
This improves code health by completing the missing platform-specific actual implementation for the JVM target without throwing an unexpected exception at runtime. It reduces codebase friction and ensures correct behavior when the multiplatform `iterateLines` API is called from JVM code. The implementation utilizes the existing `streamLines` function and converts the byte arrays into `Series<Byte>` correctly mapping the algebraic data types `Join<Long, Series<Byte>>` using the idiom `j` and `.toSeries()`. 

✅ **Verification:** 
Ran `jvmTest` test suite via `./gradlew :jvmTest`. The modified file compiled successfully without regressions. Verified using code review.

✨ **Result:** 
`Files.iterateLines` can now be safely used on JVM without crashing. The project is closer to full cross-platform compatibility for its userspace I/O APIs.

---
*PR created automatically by Jules for task [15813643538723427656](https://jules.google.com/task/15813643538723427656) started by @jnorthrup*