### PR TITLE
Implement memvid portable archive pipeline

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidDocument.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidDocument.kt
@@ -1,0 +1,30 @@
+package borg.trikeshed.memvid
+
+/**
+ * Represents a document to be archived.
+ */
+data class MemvidDocument(
+    val path: String,
+    val mediaType: String,
+    val bytes: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MemvidDocument
+
+        if (path != other.path) return false
+        if (mediaType != other.mediaType) return false
+        if (!bytes.contentEquals(other.bytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = path.hashCode()
+        result = 31 * result + mediaType.hashCode()
+        result = 31 * result + bytes.contentHashCode()
+        return result
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidFrameColumn.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidFrameColumn.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.cursor.ColumnMeta
+import borg.trikeshed.isam.meta.IOMemento
+
+/**
+ * Defines the stable ordinal-based schema for frames in a Memvid archive.
+ */
+enum class MemvidFrameColumn(val type: IOMemento) {
+    DOCUMENT_ORDINAL(IOMemento.IoInt),
+    PAYLOAD(IOMemento.IoByteArray);
+
+    val meta: ColumnMeta get() = ColumnMeta(name, type)
+}
+
+/**
+ * Strong-typed index keys for the returned meta-series.
+ */
+enum class MemvidK {
+    ArchiveId,
+    ManifestCid,
+    DocumentCount,
+    FrameCount,
+    Documents,
+    Frames
+}

--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidStoragePipeline.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidStoragePipeline.kt
@@ -1,0 +1,179 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.cursor.*
+import borg.trikeshed.job.CanonicalCbor
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.lib.*
+import borg.trikeshed.parse.confix.ConfixDoc
+import borg.trikeshed.parse.confix.confixDoc
+import borg.trikeshed.parse.confix.Syntax
+
+class MemvidStoragePipeline(
+    private val cas: CasStore,
+    private val maxFrameBytes: Int
+) {
+    init {
+        require(maxFrameBytes > 0) { "maxFrameBytes must be greater than 0" }
+    }
+
+    private fun createFrameRow(values: Series<Any?>): RowVec {
+        val meta0: `ColumnMeta↻` = { MemvidFrameColumn.DOCUMENT_ORDINAL.meta }
+        val meta1: `ColumnMeta↻` = { MemvidFrameColumn.PAYLOAD.meta }
+        val metas: Series<`ColumnMeta↻`> = values.size j { i: Int ->
+            if (i == 0) meta0 else meta1
+        }
+        return borg.trikeshed.cursor.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>(values, metas)
+    }
+
+    private fun createDocRow(values: Series<Any?>): RowVec {
+        val metaString: `ColumnMeta↻` = { ColumnMeta("path", borg.trikeshed.isam.meta.IOMemento.IoString) }
+        val metaId: `ColumnMeta↻` = { ColumnMeta("cid", borg.trikeshed.isam.meta.IOMemento.IoByteArray) }
+        val metas: Series<`ColumnMeta↻`> = values.size j { i: Int ->
+            if (i < 2) metaString else metaId
+        }
+        return borg.trikeshed.cursor.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>(values, metas)
+    }
+
+    /**
+     * Stores a series of MemvidDocuments, splitting them into frames and storing
+     * them in the CAS. Returns a typed meta-series indexable by MemvidK.
+     */
+    fun store(documents: Series<MemvidDocument>): Series<Any?> {
+        var frameCount = 0
+        val framesList = mutableListOf<RowVec>()
+
+        for (docOrdinal in 0 until documents.size) {
+            val doc = documents.b(docOrdinal)
+            val bytes = doc.bytes
+
+            if (bytes.isEmpty()) {
+                val chunk = ByteArray(0)
+                val cid = cas.put(chunk)
+                val rowValues: Series<Any?> = 2 j { i: Int -> if (i == 0) docOrdinal else cid }
+                framesList.add(createFrameRow(rowValues))
+                frameCount++
+                continue
+            }
+
+            var offset = 0
+            while (offset < bytes.size) {
+                val length = minOf(maxFrameBytes, bytes.size - offset)
+                val chunk = bytes.sliceArray(offset until offset + length)
+                val cid = cas.put(chunk)
+
+                val rowValues: Series<Any?> = 2 j { i: Int -> if (i == 0) docOrdinal else cid }
+                framesList.add(createFrameRow(rowValues))
+
+                frameCount++
+                offset += length
+            }
+        }
+
+        val frames: Cursor = framesList.size j { framesList[it] }
+        val docsCursor = buildDocsCursor(documents)
+
+        // Build canonical manifest for CID
+        val manifestJson = buildManifestJson(documents, framesList)
+        val manifestDoc = confixDoc(manifestJson) // Fix: just pass string for JSON
+        val manifestCid = ContentId.of(manifestDoc) // This canonicalizes internally
+        cas.put(manifestDoc) // Puts canonical CBOR
+
+        return MemvidK.entries.size j { i ->
+            when (MemvidK.entries[i]) {
+                MemvidK.ArchiveId -> manifestCid
+                MemvidK.ManifestCid -> manifestCid
+                MemvidK.DocumentCount -> documents.size
+                MemvidK.FrameCount -> frameCount
+                MemvidK.Documents -> docsCursor
+                MemvidK.Frames -> frames
+            }
+        }
+    }
+
+    private fun buildDocsCursor(documents: Series<MemvidDocument>): Cursor {
+        val list = mutableListOf<RowVec>()
+        for (i in 0 until documents.size) {
+            val doc = documents.b(i)
+            val expectedCid = ContentId.of(doc.bytes)
+            val rowValues: Series<Any?> = 3 j { j: Int ->
+                when (j) {
+                    0 -> doc.path
+                    1 -> doc.mediaType
+                    else -> expectedCid
+                }
+            }
+            list.add(createDocRow(rowValues))
+        }
+        return list.size j { list[it] }
+    }
+
+    private fun buildManifestJson(documents: Series<MemvidDocument>, frames: List<RowVec>): String {
+        val sb = StringBuilder()
+        sb.append("{")
+        sb.append("\"docs\":[")
+        for (i in 0 until documents.size) {
+            if (i > 0) sb.append(",")
+            val doc = documents.b(i)
+            sb.append("{\"path\":\"${doc.path}\",\"mediaType\":\"${doc.mediaType}\",\"cid\":\"${ContentId.of(doc.bytes).value}\"}")
+        }
+        sb.append("],")
+        sb.append("\"frames\":[")
+        for (i in 0 until frames.size) {
+            if (i > 0) sb.append(",")
+            val r = frames[i]
+            val vals = (r as borg.trikeshed.cursor.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries
+            val docOrd = vals.b(0) as Int
+            val cid = vals.b(1) as ContentId
+            sb.append("{\"doc\":$docOrd,\"cid\":\"${cid.value}\"}")
+        }
+        sb.append("]")
+        sb.append("}")
+        return sb.toString()
+    }
+
+    /**
+     * Restores a document from the archive by its ordinal.
+     */
+    fun restoreDocument(archive: Series<Any?>, ordinal: Int): ByteArray {
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+        val documents = archive.b(MemvidK.Documents.ordinal) as Cursor
+
+        if (ordinal < 0 || ordinal >= documents.size) {
+            throw IllegalArgumentException("Invalid document ordinal: $ordinal")
+        }
+
+        val docVals = (documents.b(ordinal) as borg.trikeshed.cursor.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries
+        val expectedCid = docVals.b(2) as ContentId
+
+        var totalBytes = 0
+        val chunks = mutableListOf<ByteArray>()
+
+        for (i in 0 until frames.size) {
+            val frame = frames.b(i)
+            val vals = (frame as borg.trikeshed.cursor.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries
+            val frameDocOrdinal = vals.b(0) as Int
+            if (frameDocOrdinal == ordinal) {
+                val cid = vals.b(1) as ContentId
+                val chunk = cas.get(cid) ?: throw IllegalStateException("CAS corruption: chunk $cid not found")
+                // cas.get verifies the digest implicitly
+                chunks.add(chunk)
+                totalBytes += chunk.size
+            }
+        }
+
+        val result = ByteArray(totalBytes)
+        var offset = 0
+        for (chunk in chunks) {
+            chunk.copyInto(result, offset)
+            offset += chunk.size
+        }
+
+        val actualCid = ContentId.of(result)
+        if (actualCid != expectedCid) {
+            throw IllegalStateException("Restored document CID $actualCid does not match expected $expectedCid")
+        }
+
+        return result
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/memvid/MemvidStoragePipelineTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/memvid/MemvidStoragePipelineTest.kt
@@ -1,0 +1,126 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.lib.seriesOf
+import borg.trikeshed.lib.b
+import borg.trikeshed.lib.size
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.isam.meta.IOMemento
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import borg.trikeshed.cursor.ReifiedSplitSeries2
+import borg.trikeshed.cursor.`ColumnMeta↻`
+
+class MemvidStoragePipelineTest {
+
+    @Test
+    fun testTwoDocsFrameSize4() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 4)
+
+        val docs = seriesOf(
+            MemvidDocument("doc1.txt", "text/plain", "abcdefgh".encodeToByteArray()),
+            MemvidDocument("doc2.txt", "text/plain", "xyz".encodeToByteArray())
+        )
+
+        val archive = pipeline.store(docs)
+
+        assertEquals(2, archive.b(MemvidK.DocumentCount.ordinal) as Int)
+        assertEquals(3, archive.b(MemvidK.FrameCount.ordinal) as Int)
+
+        val restored1 = pipeline.restoreDocument(archive, 0)
+        assertEquals("abcdefgh", restored1.decodeToString())
+
+        val restored2 = pipeline.restoreDocument(archive, 1)
+        assertEquals("xyz", restored2.decodeToString())
+    }
+
+    @Test
+    fun testFrameSize3GivesPayloadRowsWithSchema() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 3)
+
+        val docs = seriesOf(
+            MemvidDocument("doc1.txt", "text/plain", "abcdef".encodeToByteArray())
+        )
+
+        val archive = pipeline.store(docs)
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+
+        assertEquals(2, frames.size)
+
+        val frame0 = frames.b(0)
+        val schema0 = (frame0 as ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).rightSeries.b(0).invoke()
+        val schema1 = (frame0 as ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).rightSeries.b(1).invoke()
+        assertEquals("DOCUMENT_ORDINAL", schema0.name.toString())
+        assertEquals(IOMemento.IoInt, schema0.type)
+        assertEquals("PAYLOAD", schema1.name.toString())
+        assertEquals(IOMemento.IoByteArray, schema1.type)
+
+        val restored = pipeline.restoreDocument(archive, 0)
+        assertEquals("abcdef", restored.decodeToString())
+    }
+
+    @Test
+    fun testUtf8BytesRestoreExactlyAndCasCorruptionThrows() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 2)
+
+        val bytes = "Hello, 世界".encodeToByteArray()
+        val docs = seriesOf(MemvidDocument("doc", "text/plain", bytes))
+
+        val archive = pipeline.store(docs)
+
+        val restored = pipeline.restoreDocument(archive, 0)
+        assertTrue(bytes.contentEquals(restored))
+
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+        val firstCid = (frames.b(0) as ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries.b(1) as ContentId
+        cas.corrupt(firstCid)
+
+        assertFailsWith<IllegalStateException> {
+            pipeline.restoreDocument(archive, 0)
+        }
+    }
+
+    @Test
+    fun testDeterministicArchiveAndManifestCid() {
+        val cas1 = CasStore.inMemory()
+        val pipeline1 = MemvidStoragePipeline(cas1, 4)
+        val docs1 = seriesOf(MemvidDocument("d", "text/plain", "abc".encodeToByteArray()))
+        val archive1 = pipeline1.store(docs1)
+
+        val cas2 = CasStore.inMemory()
+        val pipeline2 = MemvidStoragePipeline(cas2, 4)
+        val docs2 = seriesOf(MemvidDocument("d", "text/plain", "abc".encodeToByteArray()))
+        val archive2 = pipeline2.store(docs2)
+
+        val cid1 = archive1.b(MemvidK.ArchiveId.ordinal) as ContentId
+        val cid2 = archive2.b(MemvidK.ArchiveId.ordinal) as ContentId
+
+        assertEquals(cid1, cid2)
+        assertEquals(cid1, archive1.b(MemvidK.ManifestCid.ordinal))
+    }
+
+    @Test
+    fun testEmptyArchiveAndInvalidFrameSize() {
+        assertFailsWith<IllegalArgumentException> {
+            MemvidStoragePipeline(CasStore.inMemory(), 0)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            MemvidStoragePipeline(CasStore.inMemory(), -1)
+        }
+
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 10)
+        val emptyDocs = seriesOf(emptyList<MemvidDocument>())
+
+        val archive = pipeline.store(emptyDocs)
+        assertEquals(0, archive.b(MemvidK.DocumentCount.ordinal))
+        assertEquals(0, archive.b(MemvidK.FrameCount.ordinal))
+    }
+}


### PR DESCRIPTION
Implements the Memvid archive pipeline that stores document fragments deterministically into `CasStore` while correctly handling different frame column schemas. Uses custom KMP types (`Series`, `ConfixDoc`, etc) safely without invalid JSON imports.

---
*PR created automatically by Jules for task [17480733818428156638](https://jules.google.com/task/17480733818428156638) started by @jnorthrup*