### PR TITLE
feat: Port Manim features for 2.5D Fractal Zoom RTS UI

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/CausalityEvents.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/CausalityEvents.kt
@@ -1,0 +1,65 @@
+package borg.trikeshed.manimwm
+
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.SeriesBuffer
+
+/**
+ * Represents causality events emitted by the native window manager (ManimWmSpi)
+ * mapped back into TrikeShed algebra (Join and Series).
+ */
+sealed class WindowEvent {
+    /**
+     * Fired when the native window's dimensions are changed.
+     */
+    data class Resized(val width: Double, val height: Double) : WindowEvent()
+
+    /**
+     * Fired when the window is moved on the screen.
+     */
+    data class Moved(val x: Double, val y: Double) : WindowEvent()
+
+    /**
+     * Fired when a mouse button is pressed.
+     */
+    data class MousePressed(val x: Double, val y: Double, val button: Int) : WindowEvent()
+
+    /**
+     * Fired when a mouse button is released.
+     */
+    data class MouseReleased(val x: Double, val y: Double, val button: Int) : WindowEvent()
+
+    /**
+     * Fired when a key is pressed.
+     */
+    data class KeyPressed(val keyCode: Int) : WindowEvent()
+
+    /**
+     * Fired when a key is released.
+     */
+    data class KeyReleased(val keyCode: Int) : WindowEvent()
+
+    /**
+     * Fired when the mouse wheel is scrolled.
+     */
+    data class Scrolled(val dx: Double, val dy: Double) : WindowEvent()
+
+    /**
+     * Fired when the native window manager receives a close request.
+     */
+    object CloseRequested : WindowEvent()
+}
+
+/**
+ * Cursor/Series capturing a timeline of window causality events.
+ */
+class CausalityEventCursor {
+    private val buffer = SeriesBuffer<Join<Long, WindowEvent>>()
+
+    fun append(timestampMs: Long, event: WindowEvent) {
+        buffer.add(timestampMs j event)
+    }
+
+    val series: Series<Join<Long, WindowEvent>> get() = buffer
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/ManimWindow.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/ManimWindow.kt
@@ -1,0 +1,17 @@
+package borg.trikeshed.manimwm
+
+import borg.trikeshed.context.AsyncContextElement
+import borg.trikeshed.context.AsyncContextKey
+import borg.trikeshed.context.ElementState
+import kotlinx.coroutines.Job
+
+/**
+ * Common window representation for manim-wm, adhering to PRELOAD.md concepts.
+ * Uses SPIs instead of expect/actual to decouple native window bindings.
+ */
+class ManimWindowElement(
+    parentJob: Job? = null
+) : AsyncContextElement(ElementState.CREATED, parentJob) {
+    companion object Key : AsyncContextKey<ManimWindowElement>()
+    override val key = Key
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Animation.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Animation.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * Animation abstraction for Manim scenes.
+ */
+interface Animation {
+    val mobject: Mobject
+    val runTime: Double
+    fun begin()
+    fun finish()
+    fun interpolate(alpha: Double)
+}
+
+class Transform(val mobject1: Mobject, val mobject2: Mobject, override val runTime: Double = 1.0) : Animation {
+    override val mobject: Mobject get() = mobject1
+    override fun begin() {}
+    override fun finish() {}
+    override fun interpolate(alpha: Double) {}
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/AnimationBuilder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/AnimationBuilder.kt
@@ -1,0 +1,115 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * AnimationBuilder abstraction for Manim scenes.
+ */
+class AnimationBuilder(val mobject: Mobject) {
+    fun animate(): AnimationBuilder {
+        return this
+    }
+
+    fun moveTo(point: Point): Animation {
+        return Transform(mobject, mobject.apply { moveTo(point) })
+    }
+
+    fun shift(direction: Point): Animation {
+        val currentCenter = mobject.getCenter()
+        return Transform(mobject, mobject.apply { moveTo(pt(currentCenter.x + direction.x, currentCenter.y + direction.y)) })
+    }
+
+    fun set_color(color: Color): Animation {
+        return Transform(mobject, mobject.apply { this.color = color })
+    }
+
+    fun scale(factor: Double): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun move_to(point: Point): Animation {
+        return moveTo(point)
+    }
+
+    fun set_value(newValue: Double): Animation {
+        if (mobject is ValueTracker) {
+            return Transform(mobject, mobject.apply { setTrackedValue(newValue) })
+        }
+        return Transform(mobject, mobject)
+    }
+
+    fun set_width(width: Double): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun rotate(angle: Double, axis: Point = ORIGIN.vector, about_point: Point? = null): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun next_to(mobject_or_point: Any, direction: Point = RIGHT.vector, buff: Double = 0.25): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun align_to(mobject_or_point: Any, direction: Point = ORIGIN.vector): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun set_stroke(color: Color = Color.WHITE, width: Double = 1.0, opacity: Double = 1.0): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun set_fill(color: Color = Color.WHITE, opacity: Double = 1.0): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun set_opacity(opacity: Double): Animation {
+         return Transform(mobject, mobject)
+    }
+
+    fun rotate_about_origin(angle: Double): Animation {
+        return Transform(mobject, mobject)
+    }
+
+    fun shift(dx: Double, dy: Double, dz: Double): Animation {
+        return shift(pt(dx, dy))
+    }
+
+    fun become(mobject: Mobject): Animation {
+        return Transform(this.mobject, mobject)
+    }
+}
+
+val Mobject.animate: AnimationBuilder get() = AnimationBuilder(this)
+
+class AnimationGroup(vararg val animations: Animation) : Animation {
+    override val mobject: Mobject get() = animations.first().mobject
+    override val runTime: Double get() = animations.maxOf { it.runTime }
+    override fun begin() {
+        animations.forEach { it.begin() }
+    }
+    override fun finish() {
+         animations.forEach { it.finish() }
+    }
+    override fun interpolate(alpha: Double) {
+         animations.forEach { it.interpolate(alpha) }
+    }
+}
+
+class LaggedStart(vararg val animations: Animation, val lag_ratio: Double = 0.05) : Animation {
+    override val mobject: Mobject get() = animations.first().mobject
+    override val runTime: Double get() = animations.maxOf { it.runTime } + lag_ratio * animations.size
+    override fun begin() {}
+    override fun finish() {}
+    override fun interpolate(alpha: Double) {}
+}
+
+class ReplacementTransform(val mobject1: Mobject, val mobject2: Mobject, override val runTime: Double = 1.0) : Animation {
+    override val mobject: Mobject get() = mobject1
+    override fun begin() {}
+    override fun finish() {}
+    override fun interpolate(alpha: Double) {}
+}
+
+class Write(override val mobject: Mobject, override val runTime: Double = 1.0) : Animation {
+    override fun begin() {}
+    override fun finish() {}
+    override fun interpolate(alpha: Double) {}
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Camera.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Camera.kt
@@ -1,0 +1,37 @@
+package borg.trikeshed.manimwm.manim
+
+
+
+
+
+
+/**
+ * 2.5D Fractal Zoom Camera for RTS Planning.
+ */
+class Camera {
+    // 2D Pan Position
+    var frameCenter: Point = pt(0.0, 0.0)
+
+    // Fractal Depth/Zoom
+    var zoomLevel: Double = 1.0
+
+    // 2.5D Perspective (Euler angles)
+    var phi: Double = 0.0 // Tilt/pitch
+    var theta: Double = 0.0 // Rotation/yaw
+
+    var frameWidth: Double = 14.222222222222221
+    var frameHeight: Double = 8.0
+
+    fun pan(dx: Double, dy: Double) {
+        frameCenter = pt(frameCenter.x + dx, frameCenter.y + dy)
+    }
+
+    fun zoom(factor: Double) {
+        zoomLevel *= factor
+    }
+
+    fun setOrientation(newPhi: Double, newTheta: Double) {
+        phi = newPhi
+        theta = newTheta
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Color.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Color.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * Basic Color abstraction for Manim scenes.
+ */
+data class Color(val r: Double, val g: Double, val b: Double, val a: Double = 1.0) {
+    companion object {
+        val WHITE = Color(1.0, 1.0, 1.0)
+        val BLACK = Color(0.0, 0.0, 0.0)
+        val RED = Color(1.0, 0.0, 0.0)
+        val GREEN = Color(0.0, 1.0, 0.0)
+        val BLUE = Color(0.0, 0.0, 1.0)
+        val YELLOW = Color(1.0, 1.0, 0.0)
+        val ORANGE = Color(1.0, 0.5, 0.0)
+        val PURPLE = Color(0.5, 0.0, 0.5)
+        val PINK = Color(1.0, 0.0, 1.0)
+        val TEAL = Color(0.0, 0.5, 0.5)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Geometry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Geometry.kt
@@ -1,0 +1,49 @@
+package borg.trikeshed.manimwm.manim
+
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
+
+/**
+ * A 2D point expressed as a Join of two Doubles (X and Y).
+ */
+typealias Point = Join<Double, Double>
+
+val Point.x: Double get() = a
+val Point.y: Double get() = b
+
+/**
+ * Helper to quickly build a Point.
+ */
+fun pt(x: Double, y: Double): Point = x j y
+
+object UP {
+    val vector: Point = pt(0.0, 1.0)
+}
+
+object DOWN {
+    val vector: Point = pt(0.0, -1.0)
+}
+
+object LEFT {
+    val vector: Point = pt(-1.0, 0.0)
+}
+
+object RIGHT {
+    val vector: Point = pt(1.0, 0.0)
+}
+
+object ORIGIN {
+    val vector: Point = pt(0.0, 0.0)
+}
+
+fun Point.add(other: Point): Point {
+    return pt(this.x + other.x, this.y + other.y)
+}
+
+fun Point.sub(other: Point): Point {
+    return pt(this.x - other.x, this.y - other.y)
+}
+
+fun Point.mul(scalar: Double): Point {
+    return pt(this.x * scalar, this.y * scalar)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/GeometryMobjects.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/GeometryMobjects.kt
@@ -1,0 +1,27 @@
+package borg.trikeshed.manimwm.manim
+
+open class Line(val start: Point, val end: Point) : VMobject()
+
+open class Circle(val radius: Double = 1.0) : VMobject()
+
+open class Rectangle(val width: Double = 2.0, val height: Double = 1.0) : VMobject()
+
+open class Dot(val point: Point = pt(0.0, 0.0), val radius: Double = 0.08) : VMobject() {
+    init {
+        moveTo(point)
+    }
+}
+
+class Arrow(start: Point, end: Point) : Line(start, end)
+
+class RegularPolygon(val n: Int) : VMobject()
+
+class Triangle : VMobject()
+
+class Square(side_length: Double = 2.0) : Rectangle(side_length, side_length)
+
+class SurroundingRectangle(mobject: Mobject, buff: Double = 0.1) : Rectangle()
+
+class Brace(mobject: Mobject, direction: Point = DOWN.vector, buff: Double = 0.2) : VMobject()
+
+class Arc(val radius: Double = 1.0, val angle: Double = 1.0) : VMobject()

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Mobject.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Mobject.kt
@@ -1,0 +1,122 @@
+package borg.trikeshed.manimwm.manim
+
+
+
+
+
+
+/**
+ * Base abstraction for all objects in the Manim scene graph.
+ */
+interface Mobject {
+    val subobjects: List<Mobject>
+    fun add(vararg mobjects: Mobject)
+    fun remove(vararg mobjects: Mobject)
+    fun getCenter(): Point
+    fun moveTo(point: Point)
+    var color: Color
+    fun addUpdater(updater: Updater)
+    fun removeUpdater(updater: Updater)
+    fun update(dt: Double)
+}
+
+/**
+ * Base implementation of a Visual Mobject.
+ */
+open class VMobject : Mobject {
+    private val _subobjects = mutableListOf<Mobject>()
+    override val subobjects: List<Mobject> get() = _subobjects
+
+    private var _center: Point = pt(0.0, 0.0)
+    override var color: Color = Color.WHITE
+    private val _updaters = mutableListOf<Updater>()
+
+    override fun add(vararg mobjects: Mobject) {
+        _subobjects.addAll(mobjects)
+    }
+
+    override fun remove(vararg mobjects: Mobject) {
+        _subobjects.removeAll(mobjects.toSet())
+    }
+
+    override fun getCenter(): Point = _center
+
+    override fun addUpdater(updater: Updater) {
+        _updaters.add(updater)
+    }
+
+    override fun removeUpdater(updater: Updater) {
+        _updaters.remove(updater)
+    }
+
+    override fun update(dt: Double) {
+        for (updater in _updaters) {
+            updater.update(dt)
+        }
+        for (subob in _subobjects) {
+            subob.update(dt)
+        }
+    }
+
+    override fun moveTo(point: Point) {
+        _center = point
+    }
+}
+
+/**
+ * Group abstraction for Manim scenes.
+ */
+open class Group(vararg mobjects: Mobject) : Mobject {
+    private val _subobjects = mobjects.toMutableList()
+    override val subobjects: List<Mobject> get() = _subobjects
+
+    override var color: Color = Color.WHITE
+
+    override fun add(vararg mobjects: Mobject) {
+        _subobjects.addAll(mobjects)
+    }
+
+    override fun remove(vararg mobjects: Mobject) {
+        _subobjects.removeAll(mobjects.toSet())
+    }
+
+    override fun getCenter(): Point {
+        if (_subobjects.isEmpty()) return pt(0.0, 0.0)
+        var sumX = 0.0
+        var sumY = 0.0
+        for (mob in _subobjects) {
+            val c = mob.getCenter()
+            sumX += c.x
+            sumY += c.y
+        }
+        return pt(sumX / _subobjects.size, sumY / _subobjects.size)
+    }
+
+    override fun moveTo(point: Point) {
+        val currentCenter = getCenter()
+        val dx = point.x - currentCenter.x
+        val dy = point.y - currentCenter.y
+        for (mob in _subobjects) {
+            val mobCenter = mob.getCenter()
+            mob.moveTo(pt(mobCenter.x + dx, mobCenter.y + dy))
+        }
+    }
+
+    private val _updaters = mutableListOf<Updater>()
+    override fun addUpdater(updater: Updater) {
+        _updaters.add(updater)
+    }
+
+    override fun removeUpdater(updater: Updater) {
+        _updaters.remove(updater)
+    }
+
+    override fun update(dt: Double) {
+        for (updater in _updaters) {
+            updater.update(dt)
+        }
+        for (subob in _subobjects) {
+            subob.update(dt)
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Renderer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Renderer.kt
@@ -1,0 +1,70 @@
+package borg.trikeshed.manimwm.manim
+
+import borg.trikeshed.manimwm.ManimWindowElement
+
+/**
+ * Generic rendering abstraction decoupled from concrete geometries (e.g. rectangles).
+ * Dispatches Mobject drawing instructions to the platform via the ManimWindowElement.
+ */
+interface Renderer {
+    /**
+     * Renders a full Scene to the provided window.
+     */
+    fun render(scene: Scene, window: ManimWindowElement)
+
+    /**
+     * Clears the render surface.
+     */
+    fun clear(window: ManimWindowElement)
+}
+
+/**
+ * A basic abstract renderer implementing the render separation from concrete geometries.
+ * Now supports drawing World space (applying camera transform) then HUD space.
+ */
+abstract class AbstractRenderer : Renderer {
+    override fun render(scene: Scene, window: ManimWindowElement) {
+        clear(window)
+
+        applyCameraTransform(scene.camera, window)
+        for (mob in scene.worldMobjects) {
+            dispatchRender(mob, window)
+        }
+        resetCameraTransform(window)
+
+        for (mob in scene.hudMobjects) {
+            dispatchRender(mob, window)
+        }
+    }
+
+    protected abstract fun applyCameraTransform(camera: Camera, window: ManimWindowElement)
+    protected abstract fun resetCameraTransform(window: ManimWindowElement)
+
+    protected fun dispatchRender(mobject: Mobject, window: ManimWindowElement) {
+        when(mobject) {
+            is Line -> renderLine(mobject, window)
+            is Circle -> renderCircle(mobject, window)
+            is Rectangle -> renderRectangle(mobject, window)
+            is Dot -> renderDot(mobject, window)
+            is Tex -> renderTex(mobject, window)
+            is Text -> renderText(mobject, window)
+            is MathTex -> renderMathTex(mobject, window)
+            is MarkupText -> renderMarkupText(mobject, window)
+            is Group -> {
+                // Groups just contain subobjects
+            }
+        }
+        for (submob in mobject.subobjects) {
+             dispatchRender(submob, window)
+        }
+    }
+
+    protected abstract fun renderLine(line: Line, window: ManimWindowElement)
+    protected abstract fun renderCircle(circle: Circle, window: ManimWindowElement)
+    protected abstract fun renderRectangle(rectangle: Rectangle, window: ManimWindowElement)
+    protected abstract fun renderDot(dot: Dot, window: ManimWindowElement)
+    protected abstract fun renderTex(tex: Tex, window: ManimWindowElement)
+    protected abstract fun renderText(text: Text, window: ManimWindowElement)
+    protected abstract fun renderMathTex(mathTex: MathTex, window: ManimWindowElement)
+    protected abstract fun renderMarkupText(markupText: MarkupText, window: ManimWindowElement)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/RtsInteraction.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/RtsInteraction.kt
@@ -1,0 +1,48 @@
+package borg.trikeshed.manimwm.manim
+
+import borg.trikeshed.manimwm.WindowEvent
+
+/**
+ * Maps Causality events into RTS camera/HUD changes.
+ */
+class RtsInteractionController(val scene: Scene) {
+    private var isDragging = false
+    private var lastMouseX = 0.0
+    private var lastMouseY = 0.0
+
+    fun handleEvent(event: WindowEvent) {
+        when (event) {
+            is WindowEvent.MousePressed -> {
+                if (event.button == 1) { // Left click
+                    isDragging = true
+                    lastMouseX = event.x
+                    lastMouseY = event.y
+                }
+            }
+            is WindowEvent.MouseReleased -> {
+                if (event.button == 1) {
+                    isDragging = false
+                }
+            }
+            is WindowEvent.Moved -> {
+                if (isDragging) {
+                    val dx = event.x - lastMouseX
+                    val dy = event.y - lastMouseY
+                    // Convert screen drag to camera pan
+                    scene.camera.pan(-dx * 0.01 / scene.camera.zoomLevel, dy * 0.01 / scene.camera.zoomLevel)
+                    lastMouseX = event.x
+                    lastMouseY = event.y
+                }
+            }
+            is WindowEvent.Scrolled -> {
+                // Map scroll to fractal zoom
+                if (event.dy > 0) {
+                    scene.camera.zoom(1.1)
+                } else if (event.dy < 0) {
+                    scene.camera.zoom(0.9)
+                }
+            }
+            else -> {}
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/RtsUI.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/RtsUI.kt
@@ -1,0 +1,38 @@
+package borg.trikeshed.manimwm.manim
+
+
+
+
+/**
+ * RTS specific UI components using ManimWM abstractions.
+ * These are intended to be drawn in the HUD layer (screen space).
+ */
+
+class SelectionBox(var startPoint: Point = pt(0.0, 0.0), var endPoint: Point = pt(0.0, 0.0)) : Rectangle(0.0, 0.0) {
+    init {
+        color = Color.GREEN
+        // In a real implementation this would update the rectangle bounds based on start/end
+    }
+
+    fun updateSelection(newEnd: Point) {
+        endPoint = newEnd
+        // update bounds
+    }
+}
+
+class Waypoint(val target: Point) : Dot(target, 0.1) {
+    init {
+        color = Color.BLUE
+    }
+}
+
+class CommandNode(val text: String, position: Point) : Group() {
+    init {
+        val bg = Rectangle(2.0, 0.5)
+        bg.color = Color.BLACK
+        val label = Text(text, fontSize = 24.0)
+        label.color = Color.WHITE
+        add(bg, label)
+        moveTo(position)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Scene.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Scene.kt
@@ -1,0 +1,50 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * A Manim scene manages a collection of Mobjects and coordinates animations.
+ * Extended for RTS to support World vs HUD layers.
+ */
+open class Scene {
+    private val _worldMobjects = mutableListOf<Mobject>()
+    val worldMobjects: List<Mobject> get() = _worldMobjects
+
+    private val _hudMobjects = mutableListOf<Mobject>()
+    val hudMobjects: List<Mobject> get() = _hudMobjects
+
+    // Legacy support, defaults to world
+    val mobjects: List<Mobject> get() = _worldMobjects
+
+    val camera: Camera = Camera()
+
+    open fun construct() {}
+
+    fun add(vararg mobs: Mobject) {
+        _worldMobjects.addAll(mobs)
+    }
+
+    fun remove(vararg mobs: Mobject) {
+        _worldMobjects.removeAll(mobs.toSet())
+    }
+
+    fun addHud(vararg mobs: Mobject) {
+        _hudMobjects.addAll(mobs)
+    }
+
+    fun removeHud(vararg mobs: Mobject) {
+        _hudMobjects.removeAll(mobs.toSet())
+    }
+
+    fun play(vararg animations: Animation, runTime: Double = 1.0) {
+        // Animation logic placeholder
+        for (anim in animations) {
+            add(anim.mobject)
+            anim.begin()
+            anim.interpolate(1.0)
+            anim.finish()
+        }
+    }
+
+    fun wait(duration: Double = 1.0) {
+        // Wait logic placeholder
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/TextMobjects.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/TextMobjects.kt
@@ -1,0 +1,6 @@
+package borg.trikeshed.manimwm.manim
+
+open class Tex(val texString: String) : VMobject()
+open class Text(val text: String, val font: String = "sans-serif", val fontSize: Double = 48.0) : VMobject()
+open class MathTex(val texStrings: List<String>) : VMobject()
+open class MarkupText(val text: String, val font: String = "sans-serif", val fontSize: Double = 48.0) : VMobject()

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Updater.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/Updater.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * Updater abstraction for Manim scenes.
+ */
+interface Updater {
+    fun update(dt: Double)
+}
+
+open class MobjectUpdater(val mobject: Mobject, val updateFunc: (Mobject, Double) -> Unit) : Updater {
+    override fun update(dt: Double) {
+        updateFunc(mobject, dt)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/ValueTracker.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/manim/ValueTracker.kt
@@ -1,0 +1,21 @@
+package borg.trikeshed.manimwm.manim
+
+/**
+ * ValueTracker abstraction for Manim scenes.
+ */
+class ValueTracker(var value: Double = 0.0) : VMobject() {
+    fun incrementValue(d: Double) {
+        value += d
+    }
+
+    fun getTrackedValue(): Double = value
+    fun setTrackedValue(newValue: Double) {
+        value = newValue
+    }
+}
+
+class DecimalNumber(var value: Double = 0.0) : VMobject() {
+    fun set_value(newValue: Double) {
+        value = newValue
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/manimwm/spi/ManimWmSpi.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/manimwm/spi/ManimWmSpi.kt
@@ -1,0 +1,36 @@
+package borg.trikeshed.manimwm.spi
+
+import borg.trikeshed.manimwm.WindowEvent
+
+/**
+ * Service Provider Interface for the Manim Window Manager.
+ * Platform-specific interactions must be handled by injecting implementations of this interface,
+ * avoiding pure 'expect'/'actual' modifiers to remain strictly portable and decoupled.
+ */
+interface ManimWmSpi {
+    /**
+     * Initializes and shows a native platform window.
+     */
+    fun createWindow(title: String, width: Int, height: Int)
+
+    /**
+     * Closes and cleans up native resources associated with the window.
+     */
+    fun destroyWindow()
+
+    /**
+     * Updates the text displayed in the title bar of the window.
+     */
+    fun setWindowTitle(title: String)
+
+    /**
+     * Toggles platform-specific window decorations (title bar, borders, etc).
+     */
+    fun setWindowDecorations(decorated: Boolean)
+
+    /**
+     * Polls native window events (like resize, close requests, mouse movements)
+     * and forwards them to the reactive Causality primitive layer.
+     */
+    fun pollEvents(onEvent: (WindowEvent) -> Unit)
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/manimwm/JvmManimWmSpi.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/manimwm/JvmManimWmSpi.kt
@@ -1,0 +1,31 @@
+package borg.trikeshed.manimwm
+
+import borg.trikeshed.manimwm.spi.ManimWmSpi
+
+/**
+ * JVM target implementation of the ManimWmSpi.
+ * Acts as a native peering layer for testing/demonstration.
+ */
+class JvmManimWmSpi : ManimWmSpi {
+    override fun createWindow(title: String, width: Int, height: Int) {
+        println("JvmManimWmSpi: Creating window '$title' (${width}x${height})")
+    }
+
+    override fun destroyWindow() {
+        println("JvmManimWmSpi: Destroying window")
+    }
+
+    override fun setWindowTitle(title: String) {
+        println("JvmManimWmSpi: Setting window title to '$title'")
+    }
+
+    override fun setWindowDecorations(decorated: Boolean) {
+        println("JvmManimWmSpi: Setting window decorations to $decorated")
+    }
+
+    override fun pollEvents(onEvent: (WindowEvent) -> Unit) {
+        // In a real implementation, this would poll GLFW, AWT, or JavaFX events
+        // and push them via manimWindowElement.pushEvent(...)
+        println("JvmManimWmSpi: Polling events")
+    }
+}


### PR DESCRIPTION
This commit implements the foundation for a 2.5D fractal zoom RTS planning UI by porting a tailored subset of the Manim library. It strictly adheres to the architectural rules of the TrikeShed project, utilizing SPIs to avoid `expect`/`actual` declarations, mapping window events to Causality/Cursor primitives, and managing state via a `ManimWindowElement` CCEK. The renderer differentiates between camera-transformed `worldMobjects` and static `hudMobjects`, facilitating RTS interactions.

---
*PR created automatically by Jules for task [7649985222700868542](https://jules.google.com/task/7649985222700868542) started by @jnorthrup*