### PR TITLE
Fix: Randomize event triggering order in multicqes_drain test

### DIFF
--- a/multicqes_drain_randomize.patch
+++ b/multicqes_drain_randomize.patch
@@ -1,0 +1,30 @@
+diff --git a/test/multicqes_drain.c b/test/multicqes_drain.c
+index 4ed8345..b502b94 100644
+--- a/test/multicqes_drain.c
++++ b/test/multicqes_drain.c
+@@ -233,12 +233,22 @@ static int test_generic_drain(struct io_uring *ring)
+	}
+
+	sleep(1);
+-	// TODO: randomize event triggering order
++	int trigger_order[max_entry];
++	for (i = 0; i < max_entry; i++)
++		trigger_order[i] = i;
+	for (i = 0; i < max_entry; i++) {
+-		if (si[i].op != multi && si[i].op != single)
++		int j = i + rand() % (max_entry - i);
++		int tmp = trigger_order[i];
++		trigger_order[i] = trigger_order[j];
++		trigger_order[j] = tmp;
++	}
++
++	for (i = 0; i < max_entry; i++) {
++		int idx = trigger_order[i];
++		if (si[idx].op != multi && si[idx].op != single)
+			continue;
+
+-		if (trigger_event(ring, pipes[i]))
++		if (trigger_event(ring, pipes[idx]))
+			goto err;
+	}
+	sleep(1);


### PR DESCRIPTION
Randomize the event triggering order in multicqes_drain test for liburing.

---
*PR created automatically by Jules for task [16235970178691726211](https://jules.google.com/task/16235970178691726211) started by @jnorthrup*