### PR TITLE
refactor(job): Implement durable-before-visible pipeline for JobSupervisorElement

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/job/CasStore.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/CasStore.kt
@@ -4,7 +4,7 @@ package borg.trikeshed.job
  * CasStore — content-addressable store.
  * In-memory implementation: SHA-256 keyed blob map with digest verification on read.
  */
-open class CasStore private constructor(
+open class CasStore protected constructor(
     private val blobs: MutableMap<ContentId, ByteArray> = mutableMapOf(),
 ) {
     open fun put(bytes: ByteArray): ContentId {

--- a/src/commonMain/kotlin/borg/trikeshed/job/JobLog.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/JobLog.kt
@@ -7,7 +7,7 @@ package borg.trikeshed.job
  * Each frame: [sequence(Long)][payloadLen(Int)][payload(bytes)].
  * A "torn frame" has a payload length that exceeds available bytes → replay stops.
  */
-open class JobLog private constructor(
+open class JobLog protected constructor(
     private val frames: MutableList<Frame> = mutableListOf(),
 ) {
 
@@ -44,6 +44,11 @@ open class JobLog private constructor(
     open fun injectTornFrame(sequence: Long, payload: ByteArray) {
         frames.add(Frame(sequence, ByteArray(0)))
     }
+
+    /**
+     * Explicit durability barrier.
+     */
+    open fun flush() {}
 
     fun toMap(): MutableMap<String, ByteArray> {
         val map = mutableMapOf<String, ByteArray>()

--- a/src/commonMain/kotlin/borg/trikeshed/job/JobSupervisorElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/JobSupervisorElement.kt
@@ -25,7 +25,8 @@ import kotlin.coroutines.CoroutineContext
 class JobSupervisorElement private constructor(
     private val parentScope: kotlinx.coroutines.CoroutineScope,
     private val capacity: Int,
-    private val walData: MutableMap<String, ByteArray>?,
+    private val casStore: CasStore,
+    private val jobLog: JobLog,
     private val instrumentationRef: Instrumentation,
 ) : kotlinx.coroutines.CoroutineScope {
 
@@ -77,14 +78,11 @@ class JobSupervisorElement private constructor(
     init {
         _lifecycleState = ElementState.OPEN
         // Replay from WAL if available
-        if (walData != null && walData.isNotEmpty()) {
-            val log = JobLog.fromMap(walData)
-            log.replay().forEach { frame ->
-                val result = reducer.reduce(CanonicalCbor.decodeJobCommand(frame.payload))
-                committedSequence = frame.sequence
-                if (result.accepted) {
-                    result.snapshot?.let { snapshots[it.jobId] = it }
-                }
+        jobLog.replay().forEach { frame ->
+            val result = reducer.reduce(CanonicalCbor.decodeJobCommand(frame.payload))
+            committedSequence = frame.sequence
+            if (result.accepted) {
+                result.snapshot?.let { snapshots[it.jobId] = it }
             }
         }
         _lifecycleState = ElementState.ACTIVE
@@ -106,20 +104,37 @@ class JobSupervisorElement private constructor(
         val canonicalBytes = CanonicalCbor.encode(cmd)
 
         // Step 3: CAS write
-        val cid = ContentId.of(canonicalBytes)
+        val cid: ContentId
         instrumentationRef.casWriteAttempts++
-        if (_injectCasFailure) return
+        try {
+            cid = casStore.put(canonicalBytes)
+            // read-back digest verification
+            val verify = casStore.get(cid)
+            if (verify == null || !verify.contentEquals(canonicalBytes)) {
+                return
+            }
+        } catch (e: Exception) {
+            return
+        }
         instrumentationRef.casWriteCount++
         instrumentationRef.casWriteSequence = ++instrumentationRef.globalSequence
 
         // Step 4: WAL append
         instrumentationRef.walAppendAttempts++
-        if (_injectWalFailure) return
-        walData?.let { it["${committedSequence + 1}"] = canonicalBytes }
+        try {
+            jobLog.append(committedSequence + 1, canonicalBytes)
+        } catch (e: Exception) {
+            return
+        }
         instrumentationRef.walAppendCount++
         instrumentationRef.walAppendSequence = ++instrumentationRef.globalSequence
 
         // Step 5: durability barrier
+        try {
+            jobLog.flush()
+        } catch (e: Exception) {
+            return
+        }
         instrumentationRef.durabilityBarrierCount++
         instrumentationRef.durabilityBarrierSequence = ++instrumentationRef.globalSequence
 
@@ -239,12 +254,7 @@ class JobSupervisorElement private constructor(
     fun facts(jobId: String): List<String> = factLog[JobId.of(jobId)] ?: emptyList()
 
     fun setWipLimit(limit: Int) { }
-    fun injectCasFailure() { _injectCasFailure = true }
-    fun injectWalFailure() { _injectWalFailure = true }
     fun setInstrumentation(inst: Instrumentation) { }
-
-    private var _injectCasFailure = false
-    private var _injectWalFailure = false
 
     companion object {
         private val RAW_FACET_PLAN = ConfixFacetPlan.fromSchema("confix/job-nexus.schema.json")
@@ -252,11 +262,12 @@ class JobSupervisorElement private constructor(
         fun open(
             scope: kotlinx.coroutines.CoroutineScope,
             capacity: Int = 64,
-            walData: MutableMap<String, ByteArray>? = null,
+            casStore: CasStore = CasStore.inMemory(),
+            jobLog: JobLog = JobLog.inMemory(),
         ): JobSupervisorElement {
             require(capacity > 0) { "command capacity must be positive: $capacity" }
             val inst = Instrumentation()
-            return JobSupervisorElement(scope, capacity, walData, inst)
+            return JobSupervisorElement(scope, capacity, casStore, jobLog, inst)
         }
     }
 }

--- a/src/commonTest/kotlin/borg/trikeshed/job/JobSupervisorDrainTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/job/JobSupervisorDrainTest.kt
@@ -27,8 +27,12 @@ class JobSupervisorDrainTest {
 
     @Test
     fun casFailureStopsBeforeWalReducerAndVisibility() = runTest {
-        val nexus = JobSupervisorElement.open(this, capacity = 1)
-        nexus.injectCasFailure()
+        val brokenCas = object : CasStore() {
+            override fun put(bytes: ByteArray): ContentId {
+                throw RuntimeException("injected CAS failure")
+            }
+        }
+        val nexus = JobSupervisorElement.open(this, capacity = 1, casStore = brokenCas)
 
         nexus.submit(JobCommand.Submit(JobId.of("j-cas-fail"), "k-cas-fail"))
         nexus.drain()
@@ -39,6 +43,23 @@ class JobSupervisorDrainTest {
         assertEquals(0, nexus.instrumentation.reducerApplyCount)
         assertEquals(0L, nexus.committedSequence)
         assertEquals(null, nexus.snapshot("j-cas-fail"))
+    }
+
+    @Test
+    fun casDigestReadbackFailureStopsPipeline() = runTest {
+        val lyingCas = object : CasStore() {
+            override fun put(bytes: ByteArray): ContentId = ContentId.of(bytes)
+            override fun get(cid: ContentId): ByteArray = "wrong bytes".encodeToByteArray()
+        }
+        val nexus = JobSupervisorElement.open(this, capacity = 1, casStore = lyingCas)
+
+        nexus.submit(JobCommand.Submit(JobId.of("j-cas-readback"), "k-readback"))
+        nexus.drain()
+
+        assertEquals(1, nexus.instrumentation.casWriteAttempts)
+        assertEquals(0, nexus.instrumentation.casWriteCount)
+        assertEquals(0, nexus.instrumentation.walAppendAttempts)
+        assertEquals(0L, nexus.committedSequence)
     }
 
     @Test
@@ -127,7 +148,7 @@ class JobSupervisorDrainTest {
             ),
         )
 
-        val nexus = JobSupervisorElement.open(this, capacity = 1, walData = wal)
+        val nexus = JobSupervisorElement.open(this, capacity = 1, jobLog = JobLog.fromMap(wal))
 
         assertEquals(9L, nexus.committedSequence)
         assertEquals(1L, nexus.snapshot("j-replay")?.revision)
@@ -136,8 +157,12 @@ class JobSupervisorDrainTest {
 
     @Test
     fun walFailureStopsAfterCasBeforeReducerAndVisibility() = runTest {
-        val nexus = JobSupervisorElement.open(this, capacity = 1)
-        nexus.injectWalFailure()
+        val brokenWal = object : JobLog() {
+            override fun append(sequence: Long, payload: ByteArray) {
+                throw RuntimeException("injected WAL append failure")
+            }
+        }
+        val nexus = JobSupervisorElement.open(this, capacity = 1, jobLog = brokenWal)
 
         nexus.submit(JobCommand.Submit(JobId.of("j-wal-fail"), "k-wal-fail"))
         nexus.drain()
@@ -148,6 +173,25 @@ class JobSupervisorDrainTest {
         assertEquals(0, nexus.instrumentation.reducerApplyCount, "reducer must not run after WAL failure")
         assertEquals(0L, nexus.committedSequence, "committedSequence must not advance after WAL failure")
         assertEquals(null, nexus.snapshot("j-wal-fail"), "snapshot must not be visible after WAL failure")
+    }
+
+    @Test
+    fun barrierFailureStopsPipeline() = runTest {
+        val brokenBarrier = object : JobLog() {
+            override fun flush() {
+                throw RuntimeException("injected barrier failure")
+            }
+        }
+        val nexus = JobSupervisorElement.open(this, capacity = 1, jobLog = brokenBarrier)
+
+        nexus.submit(JobCommand.Submit(JobId.of("j-barrier-fail"), "k-barrier-fail"))
+        nexus.drain()
+
+        assertEquals(1, nexus.instrumentation.walAppendCount)
+        assertEquals(0, nexus.instrumentation.durabilityBarrierCount)
+        assertEquals(0, nexus.instrumentation.reducerApplyCount)
+        assertEquals(0L, nexus.committedSequence)
+        assertEquals(null, nexus.snapshot("j-barrier-fail"))
     }
 
     @Test


### PR DESCRIPTION
This PR implements the exact strict durability pipeline for `JobSupervisorElement`. 

Specifically, it ensures:
1. `CasStore` is used for content-addressable storage of the canonical command.
2. A read-back validation over the CAS verifies the digest.
3. The command is explicitly appended to the `JobLog` and then explicitly flushed via a durability barrier (`flush()`).
4. If *any* step fails (an exception is thrown), the transaction gracefully aborts without corrupting local indexes or publishing events, and the single-writer reactor simply advances to the next command.
5. Injected failure states (via mutable flags) are replaced by injecting robust component test doubles (anonymous subclasses throwing exceptions) in `JobSupervisorDrainTest.kt`.

---
*PR created automatically by Jules for task [3963603298306534866](https://jules.google.com/task/3963603298306534866) started by @jnorthrup*