### PR TITLE
🔒 Fix Javascript Code Injection in GraalVmViewServer

### DIFF
--- a/libs/couch/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServer.kt
+++ b/libs/couch/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServer.kt
@@ -19,6 +19,8 @@ class GraalVmViewServer(
 ) : AutoCloseable {
 
     private val context: Context = Context.newBuilder("js")
+        .allowHostAccess(org.graalvm.polyglot.HostAccess.NONE)
+        .resourceLimits(org.graalvm.polyglot.ResourceLimits.newBuilder().statementLimit(10000, null).build())
         .build()
 
     /**

--- a/libs/couch/src/jvmTest/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServerTest.kt
+++ b/libs/couch/src/jvmTest/kotlin/borg/trikeshed/couch/viewserver/GraalVmViewServerTest.kt
@@ -1,0 +1,40 @@
+package borg.trikeshed.couch.viewserver
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import borg.trikeshed.couch.ViewStore
+import borg.trikeshed.couch.ConfixDocStoreEntry
+import borg.trikeshed.parse.confix.ConfixDoc
+import borg.trikeshed.cursor.Series
+
+class GraalVmViewServerTest {
+    @Test
+    fun testViewServer() {
+        val dummyStore = object : ViewStore {
+            override fun define(
+                name: String,
+                map: (ConfixDocStoreEntry, (String, String) -> Unit) -> Unit,
+                reduce: ((String, Series<String>) -> Int)?
+            ) {
+                // Not doing much
+                println("defined $name")
+                val mockDoc = object : ConfixDocStoreEntry {
+                    override val doc: ConfixDoc = object : ConfixDoc {
+                        override fun toString(): String {
+                            return "{\"hello\":\"world\"}"
+                        }
+                    }
+                }
+                var emittedKey: String? = null
+                var emittedVal: String? = null
+                map(mockDoc) { k, v ->
+                    emittedKey = k
+                    emittedVal = v
+                }
+                assertEquals("world", emittedVal)
+            }
+        }
+        val server = GraalVmViewServer(dummyStore)
+        server.defineView("test", "function(doc) { emit('mykey', doc.hello); }")
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `GraalVmViewServer` previously allowed unrestricted access to the host environment (Java classes, methods, etc.) and had no limits on execution time when evaluating JavaScript maps and reduces.
⚠️ **Risk:** An attacker could submit malicious JavaScript code to the view server that escapes the Javascript sandbox to execute arbitrary Java code (Remote Code Execution), exfiltrate data, or cause a Denial of Service (DoS) through infinite loops.
🛡️ **Solution:** Configured the GraalVM Context with `HostAccess.NONE` to enforce strict sandboxing, preventing any interaction between the evaluated JavaScript and the Java host environment. Additionally, applied a `statementLimit` of 10000 via `ResourceLimits` to prevent DoS attacks through computationally expensive scripts. I have also added a basic unit test to ensure normal evaluation continues to operate properly within the boundaries of the new sandbox.

---
*PR created automatically by Jules for task [15262828789728995361](https://jules.google.com/task/15262828789728995361) started by @jnorthrup*