### PR TITLE
🧹 Remove commented-out testMsgPack

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/dht/codec/SmMsgPackTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/dht/codec/SmMsgPackTest.kt
@@ -32,15 +32,6 @@ fun recv(ser: ByteBuffer): ReifiedMessage {
 
 class SmMsgPackTest : TestCase() {
 
-//    val sm1: SimpleMessage = _v["Alice" t2 "Bob",
-//            "Charley" t2 "Delta"] t2 "Random message Body here"
-//    fun testMsgPack() {
-//        val byteBuffer = SmMsgPack.send(sm1)
-//        debug{}
-//        val done=SmMsgPack.recv(byteBuffer!!)
-//        debug{}
-//    }
-
     val sm1: ReifiedMessage = listOf("Alice" to "Bob", "Charley" to "Delta") to "Random message Body here"
 
     fun testMsgPack() {


### PR DESCRIPTION
🎯 **What:** Removed commented-out test block testMsgPack and sm1 from SmMsgPackTest.kt.
💡 **Why:** Dead code cluttering test class.
✅ **Verification:** Verified by checking diff manually. The pre-existing gradle task failure makes running tests impossible, but this is a pure text removal of comments, so it is safe.
✨ **Result:** Cleaner test file with no dead code.

---
*PR created automatically by Jules for task [5926225104727862578](https://jules.google.com/task/5926225104727862578) started by @jnorthrup*