### PR TITLE
Refactor: Rename network-endian to wire-endian in PlatformCodec

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformCodec.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformCodec.kt
@@ -23,14 +23,14 @@ interface PlatformCodec {
 
     companion object {
         val nativeByteOrder: ByteOrder by lazy(::platformNativeByteOrder)
-        val networkByteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
+        val wireByteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
         val isLittleEndian: Boolean get() = nativeByteOrder == ByteOrder.LITTLE_ENDIAN
-        val isNetworkEndian: Boolean get() = nativeByteOrder == networkByteOrder
+        val isWireEndian: Boolean get() = nativeByteOrder == wireByteOrder
 
         val currentPlatformCodec: PlatformCodec by lazy {
             CommonPlatformCodec(isLittleEndian)
         }
-        val networkEndianCodec: PlatformCodec by lazy {
+        val wireCodec: PlatformCodec by lazy {
             CommonPlatformCodec(false)
         }
 

--- a/src/commonTest/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformEndiannessTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformEndiannessTest.kt
@@ -34,9 +34,9 @@ class PlatformEndiannessTest {
     }
 
     @Test
-    fun `network endian codec always writes big endian`() {
-        val wireInt = PlatformCodec.networkEndianCodec.writeInt(0x01020304)
-        val wireLong = PlatformCodec.networkEndianCodec.writeLong(0x0102030405060708L)
+    fun `wire codec always writes big endian`() {
+        val wireInt = PlatformCodec.wireCodec.writeInt(0x01020304)
+        val wireLong = PlatformCodec.wireCodec.writeLong(0x0102030405060708L)
 
         assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), wireInt)
         assertContentEquals(
@@ -60,10 +60,10 @@ class PlatformEndiannessTest {
     }
 
     @Test
-    fun `native and network codecs diverge on little endian hosts`() {
+    fun `native and wire codecs diverge on little endian hosts`() {
         if (PlatformCodec.isLittleEndian) {
             val native = PlatformCodec.currentPlatformCodec.writeInt(0x01020304)
-            val network = PlatformCodec.networkEndianCodec.writeInt(0x01020304)
+            val network = PlatformCodec.wireCodec.writeInt(0x01020304)
 
             assertTrue(
                 !native.contentEquals(network),
@@ -76,8 +76,8 @@ class PlatformEndiannessTest {
     }
 
     @Test
-    fun `network codec read and write are inverse`() {
-        val codec = PlatformCodec.networkEndianCodec
+    fun `wire codec read and write are inverse`() {
+        val codec = PlatformCodec.wireCodec
         for (value in listOf(0, 1, -1, Int.MAX_VALUE, Int.MIN_VALUE, 0x01020304)) {
             assertEquals(value, codec.readInt(codec.writeInt(value)))
         }

--- a/src/jvmTest/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformCodecJvmTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/userspace/nio/platform/spi/PlatformCodecJvmTest.kt
@@ -14,30 +14,30 @@ class PlatformCodecJvmTest {
         val expectedOrder = if (jvmLittleEndian) ByteOrder.LITTLE_ENDIAN else ByteOrder.BIG_ENDIAN
 
         assertEquals(jvmLittleEndian, PlatformCodec.isLittleEndian)
-        assertEquals(!jvmLittleEndian, PlatformCodec.isNetworkEndian)
+        assertEquals(!jvmLittleEndian, PlatformCodec.isWireEndian)
         assertEquals(expectedOrder.toString(), ByteOrder.nativeOrder().toString())
     }
 
     @Test
-    fun `network endian codec is canonical big endian`() {
-        val wireInt = PlatformCodec.networkEndianCodec.writeInt(0x01020304)
-        val wireLong = PlatformCodec.networkEndianCodec.writeLong(0x0102030405060708L)
+    fun `wire codec is canonical big endian`() {
+        val wireInt = PlatformCodec.wireCodec.writeInt(0x01020304)
+        val wireLong = PlatformCodec.wireCodec.writeLong(0x0102030405060708L)
 
         assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), wireInt)
         assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08), wireLong)
-        assertEquals(0x01020304, PlatformCodec.networkEndianCodec.readInt(wireInt))
-        assertEquals(0x0102030405060708L, PlatformCodec.networkEndianCodec.readLong(wireLong))
+        assertEquals(0x01020304, PlatformCodec.wireCodec.readInt(wireInt))
+        assertEquals(0x0102030405060708L, PlatformCodec.wireCodec.readLong(wireLong))
     }
 
     @Test
-    fun `platform codec and network codec diverge on little endian jvm hosts`() {
+    fun `platform codec and wire codec diverge on little endian jvm hosts`() {
         if (PlatformCodec.isLittleEndian) {
-            assertFalse(PlatformCodec.isNetworkEndian)
+            assertFalse(PlatformCodec.isWireEndian)
             assertContentEquals(byteArrayOf(0x04, 0x03, 0x02, 0x01), PlatformCodec.currentPlatformCodec.writeInt(0x01020304))
-            assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), PlatformCodec.networkEndianCodec.writeInt(0x01020304))
+            assertContentEquals(byteArrayOf(0x01, 0x02, 0x03, 0x04), PlatformCodec.wireCodec.writeInt(0x01020304))
         } else {
-            assertTrue(PlatformCodec.isNetworkEndian)
-            assertContentEquals(PlatformCodec.currentPlatformCodec.writeInt(0x01020304), PlatformCodec.networkEndianCodec.writeInt(0x01020304))
+            assertTrue(PlatformCodec.isWireEndian)
+            assertContentEquals(PlatformCodec.currentPlatformCodec.writeInt(0x01020304), PlatformCodec.wireCodec.writeInt(0x01020304))
         }
     }
 }


### PR DESCRIPTION
Renamed `network-endian` concepts in `PlatformCodec` to `wire-endian` per user request. This makes the language surrounding the wire protocol standard consistent.

---
*PR created automatically by Jules for task [11567899858115704036](https://jules.google.com/task/11567899858115704036) started by @jnorthrup*