### PR TITLE
docs(ngsctp): add interop testing plan and partial type fixes

### DIFF
--- a/docs/NG_SCTP_TODO.md
+++ b/docs/NG_SCTP_TODO.md
@@ -1,0 +1,51 @@
+# ng-sctp (Next-Generation SCTP) Testing and Development Plan
+
+This document details the necessary steps to make the `ng-sctp` module testable and interoperable with standard implementations like Pion SCTP.
+
+## Context
+The `ng-sctp` library represents a high-performance SCTP implementation utilizing Kotlin Coroutines and a zero-copy parser (Spirit parser). However, the implementation is currently incomplete and excluded from the main Gradle build.
+
+## Blocking Issues for Interop Testing
+
+1. **Pervasive Unsigned/Signed Type Mismatches**
+   - **Problem:** Many chunks (e.g. `NgChunk.kt`) and congestion models attempt to write unsigned Kotlin types (`UByte`, `UShort`, `UInt`) directly into `java.nio.ByteBuffer`, which only accepts signed primitives.
+   - **Resolution:** Refactor serialization code to cast to standard primitive types (e.g., `.toByte()`, `.toShort()`, `.toInt()`) immediately before interacting with `ByteBuffer`, or adopt a more robust, multiplatform-friendly byte stream library like `okio`.
+
+2. **Incomplete Transport Implementations**
+   - **Problem:** `IoUringSctpTransport.kt` misses Netty io_uring dependencies and contains unwritten functions. The general abstraction in `SctpEngine.kt` uses `throw NotImplementedError("Chunk waiting mechanism needs implementation")`.
+   - **Resolution:** Complete the minimal UDP-based datagram socket transport layer (perhaps avoiding kernel bypass constraints initially) to allow standard packet transmission.
+
+## Proposed Interoperability Testing Plan (vs. Pion)
+
+Once the above blocking issues are resolved, follow this plan to test against the standard Pion SCTP implementation:
+
+### 1. Launch a Reference UDP SCTP Server (Pion)
+Use the `pion/sctp` Go library's `ping-pong` example.
+```bash
+git clone https://github.com/pion/sctp.git
+cd sctp/examples/ping-pong
+go run pong/*.go
+```
+
+### 2. Implement a Client Integration Test in `ng-sctp`
+Write a Kotlin test to attempt the standard 4-way SCTP handshake using raw UDP encapsulation against the Pion server.
+```kotlin
+suspend fun testInteropWithPion() = coroutineScope {
+    val transport = UdpSctpTransport(InetSocketAddress("127.0.0.1", 9899))
+
+    // The connect method performs: INIT -> INIT_ACK -> COOKIE_ECHO -> COOKIE_ACK
+    val assoc = NgSctpAssociation.connect(
+        remote = InetSocketAddress("127.0.0.1", 9899),
+        transport = transport
+    )
+
+    val stream = assoc.openStream(0)
+    stream.write("ping 1".toByteArray())
+
+    val response = stream.receive()
+    assertEquals("pong 1", String(response))
+}
+```
+
+### 3. Verify Wireshark / PCAP Observability
+Ensure the `ng-sctp` UDP payloads are decodable by standard network analysis tools (Wireshark decode as SCTP-over-UDP).

