### PR TITLE
Implement proper ConfixDoc navigation in ConfixBlackboard

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
@@ -1,8 +1,8 @@
 package borg.trikeshed.graal
 
 import borg.trikeshed.parse.confix.*
-import borg.trikeshed.lib.Series
-import borg.trikeshed.lib.j
+import borg.trikeshed.cursor.*
+import borg.trikeshed.lib.*
 import kotlinx.datetime.Clock
 
 /**
@@ -129,13 +129,27 @@ private fun ConfixDoc.set(key: String, value: Any?): ConfixDoc {
     return confixDoc(json.encodeToByteArray(), Syntax.JSON)
 }
 
-private fun ConfixDoc.get(key: String): Any? {
-    // TODO: implement proper Confix navigation
-    return null
-}
+private fun ConfixDoc.get(key: String): Any? = this.value(key)
 
 private fun ConfixDoc.remove(key: String): ConfixDoc = this
 
-private fun ConfixDoc.has(key: String): Boolean = true
+private fun ConfixDoc.has(key: String): Boolean = this.docAt(key) != null
 
-private fun ConfixDoc.keys(): List<String> = listOf()
+private fun ConfixDoc.keys(): List<String> {
+    val r = this.root
+    if (r != null && r.tag == IOMemento.IoObject) {
+        val keys = mutableListOf<String>()
+        val ch = r.kids
+        var i = 0
+        while (i + 1 < ch.size) {
+            val k = ch[i]
+            if (k.tag == IOMemento.IoString) {
+                val key = k.reify(this.src) as? String
+                if (key != null) keys.add(key)
+            }
+            i += 2
+        }
+        return keys
+    }
+    return emptyList()
+}


### PR DESCRIPTION
This change replaces the mock implementations in `ConfixBlackboard.kt` for `ConfixDoc.get(key)`, `has(key)`, and `keys()` with the correct navigation mechanism by leveraging `ConfixKit` helpers (`this.value(key)`, `this.docAt(key)`, and traversing `this.root.kids`).

---
*PR created automatically by Jules for task [4536516295984864501](https://jules.google.com/task/4536516295984864501) started by @jnorthrup*