### PR TITLE
DRY SeriesBuffer into one abstraction

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/SeriesBuffer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/SeriesBuffer.kt
@@ -1,0 +1,97 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package borg.trikeshed.lib
+
+import borg.trikeshed.cursor.j
+
+class SeriesBuffer<T>(
+    capacity: Int = 8,
+) : MutableSeries<T> {
+    var buf: Array<Any?> = arrayOfNulls(capacity)
+    var count: Int = 0
+
+    override val a: Int get() = count
+    override val b: (Int) -> T get() = { index -> buf[index] as T }
+
+    override fun set(index: Int, item: T) {
+        require(index in 0 until count) { "Index out of bounds" }
+        buf[index] = item
+    }
+
+    override fun add(item: T) {
+        if (count == buf.size) {
+            val nextSize = if (buf.size == 0) 8 else buf.size * 2
+            val next = arrayOfNulls<Any?>(nextSize)
+            buf.copyInto(next)
+            buf = next
+        }
+        buf[count++] = item
+    }
+
+    override fun add(index: Int, item: T) {
+        require(index in 0..count) { "Index out of bounds" }
+        if (count == buf.size) {
+            val nextSize = if (buf.size == 0) 8 else buf.size * 2
+            val next = arrayOfNulls<Any?>(nextSize)
+            buf.copyInto(next, 0, 0, index)
+            next[index] = item
+            buf.copyInto(next, index + 1, index, count)
+            buf = next
+        } else {
+            buf.copyInto(buf, index + 1, index, count)
+            buf[index] = item
+        }
+        count++
+    }
+
+    fun removeLast(): T {
+        require(count > 0) { "removeLast on empty SeriesBuffer" }
+        val idx = --count
+        return (buf[idx] as T).also { buf[idx] = null }
+    }
+
+    override fun removeAt(index: Int): T {
+        require(index in 0 until count) { "Index out of bounds" }
+        val item = buf[index] as T
+        buf.copyInto(buf, index, index + 1, count)
+        buf[--count] = null
+        return item
+    }
+
+    override fun remove(item: T): Boolean {
+        for (i in 0 until count) {
+            if (buf[i] == item) {
+                removeAt(i)
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun clear() {
+        for (i in 0 until count) {
+            buf[i] = null
+        }
+        count = 0
+    }
+
+    override fun plus(item: T): MutableSeries<T> {
+        add(item)
+        return this
+    }
+
+    override fun minus(item: T): MutableSeries<T> {
+        remove(item)
+        return this
+    }
+
+    override fun plusAssign(item: T) {
+        add(item)
+    }
+
+    override fun minusAssign(item: T) {
+        remove(item)
+    }
+
+    fun snapshot(): Series<T> = count j { index -> buf[index] as T }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/parse/kursive/legacy/Jursive.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/kursive/legacy/Jursive.kt
@@ -8,6 +8,7 @@ import borg.trikeshed.cursor.SeqTypeMemento
 import borg.trikeshed.cursor.TypeMemento
 import borg.trikeshed.cursor.joins
 import borg.trikeshed.cursor.label
+import borg.trikeshed.lib.SeriesBuffer
 import borg.trikeshed.lib.CharSeries
 import borg.trikeshed.lib.Join
 import borg.trikeshed.lib.Series
@@ -24,35 +25,6 @@ import borg.trikeshed.isam.meta.IOMemento
 
 typealias NarsiveEvent = Join<Series<Char>, Twin<Int>>
 typealias NarsiveTrace = Series<NarsiveEvent>
-
-class SeriesBuffer<T>(
-    capacity: Int = 8,
-) : Series<T> {
-    var buf: Array<Any?> = arrayOfNulls(capacity)
-    var count: Int = 0
-
-    override val a: Int get() = count
-    override val b: (Int) -> T get() = { index -> buf[index] as T }
-
-    fun add(item: T) {
-        if (count == buf.size) {
-            val next = arrayOfNulls<Any?>(buf.size * 2)
-            buf.copyInto(next)
-            buf = next
-        }
-        buf[count++] = item
-    }
-
-    fun removeLast(): T {
-        require(count > 0) { "removeLast on empty SeriesBuffer" }
-        val idx = --count
-        @Suppress("UNCHECKED_CAST")
-        return (buf[idx] as T).also { buf[idx] = null }
-    }
-
-    fun snapshot(): Series<T> = count j { index -> buf[index] as T }
-}
-//TODO DRY THESE INTO ON ABSTRACTION
 
 class JursiveCharSeries constructor(
     val source: CharSeries,

--- a/src/commonMain/kotlin/borg/trikeshed/parse/kursive/std.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/kursive/std.kt
@@ -5,7 +5,7 @@ import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.*
 import borg.trikeshed.parse.kursive.legacy.KursiveParser
 import borg.trikeshed.parse.kursive.legacy.KursiveStep
-import borg.trikeshed.parse.kursive.legacy.SeriesBuffer
+import borg.trikeshed.lib.SeriesBuffer
 import borg.trikeshed.parse.kursive.legacy.parser
 import borg.trikeshed.parse.kursive.legacy.s
 


### PR DESCRIPTION
Moved `SeriesBuffer` from `borg.trikeshed.parse.kursive.legacy.Jursive` into a new file `src/commonMain/kotlin/borg/trikeshed/lib/SeriesBuffer.kt`. Expanded its functionality to implement `MutableSeries<T>` fully while preserving existing functions. Updated its usages across the codebase, successfully adhering to the DRY principle.

---
*PR created automatically by Jules for task [5441988913878849229](https://jules.google.com/task/5441988913878849229) started by @jnorthrup*