### PR TITLE
🧹 Remove commented-out test testConformant2Isam in LinuxCSVUtilTest

### DIFF
--- a/src/linuxTest/kotlin/LinuxCSVUtilTest.kt
+++ b/src/linuxTest/kotlin/LinuxCSVUtilTest.kt
@@ -94,48 +94,4 @@ class LinuxCSVUtilTest {
         }
     }
 
-//    @Test
-//    fun testConformant2Isam() {
-//        val fileBuf = fileBuffer(target)
-//        fileBuf.use {
-//            val cursor = CSVUtil.parseConformant(fileBuf)
-//            val meta = cursor.meta.debug {
-//                logDebug { "meta: ${it.toList()}" }
-//            }
-//            meta.forEach { println(it) }
-//            UringIsamDataFile.write  (cursor, "/tmp/hi.isam")
-//            IsamDataFile("/tmp/hi.isam").use { isam:Cursor ->
-//
-//                isam.head()
-//                logDebug {
-//                    "meta: ${
-//                        isam.meta.map { isam ->
-//                            isam.name to isam.type
-//                        }
-//                    }"
-//                }
-//                //test row 16 against the contents
-//                // 1502943360000,4261.48000000,4261.48000000,4261.48000000,4261.48000000,0.00000000,1502943419999,0.00000000,0,0.00000000,0.00000000,7958.34896534
-//                val row16 = isam.row(16)
-//                val row16List = row16.left
-//                assertEquals(12, row16List.size)
-//                assertEquals(1502943360000, row16List[0])
-//
-//                assertEquals(1502943419999, row16List[6])
-//                assertEquals(
-//                    0.toByte(),
-//                    row16List[8]
-//                )//this test arrives at a Byte duck type, and needs a cast or fails.
-//                assertEquals(4261.48f, row16List[1])
-//                assertEquals(4261.48f, row16List[2])
-//                assertEquals(4261.48f, row16List[3])
-//                assertEquals(4261.48f, row16List[4])
-//                assertEquals(7958.34896534, row16List[11])
-//                assertEquals(0f, row16List[5])
-//                assertEquals(0f, row16List[7])
-//                assertEquals(0f, row16List[9])
-//                assertEquals(0f, row16List[10])
-//            }
-//        }
-//    }
 }


### PR DESCRIPTION
🎯 **What:** The commented-out test `testConformant2Isam` was removed from `src/linuxTest/kotlin/LinuxCSVUtilTest.kt`.

💡 **Why:** Having large blocks of commented-out code degrades readability and maintainability. Tests should be active or completely removed. If this functionality is needed in the future, it can be retrieved from version control.

✅ **Verification:** Verified the code compiles and that `jvmTest` and `linuxX64Test` tasks behave consistently with the baseline state (which fails due to an unrelated known build configuration error `Cannot add task 'kmpPartiallyResolvedDependenciesChecker'`). No logical paths were modified, meaning no regressions were introduced.

✨ **Result:** A cleaner and more readable test file.

---
*PR created automatically by Jules for task [473137433507306125](https://jules.google.com/task/473137433507306125) started by @jnorthrup*