### PR TITLE
⚡ Optimize ConfixOracleService getTypedefChain lookups

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/confix/ConfixOracleService.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/confix/ConfixOracleService.kt
@@ -81,13 +81,15 @@ class ConfixOracleService : ConfixOracleFacade {
         var currentName = typeName
         val seen = mutableSetOf<String>()
 
+        val entriesMap = (0 until row.entries.a).associate { row.entries.b(it).name to row.entries.b(it) }
+
         while (true) {
             if (!seen.add(currentName)) {
                 // Cycle detected — terminate
                 break
             }
 
-            val entry = (0 until row.entries.a).map { row.entries.b(it) }.find { it.name == currentName } ?: break
+            val entry = entriesMap[currentName] ?: break
 
             // Extract the base name from referredToType (strip params, unions, etc.)
             val baseName = extractBaseName(entry.referredToType)

--- a/src/commonTest/kotlin/borg/trikeshed/confix/ConfixOracleServiceBenchmarkTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/confix/ConfixOracleServiceBenchmarkTest.kt
@@ -1,0 +1,15 @@
+package borg.trikeshed.confix
+
+import kotlin.test.*
+import kotlin.time.measureTime
+
+class ConfixOracleServiceBenchmarkTest {
+    @Test fun benchmarkGetTypedefChain() {
+        val service = ConfixOracleService()
+        val sourceText = buildString { for (i in 0 until 1000) appendLine("typedef Type${i+1} as Type${i};") }
+        service.addSource(sourceText, "benchmark.x")
+        for (i in 0 until 10) service.getTypedefChain("benchmark.x", "Type0")
+        val duration = measureTime { for (i in 0 until 1000) service.getTypedefChain("benchmark.x", "Type0") }
+        println("BENCHMARK_RESULT: ${duration.inWholeMilliseconds} ms")
+    }
+}


### PR DESCRIPTION
💡 What: Replaced O(N) linear scan inside the typedef chain resolution loop with an O(1) map lookup.
🎯 Why: Resolving deep typedef chains triggered an N+1 performance issue because the entire list of typedef entries was mapped and linearly scanned repeatedly. By precomputing a name-to-entry map before the loop, we drastically reduce execution time.
📊 Measured Improvement: Verified the algorithmic improvement. The JVM benchmark test could not compile locally due to Java 25 compatibility issues from other project modules, but the logic changes map creation outside the loop resolving the O(N^2) overhead to O(N).

---
*PR created automatically by Jules for task [6951933905332681055](https://jules.google.com/task/6951933905332681055) started by @jnorthrup*