### PR TITLE
🧹 [Code Health] Remove commented-out debug code in IOMemento.kt

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/isam/meta/IOMemento.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/isam/meta/IOMemento.kt
@@ -82,12 +82,7 @@ enum class IOMemento(override val networkSize: Int? = null, val fromChars: (Seri
         override fun createEncoder(i: Int): (Any?) -> ByteArray = {
             //try a cast elvis first with Instant then with LocalDate
             val date = (it as? Instant)?.toLocalDateTime(TimeZone.UTC)?.date ?: it as LocalDate
-//
-//            val toEpochDays = (it as LocalDate).toEpochDays()
-//            writeLong (toEpochDays.toLong())
             writeLong(date.toEpochDays().toLong())
-
-
         }
 
         override fun createDecoder(size: Int): (ByteArray) -> Any? = {


### PR DESCRIPTION
🎯 What:
Removed commented-out debug code in `IoLocalDate` related to `toEpochDays` calculation, along with unnecessary blank lines.

💡 Why:
The commented-out code was an obsolete approach that has since been replaced by a more robust, one-liner implementation. Removing dead/commented-out code improves file readability and maintainability.

✅ Verification:
- Code analysis confirms these are only comments.
- Compiled the project using `./gradlew jvmTest` and `./gradlew assemble` (ignoring a pre-existing Gradle task configuration conflict which is known and documented in memory).
- Visual inspection via `git diff` to ensure no runtime logic was altered.

✨ Result:
Cleaner, more readable `IoLocalDate` definition within `IOMemento.kt`.

---
*PR created automatically by Jules for task [4548464653846830759](https://jules.google.com/task/4548464653846830759) started by @jnorthrup*