### PR TITLE
feat: Extend pointcut harness to Graal polyglot languages

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/graal/GraalPointcutHarness.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/GraalPointcutHarness.kt
@@ -1,0 +1,25 @@
+package borg.trikeshed.graal
+
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.HostAccess
+import org.graalvm.polyglot.Value
+import org.xvm.activejs.ccek.PointcutEventProducer
+
+/**
+ * GraalPointcutHarness - extends pointcut capturing to any Graal polyglot language.
+ *
+ * It uses Context.newBuilder() to manage the evaluation environment for multiple languages.
+ */
+class GraalPointcutHarness(private val pointcutProducer: PointcutEventProducer? = null) {
+
+    val context: Context = Context.newBuilder()
+        .build()
+
+    fun eval(languageId: String, source: String): Any? {
+        return context.eval(languageId, source)?.asHostObject()
+    }
+
+    fun close() {
+        context.close()
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/PolyglotCcekBridge.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/PolyglotCcekBridge.kt
@@ -1,0 +1,48 @@
+package borg.trikeshed.graal
+
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.HostAccess
+import org.xvm.activejs.ccek.FieldSynapse
+import org.xvm.activejs.ccek.PointcutEventProducer
+
+/**
+ * Host class to emit CCEK pointcut events from polyglot code.
+ */
+class PolyglotPointcutEmitter(private val producer: PointcutEventProducer) {
+
+    @HostAccess.Export
+    fun emit(
+        phase: Byte,
+        opcode: Byte,
+        methodIdx: Int,
+        addr: Int,
+        seq: Int,
+        timestamp: Long,
+        callsiteHash: Int,
+        templateIdx: Int
+    ) {
+        val synapse = FieldSynapse(
+            phase = phase,
+            opcode = opcode,
+            methodIdx = methodIdx,
+            addr = addr,
+            seq = seq,
+            nano = timestamp,
+            callsiteHash = callsiteHash,
+            templateIdx = templateIdx
+        )
+        producer.emit(synapse)
+    }
+}
+
+/**
+ * Evaluates code in a Context while exposing a PointcutEventProducer to it.
+ */
+fun Context.evalWithPointcuts(language: String, source: String, producer: PointcutEventProducer): Any? {
+    val emitter = PolyglotPointcutEmitter(producer)
+
+    // Bind the emitter to the context so polyglot scripts can access it
+    this.getBindings(language).putMember("pointcutEmitter", emitter)
+
+    return this.eval(language, source)?.asHostObject()
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/PolyglotTaxonomy.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/PolyglotTaxonomy.kt
@@ -1,0 +1,43 @@
+package borg.trikeshed.graal
+
+import org.xvm.cursor.PointcutFacet
+import borg.trikeshed.lib.MutableSeries
+import borg.trikeshed.lib.SeriesBuffer
+
+/**
+ * PolyglotFacet represents different language features for pointcuts.
+ */
+sealed class PolyglotFacet : PointcutFacet {
+    object PolyglotFunction : PolyglotFacet()
+    object PolyglotVariable : PolyglotFacet()
+    object PolyglotBlock : PolyglotFacet()
+    object Unfaceted : PolyglotFacet()
+}
+
+/**
+ * PolyglotCoordinateRow stores metadata about intercepted executions.
+ */
+data class PolyglotCoordinateRow(
+    val languageId: String,
+    val symbolName: String,
+    val sourceLocation: String,
+    val poolId: Int,
+    val facet: PolyglotFacet = PolyglotFacet.Unfaceted
+)
+
+/**
+ * PolyglotTaxonomy registers these rows into the broader TrikeShed taxonomic structure.
+ */
+class PolyglotTaxonomy {
+    var rows: MutableSeries<PolyglotCoordinateRow> = SeriesBuffer()
+
+    val size: Int get() = rows.a
+
+    fun register(row: PolyglotCoordinateRow) {
+        rows.add(row)
+    }
+
+    fun rowAt(index: Int): PolyglotCoordinateRow = rows.b(index)
+
+    fun getRows(): borg.trikeshed.lib.Series<PolyglotCoordinateRow> = rows
+}


### PR DESCRIPTION
Extends the pointcut harness to all the graal languages, creating tentative taxonomical code features managing abstractions, and mapping pointcuts from CCEK primitives via `HostAccess` bindings.

---
*PR created automatically by Jules for task [14325768086319278377](https://jules.google.com/task/14325768086319278377) started by @jnorthrup*