### PR TITLE
feat: add CouchWal java wrapper

### DIFF
--- a/run_couch_wal.sh
+++ b/run_couch_wal.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./gradlew compileJvmMainJava
+java -cp build/classes/java/jvmMain:build/classes/kotlin/jvm/main borg.trikeshed.couch.wal.CouchWal .

--- a/src/jvmMain/java/borg/trikeshed/couch/wal/CouchWal.java
+++ b/src/jvmMain/java/borg/trikeshed/couch/wal/CouchWal.java
@@ -1,0 +1,104 @@
+package borg.trikeshed.couch.wal;
+
+import borg.trikeshed.cursor.ConfixBlackboard;
+import borg.trikeshed.cursor.ClassfileBlackboardAdapter;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CouchWal {
+    private final ConfixBlackboard blackboard;
+    private final ClassfileBlackboardAdapter adapter;
+    private final String projectRoot;
+
+    public CouchWal(String projectRoot) {
+        this.projectRoot = projectRoot;
+        this.blackboard = new ConfixBlackboard();
+        this.adapter = new ClassfileBlackboardAdapter(this.blackboard);
+    }
+
+    public void runGradleBuild() throws IOException, InterruptedException {
+        ProcessBuilder builder = new ProcessBuilder();
+        builder.directory(new File(projectRoot));
+
+        // Use the gradle wrapper from the project root
+        String gradlewCommand = "./gradlew";
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            gradlewCommand = "gradlew.bat";
+        }
+
+        builder.command(gradlewCommand, "compileJvmMainJava", "compileKotlinJvm", "jvmJar");
+        builder.redirectErrorStream(true);
+
+        Process process = builder.start();
+
+        // Log output
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+        }
+
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("Gradle build failed with exit code: " + exitCode);
+        }
+    }
+
+    public void parseBuiltClasses() throws IOException {
+        List<Path> classesDirs = new ArrayList<>();
+
+        Path kotlinClassesDir = Paths.get(projectRoot, "build", "classes", "kotlin", "jvm", "main");
+        if (Files.exists(kotlinClassesDir)) {
+            classesDirs.add(kotlinClassesDir);
+        }
+
+        Path javaClassesDir = Paths.get(projectRoot, "build", "classes", "java", "jvmMain");
+        if (Files.exists(javaClassesDir)) {
+            classesDirs.add(javaClassesDir);
+        }
+
+        if (classesDirs.isEmpty()) {
+            System.err.println("Warning: no classes directory found in " + projectRoot + "/build/classes/");
+            return;
+        }
+
+        for (Path classesDir : classesDirs) {
+            try (Stream<Path> paths = Files.walk(classesDir)) {
+                paths.filter(Files::isRegularFile)
+                     .filter(p -> p.toString().endsWith(".class"))
+                     .forEach(p -> {
+                         try {
+                             String id = classesDir.relativize(p).toString();
+                             adapter.parseAndRegister(p, id);
+                         } catch (IOException e) {
+                             System.err.println("Failed to parse " + p + ": " + e.getMessage());
+                         }
+                     });
+            }
+        }
+    }
+
+    public ConfixBlackboard getBlackboard() {
+        return blackboard;
+    }
+
+    public static void main(String[] args) throws Exception {
+        String root = args.length > 0 ? args[0] : ".";
+        CouchWal wal = new CouchWal(root);
+        System.out.println("Running gradle build wrapper...");
+        wal.runGradleBuild();
+        System.out.println("Parsing compiled classes...");
+        wal.parseBuiltClasses();
+        System.out.println("Done. Registered classes: " + wal.getBlackboard().ids().size());
+    }
+}


### PR DESCRIPTION
Created `CouchWal.java` as a self-hosted wrapper to trigger the `trikeshed`
Gradle build programmatically via `ProcessBuilder`. Post-compilation, it sweeps
the `build/classes/kotlin/jvm/main` and `build/classes/java/jvmMain` directories
and passes the generated `.class` files into the `ClassfileBlackboardAdapter`
for population into the `ConfixBlackboard` registry.

---
*PR created automatically by Jules for task [16579056117424685554](https://jules.google.com/task/16579056117424685554) started by @jnorthrup*