### PR TITLE
feat: add pure Kotlin PowerIterationEigenFinder for Gaussian splat inputs

### DIFF
--- a/libs/motion-estimation/build.gradle.kts
+++ b/libs/motion-estimation/build.gradle.kts
@@ -12,5 +12,10 @@ kotlin {
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
+        }
     }
 }

--- a/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/EigenFinder.kt
+++ b/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/EigenFinder.kt
@@ -1,0 +1,11 @@
+package borg.trikeshed.splat
+
+import borg.trikeshed.lib.Tensor
+import borg.trikeshed.lib.Shape
+
+/**
+ * Finds an eigenvalue signature among Gaussian splat inputs.
+ */
+interface EigenFinder<T> {
+    fun extractSignature(splat: Splat<T>): Tensor<Double>
+}

--- a/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/EmpiricalMotionModel.kt
+++ b/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/EmpiricalMotionModel.kt
@@ -21,7 +21,7 @@ class EmpiricalMotionModel<Context, T> : SplatModel<Context, T> {
         val entries = outcomes.keys.toList()
         val size = entries.size
 
-        return size.j { i ->
+        return size.j { i: Int ->
             val outcome = entries[i]
             val count = outcomes[outcome] ?: 0
             val prob = (count + laplaceSmoothing) / (total + laplaceSmoothing * size)
@@ -29,7 +29,7 @@ class EmpiricalMotionModel<Context, T> : SplatModel<Context, T> {
         }
     }
 
-    fun emptySplat(): Splat<T> = 0.j { _ -> error("empty") }
+    fun emptySplat(): Splat<T> = 0.j { _ : Int -> error("empty") }
 
     fun asStateAdapter(): SplatModel<borg.trikeshed.context.ElementState, borg.trikeshed.context.ElementState> {
         val self = this
@@ -37,7 +37,7 @@ class EmpiricalMotionModel<Context, T> : SplatModel<Context, T> {
             override fun predict(context: borg.trikeshed.context.ElementState): Splat<borg.trikeshed.context.ElementState> {
                 // Return an empty splat since the types don't necessarily match the generic context
                 // This is a bridge for the ChannelRunner to supply a model
-                return 0.j { _ -> error("empty") }
+                return 0.j { _ : Int -> error("empty") }
             }
         }
     }

--- a/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/PowerIterationEigenFinder.kt
+++ b/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/PowerIterationEigenFinder.kt
@@ -1,0 +1,83 @@
+package borg.trikeshed.splat
+
+import borg.trikeshed.lib.Tensor
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.shapeOf
+import borg.trikeshed.lib.size
+import kotlin.math.sqrt
+
+/**
+ * A simple implementation of EigenFinder using the Power Iteration method.
+ * We treat the input splat as defining a covariance matrix based on
+ * the probability (weight) of each dimension.
+ * Since a Splat<T> has `size` elements and probabilities, we can treat this
+ * as a diagonal covariance matrix (or simple weighted representation)
+ * where we want to find the principal eigenvector/eigenvalue.
+ */
+class PowerIterationEigenFinder<T>(
+    private val iterations: Int = 10,
+    private val tolerance: Double = 1e-6
+) : EigenFinder<T> {
+
+    override fun extractSignature(splat: Splat<T>): Tensor<Double> {
+        val n = splat.a
+        if (n == 0) {
+            return shapeOf(1) j { _ : borg.trikeshed.lib.Shape -> 0.0 }
+        }
+
+        // Initialize a random vector (here we just use uniform 1.0)
+        val v = DoubleArray(n) { 1.0 }
+
+        // Normalize initial vector
+        var norm = sqrt(v.sumOf { it * it })
+        if (norm > 0) {
+            for (i in 0 until n) {
+                v[i] /= norm
+            }
+        }
+
+        var eigenvalue = 0.0
+
+        for (iter in 0 until iterations) {
+            // Apply covariance matrix. For a splat, we assume each dimension i
+            // is independent with variance = prob_i. So multiply v by prob.
+            val vNext = DoubleArray(n)
+            for (i in 0 until n) {
+                val prob = splat.b(i).b
+                vNext[i] = v[i] * prob
+            }
+
+            // Calculate eigenvalue approximation (Rayleigh quotient): v^T * Cov * v
+            // Since v is normalized, it's just v^T * vNext
+            eigenvalue = 0.0
+            for (i in 0 until n) {
+                eigenvalue += v[i] * vNext[i]
+            }
+
+            // Normalize vNext
+            norm = sqrt(vNext.sumOf { it * it })
+            if (norm < tolerance) {
+                break
+            }
+
+            var diff = 0.0
+            for (i in 0 until n) {
+                val newVal = vNext[i] / norm
+                diff += kotlin.math.abs(newVal - v[i])
+                v[i] = newVal
+            }
+
+            if (diff < tolerance) {
+                break
+            }
+        }
+
+        // Return as a rank-1 Tensor
+        // Shape is [n + 1] to store eigenvalue as the first element, and eigenvector as the rest.
+        val shape = shapeOf(n + 1)
+        return shape j { idx : borg.trikeshed.lib.Shape ->
+            val index = idx.b(0)
+            if (index == 0) eigenvalue else v[index - 1]
+        }
+    }
+}

--- a/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/Splat.kt
+++ b/libs/motion-estimation/src/commonMain/kotlin/borg/trikeshed/splat/Splat.kt
@@ -5,6 +5,8 @@ import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.j
 import borg.trikeshed.lib.size
 import borg.trikeshed.lib.view
+import borg.trikeshed.lib.a
+import borg.trikeshed.lib.b
 
 typealias OutcomeVec<T> = Join<T, Double>
 typealias Splat<T> = Series<OutcomeVec<T>>

--- a/libs/motion-estimation/src/commonTest/kotlin/borg/trikeshed/splat/PowerIterationEigenFinderTest.kt
+++ b/libs/motion-estimation/src/commonTest/kotlin/borg/trikeshed/splat/PowerIterationEigenFinderTest.kt
@@ -1,0 +1,69 @@
+package borg.trikeshed.splat
+
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.shapeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PowerIterationEigenFinderTest {
+
+    @Test
+    fun testExtractSignatureEmpty() {
+        val finder = PowerIterationEigenFinder<String>()
+        val emptySplat: Splat<String> = 0 j { _ : Int -> error("empty") }
+
+        val tensor = finder.extractSignature(emptySplat)
+
+        // Tensor shape should be [1] indicating 1D array of length 1 (just eigenvalue 0.0)
+        assertEquals(1, tensor.a.a) // shape size
+        assertEquals(1, tensor.a.b(0)) // extent of first dimension is 1
+        assertEquals(0.0, tensor.b(shapeOf(0)))
+    }
+
+    @Test
+    fun testExtractSignatureSingleElement() {
+        val finder = PowerIterationEigenFinder<String>()
+        // A splat with one element having prob 0.5
+        val splat: Splat<String> = 1 j { _ : Int -> "A" j 0.5 }
+
+        val tensor = finder.extractSignature(splat)
+
+        // Tensor shape should be [2]
+        assertEquals(1, tensor.a.a) // 1D tensor shape (Series of Int)
+        assertEquals(2, tensor.a.b(0)) // dimension extent is 2
+
+        val eigenvalue = tensor.b(shapeOf(0))
+        val eigenvectorComponent = tensor.b(shapeOf(1))
+
+        // In 1D, Rayleigh quotient is essentially the probability itself (0.5), and eigenvector is normalized to 1.0.
+        // v = [1.0], vNext = [0.5], dot(v, vNext) = 0.5.
+        assertTrue(kotlin.math.abs(eigenvalue - 0.5) < 1e-5)
+        assertTrue(kotlin.math.abs(eigenvectorComponent - 1.0) < 1e-5)
+    }
+
+    @Test
+    fun testExtractSignatureMultipleElements() {
+        val finder = PowerIterationEigenFinder<String>(iterations = 50)
+        // A splat with two elements having probs 0.8 and 0.2
+        val splat: Splat<String> = 2 j { i : Int ->
+            if (i == 0) "A" j 0.8 else "B" j 0.2
+        }
+
+        val tensor = finder.extractSignature(splat)
+
+        // Shape is [3] (size n=2, +1 for eigenvalue)
+        assertEquals(1, tensor.a.a)
+        assertEquals(3, tensor.a.b(0))
+
+        val eigenvalue = tensor.b(shapeOf(0))
+        val v0 = tensor.b(shapeOf(1))
+        val v1 = tensor.b(shapeOf(2))
+
+        // Since the matrix is diagonal [[0.8, 0], [0, 0.2]], the principal eigenvalue is 0.8
+        // and the corresponding eigenvector should be [1.0, 0.0]
+        assertTrue(kotlin.math.abs(eigenvalue - 0.8) < 1e-3)
+        assertTrue(kotlin.math.abs(v0 - 1.0) < 1e-3)
+        assertTrue(kotlin.math.abs(v1 - 0.0) < 1e-3)
+    }
+}


### PR DESCRIPTION
Implements an `EigenFinder` using power iteration over Splat inputs to extract the principal eigenvalue and eigenvector, representing them cleanly as a `Tensor<Double>` with `Shape` defined as `Series<Int>`. This provides a fundamental piece for Neural Gaussian Splatting (NGS) capabilities.

---
*PR created automatically by Jules for task [6405482875464782457](https://jules.google.com/task/6405482875464782457) started by @jnorthrup*