### PR TITLE
🧪 Improve test coverage for KeyPath extensions

### DIFF
--- a/src/commonTest/kotlin/keymux/KeyMuxTest.kt
+++ b/src/commonTest/kotlin/keymux/KeyMuxTest.kt
@@ -52,6 +52,23 @@ class KeyMuxTest {
         assertEquals(listOf("a", "b", "c"), path.iterable().toList())
         assertEquals("a.b.c", path.asString())
         assertEquals(listOf("single"), "single".toKeyPath().iterable().toList())
+
+        // Edge cases
+        val emptyPath = "".toKeyPath()
+        assertEquals(listOf(""), emptyPath.iterable().toList())
+        assertEquals("", emptyPath.asString())
+
+        val trailingPath = "a.b.".toKeyPath()
+        assertEquals(listOf("a", "b", ""), trailingPath.iterable().toList())
+        assertEquals("a.b.", trailingPath.asString())
+
+        val leadingPath = ".a.b".toKeyPath()
+        assertEquals(listOf("", "a", "b"), leadingPath.iterable().toList())
+        assertEquals(".a.b", leadingPath.asString())
+
+        val consecutivePath = "a..b".toKeyPath()
+        assertEquals(listOf("a", "", "b"), consecutivePath.iterable().toList())
+        assertEquals("a..b", consecutivePath.asString())
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Added tests for `toKeyPath` and `asString` extension functions to ensure correct behavior.
📊 **Coverage:** The test suite now explicitly covers string parsing into paths and serialization back to strings. Edge cases including empty strings, consecutive dots, and leading/trailing dots are thoroughly validated.
✨ **Result:** Better resilience when dealing with potentially malformed configuration or path keys, preventing incorrect lookup regressions.

---
*PR created automatically by Jules for task [15154615939233894530](https://jules.google.com/task/15154615939233894530) started by @jnorthrup*