### PR TITLE
🧹 Throw UnsupportedOperationException in ViewServer stub

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
@@ -350,8 +350,7 @@ class ViewServer {
     /** Execute a custom Confix DSL reducer (stub — future expansion). */
     private fun executeCustomReduce(dsl: String, input: ViewResult): ViewResult {
         // TODO: Parse and execute Confix DSL reducer expression
-        // For now, return input unchanged
-        return input
+        throw UnsupportedOperationException("Confix DSL reducer expression parsing not yet implemented")
     }
 }
 

--- a/src/jvmTest/kotlin/borg/trikeshed/couch/ViewServerTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/couch/ViewServerTest.kt
@@ -1,9 +1,11 @@
 package borg.trikeshed.couch
 
 import borg.trikeshed.parse.confix.confixDoc
+import kotlin.test.assertFailsWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
 
 class ViewServerTest {
 
@@ -263,5 +265,24 @@ class ViewServerTest {
         assertEquals("k1", result[0].key)
         assertEquals("k2", result[1].key)
         assertEquals("k3", result[2].key)
+    }
+
+    @Test
+    fun `custom reduce function throws UnsupportedOperationException`() {
+        val server = ViewServer()
+
+        val viewDef = ViewDefinition(
+            ddoc = "_design/test",
+            viewName = "customReduce",
+            mapFn = MapFunction.Emit(
+                key = KeyExpr.DocId,
+                value = ValueExpr.DocValue
+            ),
+            reduceFn = ReduceFunction.Custom("some dsl here")
+        )
+
+        assertFailsWith<UnsupportedOperationException> {
+            server.execute(viewDef, emptyList())
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Modified `executeCustomReduce` in `src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt` to throw an `UnsupportedOperationException` instead of returning input silently. Also added a corresponding unit test to `src/jvmTest/kotlin/borg/trikeshed/couch/ViewServerTest.kt`.
💡 **Why:** The custom reduce logic for Confix DSL is not yet implemented. Throwing an explicit exception fails fast and communicates this clearly, improving the health and maintainability of the codebase rather than silently ignoring a significant functional gap.
✅ **Verification:** Ensured code syntax is correct. Verified that the test uses standard Kotlin test functionality to test for exceptions. Testing via standard `./gradlew jvmTest` was bypassed because of project-wide build failures with 1049 unrelated syntax errors in gradle. Verified syntax via Kotlinc to ensure no compilation errors were introduced.
✨ **Result:** Stub fails fast cleanly instead of failing silently.

---
*PR created automatically by Jules for task [15084684121725875176](https://jules.google.com/task/15084684121725875176) started by @jnorthrup*