--- a/libs/ng-sctp/src/commonMain/kotlin/dev/jnorthrup/ngsctp/chunks/NgChunk.kt
+++ b/libs/ng-sctp/src/commonMain/kotlin/dev/jnorthrup/ngsctp/chunks/NgChunk.kt
@@ -314,8 +314,8 @@ data class NgChunk_Data(
     override fun serialize(): ByteArray {
         val length = 16 + userData.remaining()
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putShort(streamId.toShort())
         buffer.putShort(streamSequenceNumber.toShort())
@@ -343,8 +343,8 @@ data class NgChunk_Init(
             length += 4 + param.data.size
         }
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(initiateTag.toInt())
         buffer.putInt(initialTSN.toInt())
@@ -373,8 +373,8 @@ data class NgChunk_InitAck(
     override fun serialize(): ByteArray {
         val length = 20 + cookie.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(initiateTag.toInt())
         buffer.putInt(initialTSN.toInt())
@@ -404,8 +404,8 @@ data class NgChunk_Sack(
         // 12 bytes header + 4 bytes per gap ack block + 4 bytes per duplicate TSN
         val length = 12 + (gapAckBlocks.size * 4) + (duplicateTSNs.size * 4)
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(cumulativeTSNAck.toInt())
         buffer.putInt(advertisedReceiverWindowCredit.toInt())
@@ -436,8 +436,8 @@ data class NgChunk_CookieEcho(
     override fun serialize(): ByteArray {
         val length = 4 + cookie.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.put(cookie)
         return buffer.array()
@@ -463,8 +463,8 @@ data class NgChunk_Heartbeat(
     override fun serialize(): ByteArray {
         val length = 4 + info.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.put(info)
         return buffer.array()
@@ -480,8 +480,8 @@ data class NgChunk_HeartbeatAck(
     override fun serialize(): ByteArray {
         val length = 4 + info.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.put(info)
         return buffer.array()
@@ -496,8 +496,8 @@ data class NgChunk_Shutdown(
 ) : NgChunk {
     override fun serialize(): ByteArray {
         val buffer = ByteBuffer.allocate(8)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(8)
         buffer.putInt(cumulativeTSNAck.toInt())
         return buffer.array()
@@ -568,8 +568,8 @@ data class NgChunk_ForwardTsn(
         // 4 bytes header + 4 bytes per stream mapping
         val length = 4 + (streamMappings.size * 4)
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(cumulativeTSN.toInt())
         
@@ -617,8 +617,8 @@ data class NgChunk_Abort(
         val infoBytes = errorInfo?.toByteArray() ?: ByteArray(0)
         val length = 4 + infoBytes.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.put(infoBytes)
         return buffer.array()
@@ -635,8 +635,8 @@ data class NgChunk_Error(
     override fun serialize(): ByteArray {
         val length = 6 + additionalInfo.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putShort(errorCode.toShort())
         buffer.put(additionalInfo)
@@ -836,8 +836,8 @@ data class NgChunk_Ecne(
 ) : NgChunk {
     override fun serialize(): ByteArray {
         val buffer = ByteBuffer.allocate(8)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(8) // Length
         buffer.putInt(lowestTSN.toInt())
         return buffer.array()
@@ -865,8 +865,8 @@ data class NgChunk_Cwr(
 ) : NgChunk {
     override fun serialize(): ByteArray {
         val buffer = ByteBuffer.allocate(8)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(8) // Length
         buffer.putInt(lowestTSN.toInt())
         return buffer.array()
@@ -970,8 +970,8 @@ data data class NgChunk_ReConfig(
         val items = requests.ifEmpty { responses }
         val length = 4 + (items.size * 8)
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         
         // Serialize requests
@@ -1098,8 +1098,8 @@ data class NgChunk_Asconf(
         val length = 8 + paramLength
         
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(serial.toInt())
         
@@ -1180,8 +1180,8 @@ data class NgChunk_AsconfAck(
     override fun serialize(): ByteArray {
         val length = 8 + (parameters.size * 8)
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(serial.toInt())
         
@@ -1248,8 +1248,8 @@ data class NgChunk_IData(
         // 20 bytes header + user data
         val length = 20 + userData.size
         val buffer = ByteBuffer.allocate(length)
-        buffer.put(type.value)
-        buffer.put(flags.value)
+        buffer.put(type.value.toByte())
+        buffer.put(flags.value.toByte())
         buffer.putShort(length.toShort())
         buffer.putInt(tsn.toInt())
         buffer.putShort(streamId)


### PR DESCRIPTION
Added a plan for testing ng-sctp interoperability with typical services (Pion) and partially addressed unsigned type compilation issues.

---
*PR created automatically by Jules for task [16483552040203607726](https://jules.google.com/task/16483552040203607726) started by @jnorthrup*