### PR TITLE
🔒 Security: Mitigate RCE via GraalVM Context in View Server

### DIFF
--- a/libs/couch/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServer.kt
+++ b/libs/couch/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServer.kt
@@ -7,6 +7,7 @@ import borg.trikeshed.lib.j
 import borg.trikeshed.parse.confix.ConfixDoc
 import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.HostAccess
 
 /**
  * A CouchDB 1.6/1.7 compatible View Server running in-process via GraalVM Polyglot Javascript.
@@ -19,6 +20,10 @@ class GraalVmViewServer(
 ) : AutoCloseable {
 
     private val context: Context = Context.newBuilder("js")
+        .allowHostAccess(HostAccess.NONE)
+        .allowIO(false)
+        .allowNativeAccess(false)
+        .allowCreateThread(false)
         .build()
 
     /**


### PR DESCRIPTION
🎯 **What:** The `GraalVmViewServer` initialized a GraalVM `Context` without restricting access permissions, allowing arbitrary JavaScript execution to access host environment resources (e.g. file system, native access), leading to a Remote Code Execution (RCE) vulnerability.

⚠️ **Risk:** Attackers could inject malicious JS in Map/Reduce definitions to execute host commands, leading to complete server compromise.

🛡️ **Solution:** Configured the GraalVM Context builder to strictly limit permissions by setting `allowHostAccess(HostAccess.NONE)`, `allowIO(false)`, `allowNativeAccess(false)`, and `allowCreateThread(false)`.

---
*PR created automatically by Jules for task [2659966517826307561](https://jules.google.com/task/2659966517826307561) started by @jnorthrup*