### PR TITLE
🧹 Remove unused posix.syscall import in KioUring

### DIFF
--- a/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
+++ b/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
@@ -33,7 +33,6 @@ import platform.posix.ioctl as posix_ioctl
 import platform.posix.mmap as posix_mmap
 import platform.posix.off_t as posix_off_t
 
-import platform.posix.syscall as posix_syscall
 import zlinux_uring.*
 
 /**


### PR DESCRIPTION
🎯 **What:** Removed unused import `platform.posix.syscall` from `src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt`.
💡 **Why:** Reduces noise and improves maintainability by eliminating an unused import.
✅ **Verification:** Verified that it was an unused import via `cat` and `grep` and the code is clean. The compilation errors are pre-existing issues related to build setup and not this code change.
✨ **Result:** Cleaner code.

Additionally, exact red/green commands are not strictly applicable here as this is a dead code removal and not a test-driven behavior change.
Package switch state: No package switches modified.
Performance/materialization impact: None/neutral.
PRELOAD impact: None.
Proof that no `libs` path changed: Only `src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt` was modified.

---
*PR created automatically by Jules for task [6597882903188243883](https://jules.google.com/task/6597882903188243883) started by @jnorthrup*