### PR TITLE
feat(job): hydrate checkpoint state from B+Tree during recovery

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/job/CanonicalCbor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/CanonicalCbor.kt
@@ -147,6 +147,42 @@ object CanonicalCbor {
     /** Canonical encode a JobNexusSpec to its canonical bytes. */
     fun encode(spec: JobNexusSpec): ByteArray = spec.canonicalBytes
 
+    /** Decode the canonical bytes of a JobSnapshot. */
+    fun decodeJobSnapshot(bytes: ByteArray): JobSnapshot {
+        val fields = Cbor.decode(bytes) as? Item.Map
+            ?: error("canonical job snapshot must be a CBOR map")
+        fun string(name: String): String =
+            (fields[name] as? Item.Str)?.value ?: error("missing string field: $name")
+        fun long(name: String): Long =
+            (fields[name] as? Item.Num)?.value ?: error("missing integer field: $name")
+        fun int(name: String): Int = long(name).toInt()
+
+        val jobId = JobId.of(string("jobId"))
+        val revision = long("revision")
+        val causalKey = string("causalKey")
+        val lifecycle = string("lifecycle")
+        val dependencies = (fields["dependencies"] as? Item.Arr)?.let { values ->
+            List(values.size) { index ->
+                JobId.of((values[index] as? Item.Str)?.value
+                    ?: error("dependencies[$index] must be a string"))
+            }
+        } ?: emptyList()
+        val attemptCount = int("attemptCount")
+        val parentJobId = (fields["parentJobId"] as? Item.Str)?.value?.let { JobId.of(it) }
+        val attemptId = (fields["attemptId"] as? Item.Str)?.value ?: ""
+
+        return JobSnapshot(
+            jobId = jobId,
+            revision = revision,
+            causalKey = causalKey,
+            lifecycle = lifecycle,
+            dependencies = dependencies,
+            attemptCount = attemptCount,
+            parentJobId = parentJobId,
+            attemptId = attemptId
+        )
+    }
+
     /** Canonical encode a JobSnapshot for CID computation. */
     fun encode(snapshot: JobSnapshot): ByteArray {
         val fields = mutableMapOf<String, Any?>()

--- a/src/commonMain/kotlin/borg/trikeshed/job/JobRepository.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/JobRepository.kt
@@ -50,14 +50,14 @@ class JobRepository(
     }
 
     suspend fun recover(): RecoveryResult {
-        val snapshots = mutableMapOf<JobId, JobSnapshot>()
+        val tailSnapshots = mutableMapOf<JobId, JobSnapshot>()
         var latestCheckpoint: JobCheckpoint? = null
 
         val lastSequence = log.replay { _, payload ->
             val checkpoint = JobCheckpointCodec.decode(payload)
             if (checkpoint != null) {
                 latestCheckpoint = checkpoint
-                snapshots.clear() // Discard preceding tail records
+                tailSnapshots.clear() // Discard preceding tail records
                 return@replay
             }
             val record = JobRepositoryRecordCodec.decode(payload) ?: return@replay
@@ -67,25 +67,36 @@ class JobRepository(
                 ContentId.of(canonicalSnapshot) == record.snapshotCid &&
                 stored?.contentEquals(canonicalSnapshot) == true
             ) {
-                snapshots[record.snapshot.jobId] = record.snapshot
+                tailSnapshots[record.snapshot.jobId] = record.snapshot
             }
         }
         currentSequence = lastSequence
+
+        val recoveredSnapshots = mutableMapOf<JobId, JobSnapshot>()
 
         if (latestCheckpoint != null) {
             val checkpoint = latestCheckpoint!!
             // Verify schemaCid exists
             casStore.get(checkpoint.schemaCid) ?: throw IllegalStateException("Checkpoint schemaCid ${checkpoint.schemaCid} not found in CAS")
 
-            // Verify full B+Tree
-            fun verifyTree(cid: ContentId) {
+            // Verify full B+Tree and restore snapshots
+            fun verifyAndHydrateTree(cid: ContentId) {
                 val bytes = casStore.get(cid) ?: throw IllegalStateException("Checkpoint B+Tree node $cid not found in CAS")
                 val node = CowBPlusTreeCodec.decode(bytes)
-                if (node is BTreeNode.Internal) {
-                    node.children.forEach { verifyTree(it) }
+                when (node) {
+                    is BTreeNode.Internal -> {
+                        node.children.forEach { verifyAndHydrateTree(it) }
+                    }
+                    is BTreeNode.Leaf -> {
+                        node.values.forEach { value ->
+                            val snapshotBytes = casStore.get(value.cid) ?: throw IllegalStateException("Checkpoint JobSnapshot ${value.cid} not found in CAS")
+                            val snapshot = CanonicalCbor.decodeJobSnapshot(snapshotBytes)
+                            recoveredSnapshots[snapshot.jobId] = snapshot
+                        }
+                    }
                 }
             }
-            verifyTree(checkpoint.rootCid)
+            verifyAndHydrateTree(checkpoint.rootCid)
 
             // Verify metadata
             checkpoint.metadata.values.forEach { cid ->
@@ -93,7 +104,10 @@ class JobRepository(
             }
         }
 
-        return RecoveryResult(lastSequence, latestCheckpoint, snapshots)
+        // Apply tail logs, which take precedence
+        recoveredSnapshots.putAll(tailSnapshots)
+
+        return RecoveryResult(lastSequence, latestCheckpoint, recoveredSnapshots)
     }
 
     fun injectCorruptionAfter(sequence: Long) {

--- a/src/jvmTest/kotlin/borg/trikeshed/job/JobRepositoryRecoveryTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/job/JobRepositoryRecoveryTest.kt
@@ -56,13 +56,21 @@ class JobRepositoryRecoveryTest {
         val casStore = CasStore.inMemory()
         val repo = JobRepository(log, casStore)
 
-        // Write some normal commits
-        repo.commit("j1", createSnapshot("j1", 1), byteArrayOf(1))
-        repo.commit("j2", createSnapshot("j2", 1), byteArrayOf(2))
+        // Pre-checkpoint state
+        val j1Snap = createSnapshot("j1", 1)
+        val j2Snap = createSnapshot("j2", 1)
 
-        // Create a B+Tree
+        // Write normal commits
+        repo.commit("j1", j1Snap, byteArrayOf(1))
+        repo.commit("j2", j2Snap, byteArrayOf(2))
+
+        // Create a B+Tree and properly put CanonicalCbor snapshots in CasStore for the B+Tree values
         val tree = CowBPlusTree(casStore)
-        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"), 1L))
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+        val j2Cid = casStore.put(CanonicalCbor.encode(j2Snap))
+
+        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
+        rootCid = tree.insert(rootCid, BTreeKey("f", byteArrayOf(2), JobId.of("j2"), 1L), BTreeValue(j2Cid, 2L))
 
         // Put schema in CAS
         val schemaCid = casStore.put(byteArrayOf(99))
@@ -72,21 +80,35 @@ class JobRepositoryRecoveryTest {
         repo.checkpoint(cp)
 
         // Write tail commits after checkpoint
+        // j3 is a completely new job in tail
         repo.commit("j3", createSnapshot("j3", 1), byteArrayOf(3))
+        // j1 is updated in tail (it should win over the checkpointed j1)
+        val j1UpdatedSnap = createSnapshot("j1", 2)
+        repo.commit("j1", j1UpdatedSnap, byteArrayOf(4))
 
         // Recover
         val repo2 = JobRepository(log, casStore)
         val result = repo2.recover()
 
-        assertEquals(4L, result.committedSequence)
+        assertEquals(5L, result.committedSequence)
         assertNotNull(result.checkpoint)
         assertEquals(2L, result.checkpoint!!.committedSequence)
         assertEquals(rootCid, result.checkpoint!!.rootCid)
 
-        // Snapshot j1 and j2 should be discarded due to checkpoint, but j3 should be present
-        assertNull(result.snapshot("j1"))
-        assertNull(result.snapshot("j2"))
-        assertNotNull(result.snapshot("j3"))
+        // Verify j1 is present and the tail version won
+        val recoveredJ1 = result.snapshot("j1")
+        assertNotNull(recoveredJ1)
+        assertEquals(2L, recoveredJ1.revision)
+
+        // Verify j2 is present from the checkpoint
+        val recoveredJ2 = result.snapshot("j2")
+        assertNotNull(recoveredJ2)
+        assertEquals(1L, recoveredJ2.revision)
+
+        // Verify j3 is present from the tail
+        val recoveredJ3 = result.snapshot("j3")
+        assertNotNull(recoveredJ3)
+        assertEquals(1L, recoveredJ3.revision)
     }
 
     private fun assertNull(actual: Any?) {
@@ -99,8 +121,11 @@ class JobRepositoryRecoveryTest {
         val casStore = CasStore.inMemory()
         val repo = JobRepository(log, casStore)
 
+        val j1Snap = createSnapshot("j1", 1)
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+
         val tree = CowBPlusTree(casStore)
-        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"), 1L))
+        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
         val schemaCid = casStore.put(byteArrayOf(99))
         val cp = JobCheckpoint(0L, rootCid, schemaCid, emptyMap())
         repo.checkpoint(cp)
@@ -124,8 +149,11 @@ class JobRepositoryRecoveryTest {
         val casStore = CasStore.inMemory()
         val repo = JobRepository(log, casStore)
 
+        val j1Snap = createSnapshot("j1", 1)
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+
         val tree = CowBPlusTree(casStore)
-        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"), 1L))
+        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
         val schemaCid = casStore.put(byteArrayOf(99))
         val cp = JobCheckpoint(0L, rootCid, schemaCid, emptyMap())
         repo.checkpoint(cp)
@@ -144,8 +172,11 @@ class JobRepositoryRecoveryTest {
         val casStore = CasStore.inMemory()
         val repo = JobRepository(log, casStore)
 
+        val j1Snap = createSnapshot("j1", 1)
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+
         val tree = CowBPlusTree(casStore)
-        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"), 1L))
+        var rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
         val schemaCid = casStore.put(byteArrayOf(99))
         val cp = JobCheckpoint(0L, rootCid, schemaCid, emptyMap())
         repo.checkpoint(cp)
@@ -156,5 +187,100 @@ class JobRepositoryRecoveryTest {
 
         assertEquals(result1.committedSequence, result2.committedSequence)
         assertEquals(result1.checkpoint?.rootCid, result2.checkpoint?.rootCid)
+    }
+
+    @Test
+    fun testCorruptValuePageRejection() = runBlocking {
+        val log = MockLog()
+        val casStore = CasStore.inMemory()
+        val repo = JobRepository(log, casStore)
+
+        val j1Snap = createSnapshot("j1", 1)
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+
+        val tree = CowBPlusTree(casStore)
+        val rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
+        val schemaCid = casStore.put(byteArrayOf(99))
+        val cp = JobCheckpoint(0L, rootCid, schemaCid, emptyMap())
+        repo.checkpoint(cp)
+
+        casStore.corrupt(j1Cid) // Corrupt the actual value page, not the tree node
+
+        val repo2 = JobRepository(log, casStore)
+        assertFailsWith<IllegalStateException> {
+            repo2.recover()
+        }
+    }
+
+    @Test
+    fun testEmptyTreeRecovery() = runBlocking {
+        val log = MockLog()
+        val casStore = CasStore.inMemory()
+        val repo = JobRepository(log, casStore)
+
+        val tree = CowBPlusTree(casStore)
+        val emptyRootCid = casStore.put(CowBPlusTreeCodec.encode(BTreeNode.Leaf(emptyList(), emptyList())))
+
+        val schemaCid = casStore.put(byteArrayOf(99))
+        val cp = JobCheckpoint(0L, emptyRootCid, schemaCid, emptyMap())
+        repo.checkpoint(cp)
+
+        val repo2 = JobRepository(log, casStore)
+        val result = repo2.recover()
+
+        assertNotNull(result.checkpoint)
+        assertEquals(emptyRootCid, result.checkpoint!!.rootCid)
+        assertNull(result.snapshot("j1"))
+    }
+
+    @Test
+    fun testRangeTraversalRecovery() = runBlocking {
+        val log = MockLog()
+        val casStore = CasStore.inMemory()
+        val repo = JobRepository(log, casStore)
+
+        val tree = CowBPlusTree(casStore)
+        var rootCid: ContentId? = null
+        for (i in 1..50) {
+            val snap = createSnapshot("j$i", i.toLong())
+            val cid = casStore.put(CanonicalCbor.encode(snap))
+            rootCid = tree.insert(rootCid, BTreeKey("f", byteArrayOf(i.toByte()), JobId.of("j$i"), i.toLong()), BTreeValue(cid, i.toLong()))
+        }
+
+        val schemaCid = casStore.put(byteArrayOf(99))
+        val cp = JobCheckpoint(0L, rootCid!!, schemaCid, emptyMap())
+        repo.checkpoint(cp)
+
+        val repo2 = JobRepository(log, casStore)
+        val result = repo2.recover()
+
+        for (i in 1..50) {
+            val recovered = result.snapshot("j$i")
+            assertNotNull(recovered)
+            assertEquals(i.toLong(), recovered.revision)
+        }
+    }
+
+    @Test
+    fun testDeterministicRestorationCoverage() = runBlocking {
+        val log = MockLog()
+        val casStore = CasStore.inMemory()
+        val repo = JobRepository(log, casStore)
+
+        val j1Snap = createSnapshot("j1", 1)
+        val j1Cid = casStore.put(CanonicalCbor.encode(j1Snap))
+
+        val tree = CowBPlusTree(casStore)
+        val rootCid = tree.insert(null, BTreeKey("f", byteArrayOf(1), JobId.of("j1"), 1L), BTreeValue(j1Cid, 1L))
+        val schemaCid = casStore.put(byteArrayOf(99))
+        val cp = JobCheckpoint(0L, rootCid, schemaCid, emptyMap())
+        repo.checkpoint(cp)
+
+        val repo2 = JobRepository(log, casStore)
+        val result = repo2.recover()
+        val recoveredJ1 = result.snapshot("j1")
+        assertNotNull(recoveredJ1)
+        assertEquals("j1", recoveredJ1.jobId.value)
+        assertEquals(1L, recoveredJ1.revision)
     }
 }


### PR DESCRIPTION
This PR completes the checkpoint recovery path for the `JobRepository`. Previously, when a checkpoint was discovered in the WAL tail replay, all earlier in-memory states were wiped out, but the repository neglected to hydrate the committed `JobSnapshot` head state stored within the checkpoint's copy-on-write B+Tree. 

As a result, a post-recovery system would only possess those updates that appeared *after* the checkpoint within the tail log.

**Changes:**
1.  **Hydration Engine:** Added `decodeJobSnapshot` to `CanonicalCbor.kt`. This manually decodes `Item.Map` generated from `Cbor.decode()`, allowing us to retain `Confix` as the sole serialization boundary and completely eschew `kotlinx-serialization` dependencies.
2.  **Tree Traversal:** Updated `JobRepository.kt` to recursively traverse the `CowBPlusTree` upon checkpoint recovery. It fetches the canonical state of each element from the CAS and applies the `decodeJobSnapshot` logic.
3.  **Corrected Log Overlay:** The hydrated state now properly acts as a foundation. Trailing logs within the WAL that mutate checkpointed jobs correctly take precedence (overwrite) via `tailSnapshots`.
4.  **Tests Updated:** `JobRepositoryRecoveryTest` was deeply upgraded to:
    - Verify that pre-checkpoint components survive recovery.
    - Confirm that a checkpointed item that is *also* updated in the tail receives the newest revision (the tail wins).
    - Introduced missing critical tests requested: `testCorruptValuePageRejection`, `testEmptyTreeRecovery`, `testRangeTraversalRecovery`, and `testDeterministicRestorationCoverage`. 

**Checklist:**
- No libs were created or restored.
- Modifications remained scoped tightly to the requested files.
- `build.gradle.kts` syntax issues were explicitly circumvented and were not modified during this commit.

---
*PR created automatically by Jules for task [10231215632534543486](https://jules.google.com/task/10231215632534543486) started by @jnorthrup*