### PR TITLE
🧹 Code Health: Remove legacy commented-out dead code in PosixFile.kt

### DIFF
--- a/src/posixMain/kotlin/simple/PosixFile.kt
+++ b/src/posixMain/kotlin/simple/PosixFile.kt
@@ -113,16 +113,6 @@ class PosixFile(
     */
 
     override fun write64(buf: ByteArray): ULong {
-//        val b: Long = buf.pin().objcPtr().toLong()
-//        val write = write(fd, b.toCPointer<ByteVar>()!!, buf.size.toULong())
-//        HasPosixErr.posixRequires(write >= 0) { "write failed with result ${HasPosixErr.reportErr(write.toInt())}" }
-//        return write.toULong()
-//      ---  produces
-//        	at <global>.ThrowNullPointerException(Unknown Source)
-//	at simple.PosixFile#write64(Unknown Source)
-//	at borg.trikeshed.native.HasDescriptor#write(Unknown Source)
-
-        //rewrite with very verbose debug{} blocks and logdebug{ progress}
         val addressOf = buf.pin().addressOf(0)
         val b: CArrayPointer<ByteVar> = addressOf.reinterpret()
         val write = write(fd, b, buf.size.toULong())


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code and obsolete comment in `PosixFile.kt` that was causing a NullPointerException.
💡 **Why:** Improves code readability and maintainability by removing clutter.
✅ **Verification:** Verified the build using multiplatform compilation and testing tasks. The change is completely safe and has zero side effects since it only removes comments.
✨ **Result:** A cleaner, more maintainable `PosixFile.kt`.

---
*PR created automatically by Jules for task [223611296494295793](https://jules.google.com/task/223611296494295793) started by @jnorthrup*