### PR TITLE
Fix JS and WASM ChannelOperations adapters to throw unsupported exceptions instead of silent sentinels

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
@@ -30,7 +30,7 @@ internal actual object LiburingImpl : LiburingFacade {
     }
 
     actual override fun submit(): Result<Int> = unsupported()
-    actual override fun waitCqe(): Result<UringCompletion> = unsupported()
+    actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
     actual override fun cqAdvance(count: Int) {}
     actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}

--- a/src/jsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JsChannelOperations.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JsChannelOperations.kt
@@ -4,18 +4,18 @@ import borg.trikeshed.userspace.nio.ByteBuffer
 
 class JsChannelOperations : ChannelOperations {
     override fun openChannel(entries: Int): ChannelOperations.ChannelHandle = JsChannelHandle()
-    override fun socket(domain: Int, type: Int, protocol: Int): Int = -1
-    override fun bind(fd: Int, port: Int): Int = -1
-    override fun listen(fd: Int, backlog: Int): Int = -1
-    override fun accept(fd: Int): Int = -1
-    override fun connect(fd: Int, host: String, port: Int): Int = -1
-    override fun close(fd: Int): Int = -1
+    override fun socket(domain: Int, type: Int, protocol: Int): Int = throw UnsupportedOperationException("ChannelOperations.socket unsupported on JS")
+    override fun bind(fd: Int, port: Int): Int = throw UnsupportedOperationException("ChannelOperations.bind unsupported on JS")
+    override fun listen(fd: Int, backlog: Int): Int = throw UnsupportedOperationException("ChannelOperations.listen unsupported on JS")
+    override fun accept(fd: Int): Int = throw UnsupportedOperationException("ChannelOperations.accept unsupported on JS")
+    override fun connect(fd: Int, host: String, port: Int): Int = throw UnsupportedOperationException("ChannelOperations.connect unsupported on JS")
+    override fun close(fd: Int): Int = throw UnsupportedOperationException("ChannelOperations.close unsupported on JS")
 
     private class JsChannelHandle : ChannelOperations.ChannelHandle {
         override val id: Int get() = 0
-        override fun read(buffer: ByteBuffer, offset: Long): Int = -1
-        override fun write(buffer: ByteBuffer, offset: Long): Int = -1
-        override fun submit(): Int = 0
-        override fun wait(minComplete: Int): List<ChannelResult> = emptyList()
+        override fun read(buffer: ByteBuffer, offset: Long): Int = throw UnsupportedOperationException("ChannelHandle.read unsupported on JS")
+        override fun write(buffer: ByteBuffer, offset: Long): Int = throw UnsupportedOperationException("ChannelHandle.write unsupported on JS")
+        override fun submit(): Int = throw UnsupportedOperationException("ChannelHandle.submit unsupported on JS")
+        override fun wait(minComplete: Int): List<ChannelResult> = throw UnsupportedOperationException("ChannelHandle.wait unsupported on JS")
     }
 }

--- a/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
@@ -12,7 +12,7 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun prepMmap(fd: Int, addr: Long, len: Int, prot: Int, flags: Int, offset: Long, userData: Long): Result<Unit> = unsupported()
     actual override fun prepMunmap(addr: Long, len: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun submit(): Result<Int> = unsupported()
-    actual override fun waitCqe(): Result<UringCompletion> = unsupported()
+    actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
     actual override fun cqAdvance(count: Int) {}
     actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}

--- a/src/wasmJsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/WasmChannelOperations.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/WasmChannelOperations.kt
@@ -4,18 +4,18 @@ import borg.trikeshed.userspace.nio.ByteBuffer
 
 class WasmChannelOperations : ChannelOperations {
     override fun openChannel(entries: Int): ChannelOperations.ChannelHandle = WasmChannelHandle()
-    override fun socket(domain: Int, type: Int, protocol: Int): Int = -1
-    override fun bind(fd: Int, port: Int): Int = -1
-    override fun listen(fd: Int, backlog: Int): Int = -1
-    override fun accept(fd: Int): Int = -1
-    override fun connect(fd: Int, host: String, port: Int): Int = -1
-    override fun close(fd: Int): Int = -1
+    override fun socket(domain: Int, type: Int, protocol: Int): Int = throw UnsupportedOperationException("ChannelOperations.socket unsupported on WASM")
+    override fun bind(fd: Int, port: Int): Int = throw UnsupportedOperationException("ChannelOperations.bind unsupported on WASM")
+    override fun listen(fd: Int, backlog: Int): Int = throw UnsupportedOperationException("ChannelOperations.listen unsupported on WASM")
+    override fun accept(fd: Int): Int = throw UnsupportedOperationException("ChannelOperations.accept unsupported on WASM")
+    override fun connect(fd: Int, host: String, port: Int): Int = throw UnsupportedOperationException("ChannelOperations.connect unsupported on WASM")
+    override fun close(fd: Int): Int = throw UnsupportedOperationException("ChannelOperations.close unsupported on WASM")
 
     private class WasmChannelHandle : ChannelOperations.ChannelHandle {
         override val id: Int get() = 0
-        override fun read(buffer: ByteBuffer, offset: Long): Int = -1
-        override fun write(buffer: ByteBuffer, offset: Long): Int = -1
-        override fun submit(): Int = 0
-        override fun wait(minComplete: Int): List<ChannelResult> = emptyList()
+        override fun read(buffer: ByteBuffer, offset: Long): Int = throw UnsupportedOperationException("ChannelHandle.read unsupported on WASM")
+        override fun write(buffer: ByteBuffer, offset: Long): Int = throw UnsupportedOperationException("ChannelHandle.write unsupported on WASM")
+        override fun submit(): Int = throw UnsupportedOperationException("ChannelHandle.submit unsupported on WASM")
+        override fun wait(minComplete: Int): List<ChannelResult> = throw UnsupportedOperationException("ChannelHandle.wait unsupported on WASM")
     }
 }


### PR DESCRIPTION
<ArchitectureGoal --> CCEK_Reactor_SupervisorTask_ChannelOperations>.
<ChannelOperations --> LinuxIoUringPreferred>.
<OtherTargets --> UserspaceNioAdapters>.

<Claim --> Goal>.
<JSAdapter --> SentinelReturn>.
<WASMAdapter --> SentinelReturn>.
<SentinelReturn --> MISDIRECTED>.

<JSAdapter --> ExceptionsThrown>.
<WASMAdapter --> ExceptionsThrown>.
<ExceptionsThrown --> HARD>.

Severity: MEDIUM.
Changed files:
- src/jsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JsChannelOperations.kt
- src/wasmJsMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/WasmChannelOperations.kt
- src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
- src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
Verification: Verified using `./gradlew compileKotlinJs compileKotlinWasmJs --no-daemon`.
Residual gaps: No other targets return sentinels for ChannelOperations.
Next single best cut: Review NioSupervisor implementations.

---
*PR created automatically by Jules for task [14529712820080866116](https://jules.google.com/task/14529712820080866116) started by @jnorthrup*