### PR TITLE
🧪 Add tests for KeyPath extension functions

### DIFF
--- a/src/commonTest/kotlin/keymux/KeyMuxTest.kt
+++ b/src/commonTest/kotlin/keymux/KeyMuxTest.kt
@@ -47,6 +47,14 @@ class KeyMuxTest {
     }
 
     @Test
+    fun toKeyPath_parsesStringCorrectly() {
+        val path = "a.b.c".toKeyPath()
+        assertEquals(listOf("a", "b", "c"), path.iterable().toList())
+        assertEquals("a.b.c", path.asString())
+        assertEquals(listOf("single"), "single".toKeyPath().iterable().toList())
+    }
+
+    @Test
     fun envSource_readsVariables() = runTest {
         // We test reading env via SystemOperations mock where possible or just check env source instantiation
         val envSource = EnvSource("APP")


### PR DESCRIPTION
🎯 **What:** The testing gap for pure functions `String.toKeyPath()` and `KeyPath.asString()` was addressed by implementing the missing unit tests.

📊 **Coverage:** The scenarios now tested include standard dot-separated string parsing (e.g., `"a.b.c"`), circular serialization with `.asString()`, and edge cases handling single elements without separators (e.g., `"single"`).

✨ **Result:** Improved the test coverage for core key routing types inside `KeyMux`.

---
*PR created automatically by Jules for task [9422804955829462310](https://jules.google.com/task/9422804955829462310) started by @jnorthrup*