### PR TITLE
Fix waitCqe signature to return Result<UringCompletion?>

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
@@ -30,7 +30,7 @@ internal actual object LiburingImpl : LiburingFacade {
     }
 
     actual override fun submit(): Result<Int> = unsupported()
-    actual override fun waitCqe(): Result<UringCompletion> = unsupported()
+    actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
     actual override fun cqAdvance(count: Int) {}
     actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}

--- a/src/linuxMain/kotlin/borg/trikeshed/userspace/Liburing.linux.kt
+++ b/src/linuxMain/kotlin/borg/trikeshed/userspace/Liburing.linux.kt
@@ -108,7 +108,7 @@ internal actual object LiburingImpl : LiburingFacade {
         return if (rc < 0) failure("io_uring_submit failed", rc) else Result.success(rc)
     }
 
-    actual override fun waitCqe(): Result<UringCompletion> {
+    actual override fun waitCqe(): Result<UringCompletion?> {
         val currentRing = ring ?: return failure("liburing ring is not open")
         memScoped {
             val cqe = alloc<CPointerVar<io_uring_cqe>>()

--- a/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
+++ b/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
@@ -14,7 +14,7 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun prepSendmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun prepRecvmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun submit(): Result<Int> = unsupported()
-    actual override fun waitCqe(): Result<UringCompletion> = unsupported()
+    actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
     actual override fun cqAdvance(count: Int) {}
     actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}

--- a/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
@@ -12,7 +12,7 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun prepMmap(fd: Int, addr: Long, len: Int, prot: Int, flags: Int, offset: Long, userData: Long): Result<Unit> = unsupported()
     actual override fun prepMunmap(addr: Long, len: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun submit(): Result<Int> = unsupported()
-    actual override fun waitCqe(): Result<UringCompletion> = unsupported()
+    actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
     actual override fun cqAdvance(count: Int) {}
     actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}


### PR DESCRIPTION
The `Liburing.waitCqe()` common interface was modified from returning `Result<UringCompletion>` to returning `Result<UringCompletion?>` to align with the rest of the interface methods and usage of the function. However, the platform specific implementations were not updated.
This led to the following compile error: `src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt:33:18 This declaration overrides a deprecated member but is not marked as deprecated itself. Add the '@Deprecated' annotation or suppress the diagnostic.` (actually an overriding conflict error).

This PR fixes the problem by updating the platform specific signatures in jsMain, wasmJsMain, macosMain, and linuxMain.

---
*PR created automatically by Jules for task [16906525579160898384](https://jules.google.com/task/16906525579160898384) started by @jnorthrup*