### PR TITLE
Fix kernel-algebra: Extract SeriesBuffer to canonical lib package

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/SeriesBuffer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/SeriesBuffer.kt
@@ -1,0 +1,41 @@
+package borg.trikeshed.lib
+
+class SeriesBuffer<T>(
+    capacity: Int = 8,
+) : Series<T> {
+    var buf: Array<Any?> = arrayOfNulls(capacity)
+    var count: Int = 0
+
+    override val a: Int get() = count
+    override val b: (Int) -> T get() = { index ->
+        @Suppress("UNCHECKED_CAST")
+        buf[index] as T
+    }
+
+    fun add(item: T) {
+        if (count == buf.size) {
+            val next = arrayOfNulls<Any?>(buf.size * 2)
+            buf.copyInto(next)
+            buf = next
+        }
+        buf[count++] = item
+    }
+
+    fun removeLast(): T {
+        require(count > 0) { "removeLast on empty SeriesBuffer" }
+        val idx = --count
+        @Suppress("UNCHECKED_CAST")
+        val item = buf[idx] as T
+        buf[idx] = null
+        return item
+    }
+
+    fun snapshot(): Series<T> {
+        val currentBuf = buf.copyOf()
+        val currentCount = count
+        return currentCount j { index ->
+            @Suppress("UNCHECKED_CAST")
+            currentBuf[index] as T
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/parse/kursive/legacy/Jursive.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/kursive/legacy/Jursive.kt
@@ -1,5 +1,7 @@
 package borg.trikeshed.parse.kursive.legacy
 
+import borg.trikeshed.lib.SeriesBuffer
+
 import borg.trikeshed.collections.s_
 import borg.trikeshed.cursor.*
 import borg.trikeshed.isam.meta.IOMemento
@@ -8,33 +10,6 @@ import borg.trikeshed.lib.*
 typealias NarsiveEvent = Join<Series<Char>, Twin<Int>>
 typealias NarsiveTrace = Series<NarsiveEvent>
 
-class SeriesBuffer<T>(
-    capacity: Int = 8,
-) : Series<T> {
-    var buf: Array<Any?> = arrayOfNulls(capacity)
-    var count: Int = 0
-
-    override val a: Int get() = count
-    override val b: (Int) -> T get() = { index -> buf[index] as T }
-
-    fun add(item: T) {
-        if (count == buf.size) {
-            val next = arrayOfNulls<Any?>(buf.size * 2)
-            buf.copyInto(next)
-            buf = next
-        }
-        buf[count++] = item
-    }
-
-    fun removeLast(): T {
-        require(count > 0) { "removeLast on empty SeriesBuffer" }
-        val idx = --count
-        @Suppress("UNCHECKED_CAST")
-        return (buf[idx] as T).also { buf[idx] = null }
-    }
-
-    fun snapshot(): Series<T> = count j { index -> buf[index] as T }
-}
 //TODO DRY THESE INTO ONE ABSTRACTION
 
 class JursiveCharSeries constructor(

--- a/src/commonTest/kotlin/borg/trikeshed/lib/SeriesBufferTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lib/SeriesBufferTest.kt
@@ -1,0 +1,64 @@
+package borg.trikeshed.lib
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SeriesBufferTest {
+
+    @Test
+    fun testAppendOrderAndCapacity() {
+        val buffer = SeriesBuffer<Int>(capacity = 2)
+        assertEquals(0, buffer.size)
+
+        buffer.add(1)
+        buffer.add(2)
+        buffer.add(3) // triggers resize
+
+        assertEquals(3, buffer.size)
+        assertEquals(1, buffer[0])
+        assertEquals(2, buffer[1])
+        assertEquals(3, buffer[2])
+    }
+
+    @Test
+    fun testRemoveLast() {
+        val buffer = SeriesBuffer<String>()
+        buffer.add("a")
+        buffer.add("b")
+
+        val last = buffer.removeLast()
+        assertEquals("b", last)
+        assertEquals(1, buffer.size)
+        assertEquals("a", buffer[0])
+
+        buffer.removeLast()
+        assertEquals(0, buffer.size)
+
+        assertFailsWith<IllegalArgumentException> {
+            buffer.removeLast()
+        }
+    }
+
+    @Test
+    fun testSnapshotIsolation() {
+        val buffer = SeriesBuffer<Int>()
+        buffer.add(10)
+        buffer.add(20)
+
+        val snapshot = buffer.snapshot()
+        assertEquals(2, snapshot.size)
+        assertEquals(10, snapshot[0])
+        assertEquals(20, snapshot[1])
+
+        buffer.add(30)
+        buffer.removeLast() // remove 30
+        buffer.removeLast() // remove 20
+        buffer.add(40) // now buffer has 10, 40
+
+        // snapshot should remain unchanged
+        assertEquals(2, snapshot.size)
+        assertEquals(10, snapshot[0])
+        assertEquals(20, snapshot[1])
+    }
+}


### PR DESCRIPTION
Implements the required canonical changes for PACKAGE REMEDIAL JOB J01-kernel-algebra. It correctly pulls `SeriesBuffer` down into the canonical kernel algebra `borg.trikeshed.lib` package and adds regression testing for snapshot isolation. Per user constraints, the build failure related to duplicate tasks in `build.gradle.kts` was deliberately untouched and reported in the commit message.

---
*PR created automatically by Jules for task [14840399884225250297](https://jules.google.com/task/14840399884225250297) started by @jnorthrup*