### PR TITLE
🧹 Remove commented-out freeze check

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/common/collections/associative/trie/Trie.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/common/collections/associative/trie/Trie.kt
@@ -30,7 +30,6 @@ class Trie(var root: Map<String, Node> = linkedMapOf()) {
     operator fun get(vararg key: String): Int? = search(*key)?.payload
 
     fun frez(n: Node) {
-//        if (n.leaf) return
         (n.children.entries).let { cnodes ->
             n.children = ArrayMap.sorting(n.children)
             for ((_, v) in cnodes) frez(v)


### PR DESCRIPTION
🎯 What: Removed the commented out if (n.leaf) return inside frez method in Trie.kt.
💡 Why: This commented out code was likely an earlier optimization attempt that was abandoned. Removing it cleans up the function logic and improves readability.
✅ Verification: Code review confirmed safety as it only removes a dead comment.
✨ Result: Cleaner code in Trie.kt without changing any behavior.

---
*PR created automatically by Jules for task [12113314544476727577](https://jules.google.com/task/12113314544476727577) started by @jnorthrup*