### PR TITLE
Add Confix JsElement accessible blackboard with Classfile API integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,15 @@ kotlin {
 
             // Local DuckDB JVM sources unavailable (libs/ removed)
         }
+
+        tasks.withType<JavaCompile>().configureEach {
+            options.compilerArgs.addAll(
+                listOf(
+                    "--add-exports=java.base/jdk.internal.classfile=ALL-UNNAMED",
+                    "--add-exports=java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED"
+                )
+            )
+        }
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,8 @@ pluginManagement {
 rootProject.name = "TrikeShed"
 
 include(":libs:motion-estimation")
+
+// Support hybrid kotlin xvm build if ../xvm exists
+if (java.io.File("../xvm").exists()) {
+    includeBuild("../xvm")
+}

--- a/src/jvmMain/java/borg/trikeshed/cursor/ClassfileBlackboardAdapter.java
+++ b/src/jvmMain/java/borg/trikeshed/cursor/ClassfileBlackboardAdapter.java
@@ -1,0 +1,52 @@
+package borg.trikeshed.cursor;
+
+import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.ClassModel;
+import java.nio.file.Path;
+import java.io.IOException;
+
+/**
+ * Adapter integrating jdk.internal.classfile.Classfile API with ConfixBlackboard.
+ * Written in Java to easily consume the jdk.internal.classfile module with standard compiler args.
+ */
+public class ClassfileBlackboardAdapter {
+    private final ConfixBlackboard blackboard;
+
+    public ClassfileBlackboardAdapter(ConfixBlackboard blackboard) {
+        this.blackboard = blackboard;
+    }
+
+    /**
+     * Parses a .class file and maps its structural metadata into the blackboard.
+     */
+    public void parseAndRegister(Path classFilePath, String id) throws IOException {
+        // Read the class model using the internal Classfile API (static parse method in early JDK 21 preview)
+        ClassModel classModel = Classfile.parse(classFilePath);
+
+        // Convert the ClassModel into a JSON representation string
+        String jsonRepr = serializeClassModelToJson(classModel);
+
+        // Parse the JSON into a ConfixDoc using the Kotlin global function
+        Object doc = borg.trikeshed.parse.confix.ConfixKitKt.confixDoc(jsonRepr);
+
+        // Register it in the blackboard
+        blackboard.put(id, new borg.trikeshed.parse.confix.BlackBoardEntry(
+                (borg.trikeshed.lib.Join) doc,
+                borg.trikeshed.parse.confix.ConfixRole.OBSERVATION,
+                0L,
+                ""
+        ));
+    }
+
+    private String serializeClassModelToJson(ClassModel model) {
+        String className = model.thisClass().asInternalName();
+        int majorVersion = model.majorVersion();
+        int minorVersion = model.minorVersion();
+
+        return "{\n" +
+               "    \"className\": \"" + className + "\",\n" +
+               "    \"majorVersion\": " + majorVersion + ",\n" +
+               "    \"minorVersion\": " + minorVersion + "\n" +
+               "}";
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/cursor/ConfixBlackboard.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/cursor/ConfixBlackboard.kt
@@ -1,0 +1,55 @@
+package borg.trikeshed.cursor
+
+import borg.trikeshed.parse.confix.*
+import borg.trikeshed.lib.*
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Alias to support JsElement terminology over JsonElement/ConfixCell.
+ */
+typealias JsElement = ConfixCell
+
+/**
+ * Confix JsElement accessible blackboard.
+ * Centralized registry for BlackBoardEntry records, which encapsulate ConfixDoc.
+ */
+class ConfixBlackboard {
+    private val records = ConcurrentHashMap<String, BlackBoardEntry>()
+
+    fun put(id: String, entry: BlackBoardEntry) {
+        records[id] = entry
+    }
+
+    fun get(id: String): BlackBoardEntry? = records[id]
+
+    fun remove(id: String): BlackBoardEntry? = records.remove(id)
+
+    /**
+     * Navigates to a specific JsElement within the specified entry.
+     */
+    fun navigate(id: String, path: JsPath): JsElement? {
+        val entry = records[id] ?: return null
+        return entry.doc.navigate(path)
+    }
+
+    /**
+     * Resolves an element using vararg path segments.
+     */
+    fun getAt(id: String, vararg path: Any): JsElement? {
+        val entry = records[id] ?: return null
+        return entry.doc.docAt(*path)
+    }
+
+    /**
+     * Reifies the scalar value at the specified path.
+     */
+    fun scalar(id: String, vararg path: Any): Any? {
+        val entry = records[id] ?: return null
+        return entry.doc.scalar(*path)
+    }
+
+    /**
+     * Returns all registered blackboard IDs.
+     */
+    fun ids(): Set<String> = records.keys
+}


### PR DESCRIPTION
Implemented the requested Confix JsElement accessible blackboard for JVM Trikeshed.

The blackboard uses `ConfixCell` mappings and is driven by `ConfixBlackboard.kt`. It integrates with the Java 21 Classfile API (`jdk.internal.classfile`) using a dedicated Java adapter (`ClassfileBlackboardAdapter.java`) to easily append necessary compiler exports for internal APIs without corrupting standard Kotlin Multiplatform paths. The hybrid build for the local Ecstasy `xvm` compiler module has been structurally wired into `settings.gradle.kts`.

---
*PR created automatically by Jules for task [11191658994012149756](https://jules.google.com/task/11191658994012149756) started by @jnorthrup*