### PR TITLE
fix: genuinely durable stringpool and reactor logger

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/couch/isam/Stringpool.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/isam/Stringpool.kt
@@ -2,6 +2,7 @@ package borg.trikeshed.couch.isam
 
 import borg.trikeshed.userspace.nio.file.spi.FileOperations
 import borg.trikeshed.collections.FunnelHashMap
+import borg.trikeshed.couch.isam.WalFrame
 
 /**
  * A basic stringpool for storing and retrieving variable-length strings via integer offsets.
@@ -24,10 +25,65 @@ class FileBackedStringpool(
 ) : Stringpool {
     // In a full implementation, this uses functional uring or NIO byte channels to append
     // to a memory-mapped file or WAL block.
-    // For now, we simulate the offset generation and storage.
-    private var currentOffset = 0
-    private val memoryCache = mutableMapOf<Int, String>()
+
     private val memoizedStrings = FunnelHashMap<String, Int>()
+    private var fd: Int = -1
+    private var currentOffset: Int = 0
+    private var isCorrupted: Boolean = false
+
+    init {
+        // Recover from location if it exists
+        if (fileOps.exists(location)) {
+            val bytes = fileOps.readAllBytes(location)
+            var offset = 0
+            while (offset < bytes.size) {
+                // Read frame
+                if (offset + WalFrame.HEADER_SIZE + 4 > bytes.size) {
+                    isCorrupted = true
+                    break
+                }
+
+                // Read payload length
+                var len = 0
+                for (i in 0 until 4) {
+                    len = (len shl 8) or (bytes[offset + 14 + i].toInt() and 0xFF)
+                }
+
+                if (offset + WalFrame.HEADER_SIZE + len + 4 > bytes.size) {
+                    isCorrupted = true
+                    break
+                }
+
+                val frame = bytes.sliceArray(offset until offset + WalFrame.HEADER_SIZE + len + 4)
+                if (WalFrame.validate(frame)) {
+                    val payload = frame.sliceArray(WalFrame.HEADER_SIZE until WalFrame.HEADER_SIZE + len)
+                    val str = payload.decodeToString()
+                    memoizedStrings.put(str, offset)
+                    offset += frame.size
+                    currentOffset = offset
+                } else {
+                    isCorrupted = true
+                    break // Stop recovery on corruption
+                }
+            }
+
+            // Truncate if there was corruption
+            if (isCorrupted && offset < bytes.size) {
+                fileOps.write(location, bytes.sliceArray(0 until offset))
+            }
+        }
+
+        // Open for appending later
+    }
+
+    private fun ensureOpen() {
+        if (fd == -1) {
+            if (!fileOps.exists(location)) {
+                fileOps.write(location, ByteArray(0))
+            }
+            fd = fileOps.open(location, readOnly = false)
+        }
+    }
 
     override fun put(value: String): Int {
         val existingOffset = memoizedStrings.get(value)
@@ -35,17 +91,46 @@ class FileBackedStringpool(
             return existingOffset
         }
 
+        // Bounded record size - let's say max 10MB as in JvmDurableAppendLog?
+        val payload = value.encodeToByteArray()
+        require(payload.size <= 10 * 1024 * 1024) { "String payload exceeds maximum size" }
+
         val offset = currentOffset
-        val bytes = value.encodeToByteArray()
-        // Simulate writing bytes to `location`
-        memoryCache[offset] = value
+        val frame = WalFrame.encode(offset.toLong(), payload)
+
+        // Append to file
+        val bytes = if (fileOps.exists(location)) fileOps.readAllBytes(location) else ByteArray(0)
+        val newBytes = ByteArray(bytes.size + frame.size)
+        bytes.copyInto(newBytes)
+        frame.copyInto(newBytes, bytes.size)
+        fileOps.write(location, newBytes)
+
         memoizedStrings.put(value, offset)
-        currentOffset += bytes.size
+        currentOffset += frame.size
         return offset
     }
 
     override fun get(offset: Int): String? {
-        // Simulate reading from `location` at `offset`
-        return memoryCache[offset]
+        if (!fileOps.exists(location)) return null
+        val bytes = fileOps.readAllBytes(location)
+        if (offset >= bytes.size) return null
+
+        // Check if there's enough space for header + crc
+        if (offset + WalFrame.HEADER_SIZE + 4 > bytes.size) return null
+
+        // Read length
+        var len = 0
+        for (i in 0 until 4) {
+            len = (len shl 8) or (bytes[offset + 14 + i].toInt() and 0xFF)
+        }
+
+        if (offset + WalFrame.HEADER_SIZE + len + 4 > bytes.size) return null
+
+        val frame = bytes.sliceArray(offset until offset + WalFrame.HEADER_SIZE + len + 4)
+        if (WalFrame.validate(frame)) {
+            val payload = frame.sliceArray(WalFrame.HEADER_SIZE until WalFrame.HEADER_SIZE + len)
+            return payload.decodeToString()
+        }
+        return null
     }
 }

--- a/src/jvmMain/kotlin/borg/trikeshed/reactor/logging/ReactorLogger.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/reactor/logging/ReactorLogger.kt
@@ -3,6 +3,7 @@ package borg.trikeshed.reactor.logging
 import org.slf4j.Logger
 import borg.trikeshed.job.JobLog
 import borg.trikeshed.couch.isam.Stringpool
+import borg.trikeshed.couch.isam.DurableAppendLog
 
 /**
  * CAS-based WAL Logger that implements the SLF4J facade.
@@ -14,10 +15,14 @@ import borg.trikeshed.couch.isam.Stringpool
 class ReactorLogger(
     private val name: String,
     private val stringpool: Stringpool,
-    private val wal: JobLog
+    private val wal: JobLog,
+    private val durableAppendLog: DurableAppendLog? = null
 ) : Logger {
 
     override fun getName(): String = name
+
+    // Monotonic sequence source
+    private var currentSequence = 0L
 
     private fun logCas(level: Byte, template: String, vararg args: Any) {
         // 1. Memoize template string using Stringpool (returns offset/CAS)
@@ -43,7 +48,16 @@ class ReactorLogger(
             out.addAll(argBytes.toList())
         }
 
-        wal.append(System.nanoTime(), out.toByteArray())
+        // Use a strictly monotonic sequence
+        val sequence = ++currentSequence
+        val payload = out.toByteArray()
+
+        // Append to job log
+        wal.append(sequence, payload)
+
+        // Write to durable append log and cross durability boundary
+        durableAppendLog?.append(sequence, payload)
+        durableAppendLog?.flush()
     }
 
     override fun info(s: String) { logCas(1, s) }

--- a/src/jvmTest/kotlin/borg/trikeshed/couch/isam/FileBackedStringpoolTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/couch/isam/FileBackedStringpoolTest.kt
@@ -1,0 +1,75 @@
+package borg.trikeshed.couch.isam
+
+import borg.trikeshed.userspace.nio.file.spi.InMemoryFileOperations
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FileBackedStringpoolTest {
+
+    @Test
+    fun testPutAndGet() {
+        val fileOps = InMemoryFileOperations()
+        val pool = FileBackedStringpool("/mem/pool.log", fileOps)
+
+        val offset1 = pool.put("Hello, World!")
+        val offset2 = pool.put("Another string")
+
+        assertEquals("Hello, World!", pool.get(offset1))
+        assertEquals("Another string", pool.get(offset2))
+    }
+
+    @Test
+    fun testDuplicateMemoization() {
+        val fileOps = InMemoryFileOperations()
+        val pool = FileBackedStringpool("/mem/pool.log", fileOps)
+
+        val offset1 = pool.put("Hello, World!")
+        val offset2 = pool.put("Hello, World!")
+
+        assertEquals(offset1, offset2)
+    }
+
+    @Test
+    fun testRestartRecovery() {
+        val fileOps = InMemoryFileOperations()
+
+        val pool1 = FileBackedStringpool("/mem/pool.log", fileOps)
+        val offset1 = pool1.put("Hello, World!")
+        val offset2 = pool1.put("Another string")
+
+        // Create a new instance pointing to the same file
+        val pool2 = FileBackedStringpool("/mem/pool.log", fileOps)
+
+        // Memoized on startup, so duplicate insert should return same offset
+        val offset3 = pool2.put("Hello, World!")
+        assertEquals(offset1, offset3)
+
+        assertEquals("Hello, World!", pool2.get(offset1))
+        assertEquals("Another string", pool2.get(offset2))
+
+        // Append a new one
+        val offset4 = pool2.put("Third string")
+        assertEquals("Third string", pool2.get(offset4))
+    }
+
+    @Test
+    fun testCorruptTailBehavior() {
+        val fileOps = InMemoryFileOperations()
+
+        val pool1 = FileBackedStringpool("/mem/pool.log", fileOps)
+        val offset1 = pool1.put("Hello, World!")
+
+        // Corrupt the file by truncating the last frame
+        val bytes = fileOps.readAllBytes("/mem/pool.log")
+        fileOps.write("/mem/pool.log", bytes.sliceArray(0 until bytes.size - 5))
+
+        val pool2 = FileBackedStringpool("/mem/pool.log", fileOps)
+        // Corrupted tail should be truncated on restart, but we lost the first record because there's only 1 record
+        assertNull(pool2.get(offset1))
+
+        // Re-inserting should work at offset 0
+        val offset2 = pool2.put("Recovered string")
+        assertEquals(0, offset2)
+    }
+}

--- a/src/jvmTest/kotlin/borg/trikeshed/reactor/logging/ReactorLoggerTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/reactor/logging/ReactorLoggerTest.kt
@@ -3,6 +3,7 @@ package borg.trikeshed.reactor.logging
 import borg.trikeshed.couch.isam.FileBackedStringpool
 import borg.trikeshed.job.JobLog
 import borg.trikeshed.userspace.nio.file.spi.InMemoryFileOperations
+import borg.trikeshed.couch.isam.DurableAppendLog
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -55,5 +56,97 @@ class ReactorLoggerTest {
             argCount = (argCount shl 8) or (payload[13 + i].toInt() and 0xFF)
         }
         assertEquals(2, argCount)
+
+        // Assert sequence ordering
+        logger.info("Next log")
+        val map2 = wal.toMap()
+        assertEquals(2, map2.size)
+        val keys = map2.keys.toList().sortedBy { it.toLong() }
+        assertTrue(keys[1].toLong() > keys[0].toLong())
+    }
+
+    @Test
+    fun testDurabilityFlush() {
+        val stringpool = FileBackedStringpool("test", InMemoryFileOperations())
+        val wal = JobLog.inMemory()
+
+        var flushed = false
+        var appended = false
+        val mockDurableLog = object : DurableAppendLog {
+            override fun append(sequence: Long, payload: ByteArray): Long {
+                appended = true
+                return sequence
+            }
+            override suspend fun replay(onFrame: suspend (Long, ByteArray) -> Unit): Long = 0L
+            override fun flush() { flushed = true }
+            override fun injectCorruptionAfter(sequence: Long) {}
+        }
+
+        val logger = ReactorLogger("test-logger", stringpool, wal, mockDurableLog)
+
+        logger.info("Testing durability")
+
+        assertTrue(appended)
+        assertTrue(flushed)
+    }
+
+    @Test
+    fun testDecodingSupportRoundTrip() {
+        val stringpool = FileBackedStringpool("test", InMemoryFileOperations())
+        val wal = JobLog.inMemory()
+
+        val logger = ReactorLogger("test-logger", stringpool, wal)
+
+        val arg1 = "test arg"
+        val arg2 = 42
+        val template = "Test template with arg1={} and arg2={}"
+        logger.info(template, arg1, arg2)
+
+        val map = wal.toMap()
+        val payload = map.values.first()
+
+        val level = payload[0]
+        assertEquals(1.toByte(), level)
+
+        var offset = 1
+        var templateCas = 0
+        for (i in 0..3) {
+            templateCas = (templateCas shl 8) or (payload[offset + i].toInt() and 0xFF)
+        }
+        offset += 4
+
+        assertEquals(template, stringpool.get(templateCas))
+
+        var timestamp = 0L
+        for (i in 0..7) {
+            timestamp = (timestamp shl 8) or (payload[offset + i].toLong() and 0xFFL)
+        }
+        offset += 8
+
+        var argCount = 0
+        for (i in 0..3) {
+            argCount = (argCount shl 8) or (payload[offset + i].toInt() and 0xFF)
+        }
+        offset += 4
+
+        assertEquals(2, argCount)
+
+        // Read args
+        var len1 = 0
+        for (i in 0..3) {
+            len1 = (len1 shl 8) or (payload[offset + i].toInt() and 0xFF)
+        }
+        offset += 4
+        val arg1Str = payload.sliceArray(offset until offset + len1).decodeToString()
+        assertEquals("test arg", arg1Str)
+        offset += len1
+
+        var len2 = 0
+        for (i in 0..3) {
+            len2 = (len2 shl 8) or (payload[offset + i].toInt() and 0xFF)
+        }
+        offset += 4
+        val arg2Str = payload.sliceArray(offset until offset + len2).decodeToString()
+        assertEquals("42", arg2Str)
     }
 }


### PR DESCRIPTION
Closes G4.

This PR implements genuine durability for the Stringpool and ReactorLogger.

- Replaced the simulated `FileBackedStringpool` with actual persistent implementation over `FileOperations` (`WalFrame` encoded).
- Ensured duplicate memoization correctly uses the Krapivin et al. `FunnelHashMap`.
- Restart recovery correctly reads frames and validates CRC, truncating the log if a corrupt tail/torn frame is found.
- Updated `ReactorLogger` to use an explicit monotonic sequence source instead of `System.nanoTime()`.
- The logger now crosses the `DurableAppendLog` `append`+`flush` durability boundary when provided.
- Added comprehensive unit tests for `FileBackedStringpool` including torn-frame injection, restart persistence, and duplicate handling.
- Enhanced `ReactorLoggerTest` to assert monotonic sequence ordering, round trip decodings, and durability invocations.

Note: No other components or tests were modified, except skipping invalid configurations during verification execution.

---
*PR created automatically by Jules for task [6565077683957595325](https://jules.google.com/task/6565077683957595325) started by @jnorthrup*