### PR TITLE
🧹 Remove unused import PlatformLinuxBLKGETSIZE64

### DIFF
--- a/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
+++ b/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
@@ -27,7 +27,6 @@ import simple.LinuxPosixFile.Companion.getDirFd
 import simple.LinuxPosixFile.Companion.namedDirAndFile
 import simple.PosixStatMode
 import kotlin.math.min
-import platform.linux.BLKGETSIZE64 as PlatformLinuxBLKGETSIZE64
 import platform.posix.free as posix_free
 import platform.posix.fstat as posix_fstat
 import platform.posix.ioctl as posix_ioctl
@@ -242,7 +241,7 @@ fun get_file_size(fd: Int): posix_off_t = memScoped {
 
 private fun MemScope.getBlockDeviceBlockSize(fd: Int): posix_off_t {
     val bytes: LongVar = alloc()
-    posixRequires(posix_ioctl(fd, PlatformLinuxBLKGETSIZE64, bytes.ptr).z) { ("ioctl") }
+    posixRequires(posix_ioctl(fd, platform.linux.BLKGETSIZE64, bytes.ptr).z) { ("ioctl") }
     return bytes.value /* = kotlin.Long */
 }
 


### PR DESCRIPTION
🎯 **What:** Removed the unused alias import `platform.linux.BLKGETSIZE64 as PlatformLinuxBLKGETSIZE64` and updated its usage to the fully qualified name.
💡 **Why:** The alias import was flagged as a code health issue, adding unnecessary noise. Removing the alias and using the name directly improves code readability and maintainability.
✅ **Verification:** Verified that the alias was replaced successfully without breaking functionality.
✨ **Result:** Improved code cleanliness without altering any behavior.

---
*PR created automatically by Jules for task [4542219617026307183](https://jules.google.com/task/4542219617026307183) started by @jnorthrup*