### PR TITLE
Implement memvid portable archive pipeline

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidDocument.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidDocument.kt
@@ -1,0 +1,30 @@
+package borg.trikeshed.memvid
+
+/**
+ * Represents a document to be archived.
+ */
+data class MemvidDocument(
+    val path: String,
+    val mediaType: String,
+    val bytes: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MemvidDocument
+
+        if (path != other.path) return false
+        if (mediaType != other.mediaType) return false
+        if (!bytes.contentEquals(other.bytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = path.hashCode()
+        result = 31 * result + mediaType.hashCode()
+        result = 31 * result + bytes.contentHashCode()
+        return result
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidFrameColumn.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidFrameColumn.kt
@@ -1,0 +1,45 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.cursor.ColumnMeta
+import borg.trikeshed.cursor.IOMemento
+
+/**
+ * Defines the stable ordinal-based schema for frames in a Memvid archive.
+ */
+enum class MemvidFrameColumn(val type: IOMemento) {
+    DOCUMENT_ORDINAL(IOMemento.IoInt),
+    FRAME_ORDINAL(IOMemento.IoInt),
+    BYTE_OFFSET(IOMemento.IoInt),
+    BYTE_LENGTH(IOMemento.IoInt),
+    CHUNK_CID(IOMemento.IoString),
+    PAYLOAD(IOMemento.IoBytes);
+
+    val meta: ColumnMeta get() = ColumnMeta(name, type)
+}
+
+/**
+ * Defines the stable ordinal-based schema for documents in a Memvid archive.
+ */
+enum class MemvidDocumentColumn(val type: IOMemento) {
+    DOCUMENT_ORDINAL(IOMemento.IoInt),
+    PATH(IOMemento.IoString),
+    MEDIA_TYPE(IOMemento.IoString),
+    BYTE_SIZE(IOMemento.IoInt),
+    DOCUMENT_CID(IOMemento.IoString),
+    FIRST_FRAME_ORDINAL(IOMemento.IoInt),
+    FRAME_COUNT(IOMemento.IoInt);
+
+    val meta: ColumnMeta get() = ColumnMeta(name, type)
+}
+
+/**
+ * Strong-typed index keys for the returned meta-series.
+ */
+enum class MemvidK {
+    ArchiveId,
+    ManifestCid,
+    DocumentCount,
+    FrameCount,
+    Documents,
+    Frames
+}

--- a/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidStoragePipeline.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/memvid/MemvidStoragePipeline.kt
@@ -1,0 +1,220 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.cursor.*
+import borg.trikeshed.job.CanonicalCbor
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.lib.*
+import borg.trikeshed.parse.confix.*
+import borg.trikeshed.parse.confix.confixDoc
+
+class MemvidStoragePipeline(
+    private val cas: CasStore,
+    private val maxFrameBytes: Int
+) {
+    init {
+        require(maxFrameBytes > 0) { "maxFrameBytes must be greater than 0" }
+    }
+
+    private fun createFrameRow(docOrd: Int, frameOrd: Int, offset: Int, length: Int, chunkCid: String, payload: ByteArray): RowVec {
+        val values: Series<Any?> = 6 j { i: Int ->
+            when (i) {
+                0 -> docOrd
+                1 -> frameOrd
+                2 -> offset
+                3 -> length
+                4 -> chunkCid
+                else -> payload
+            }
+        }
+        val metas: Series<`ColumnMeta↻`> = 6 j { i: Int ->
+            when (i) {
+                0 -> { { MemvidFrameColumn.DOCUMENT_ORDINAL.meta } }
+                1 -> { { MemvidFrameColumn.FRAME_ORDINAL.meta } }
+                2 -> { { MemvidFrameColumn.BYTE_OFFSET.meta } }
+                3 -> { { MemvidFrameColumn.BYTE_LENGTH.meta } }
+                4 -> { { MemvidFrameColumn.CHUNK_CID.meta } }
+                else -> { { MemvidFrameColumn.PAYLOAD.meta } }
+            }
+        }
+        return borg.trikeshed.lib.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>(values, metas)
+    }
+
+    private fun createDocRow(docOrd: Int, path: String, mediaType: String, byteSize: Int, docCid: String, firstFrameOrd: Int, frameCount: Int): RowVec {
+        val values: Series<Any?> = 7 j { i: Int ->
+            when (i) {
+                0 -> docOrd
+                1 -> path
+                2 -> mediaType
+                3 -> byteSize
+                4 -> docCid
+                5 -> firstFrameOrd
+                else -> frameCount
+            }
+        }
+        val metas: Series<`ColumnMeta↻`> = 7 j { i: Int ->
+            when (i) {
+                0 -> { { MemvidDocumentColumn.DOCUMENT_ORDINAL.meta } }
+                1 -> { { MemvidDocumentColumn.PATH.meta } }
+                2 -> { { MemvidDocumentColumn.MEDIA_TYPE.meta } }
+                3 -> { { MemvidDocumentColumn.BYTE_SIZE.meta } }
+                4 -> { { MemvidDocumentColumn.DOCUMENT_CID.meta } }
+                5 -> { { MemvidDocumentColumn.FIRST_FRAME_ORDINAL.meta } }
+                else -> { { MemvidDocumentColumn.FRAME_COUNT.meta } }
+            }
+        }
+        return borg.trikeshed.lib.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>(values, metas)
+    }
+
+    /**
+     * Stores a series of MemvidDocuments, splitting them into frames and storing
+     * them in the CAS. Returns a typed meta-series indexable by MemvidK.
+     */
+    fun store(documents: Series<MemvidDocument>): Series<Any?> {
+        var globalFrameCount = 0
+        val framesList = mutableListOf<RowVec>()
+        val docsList = mutableListOf<RowVec>()
+
+        val docManifestList = mutableListOf<Map<String, Any?>>()
+        val frameManifestList = mutableListOf<Map<String, Any?>>()
+
+        for (docOrdinal in 0 until documents.size) {
+            val doc = documents.b(docOrdinal)
+            val bytes = doc.bytes
+            val docCid = ContentId.of(bytes).value
+
+            if (bytes.isEmpty()) {
+                val chunk = ByteArray(0)
+                // Zero-length restoration semantics: Do not manufacture an inconsistent frame.
+                // We add document row with 0 frames.
+                docsList.add(createDocRow(docOrdinal, doc.path, doc.mediaType, 0, docCid, globalFrameCount, 0))
+
+                docManifestList.add(mapOf(
+                    "path" to doc.path,
+                    "mediaType" to doc.mediaType,
+                    "size" to 0,
+                    "cid" to docCid,
+                    "frameCount" to 0
+                ))
+                continue
+            }
+
+            var offset = 0
+            val initialFrameOrdinal = globalFrameCount
+            var localFrameCount = 0
+
+            while (offset < bytes.size) {
+                val length = minOf(maxFrameBytes, bytes.size - offset)
+                val chunk = bytes.sliceArray(offset until offset + length)
+                val cid = cas.put(chunk) // Put to cas returns ContentId
+
+                // Add frame row
+                framesList.add(createFrameRow(docOrdinal, globalFrameCount, offset, length, cid.value, chunk))
+
+                frameManifestList.add(mapOf(
+                    "docOrdinal" to docOrdinal,
+                    "frameOrdinal" to globalFrameCount,
+                    "offset" to offset,
+                    "length" to length,
+                    "cid" to cid.value
+                ))
+
+                globalFrameCount++
+                localFrameCount++
+                offset += length
+            }
+
+            docsList.add(createDocRow(docOrdinal, doc.path, doc.mediaType, bytes.size, docCid, initialFrameOrdinal, localFrameCount))
+
+            docManifestList.add(mapOf(
+                "path" to doc.path,
+                "mediaType" to doc.mediaType,
+                "size" to bytes.size,
+                "cid" to docCid,
+                "frameCount" to localFrameCount
+            ))
+        }
+
+        val framesCursor: Cursor = framesList.size j { framesList[it] }
+        val docsCursor: Cursor = docsList.size j { docsList[it] }
+
+        // Build deterministic Confix using existing Confix APIs
+        val docJsonParts = mutableListOf<String>()
+        for (i in 0 until docManifestList.size) {
+            val d = docManifestList[i]
+            docJsonParts.add("{\"path\":\"${d["path"]}\",\"mediaType\":\"${d["mediaType"]}\",\"size\":${d["size"]},\"cid\":\"${d["cid"]}\",\"frameCount\":${d["frameCount"]}}")
+        }
+        val framesJsonParts = mutableListOf<String>()
+        for (i in 0 until frameManifestList.size) {
+            val f = frameManifestList[i]
+            framesJsonParts.add("{\"docOrdinal\":${f["docOrdinal"]},\"frameOrdinal\":${f["frameOrdinal"]},\"offset\":${f["offset"]},\"length\":${f["length"]},\"cid\":\"${f["cid"]}\"}")
+        }
+
+        val manifestJson = "{\"docs\":[${docJsonParts.joinToString(",")}]," + "\"frames\":[${framesJsonParts.joinToString(",")}]}"
+
+        val manifestDoc = confixDoc(manifestJson)
+        val manifestCid = ContentId.of(manifestDoc)
+        cas.put(manifestDoc)
+
+        return MemvidK.entries.size j { i: Int ->
+            when (MemvidK.entries[i]) {
+                MemvidK.ArchiveId -> manifestCid
+                MemvidK.ManifestCid -> manifestCid
+                MemvidK.DocumentCount -> documents.size
+                MemvidK.FrameCount -> globalFrameCount
+                MemvidK.Documents -> docsCursor
+                MemvidK.Frames -> framesCursor
+            }
+        }
+    }
+
+    /**
+     * Restores a document from the archive by its ordinal.
+     */
+    fun restoreDocument(archive: Series<Any?>, ordinal: Int): ByteArray {
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+        val documents = archive.b(MemvidK.Documents.ordinal) as Cursor
+
+        if (ordinal < 0 || ordinal >= documents.size) {
+            throw IllegalArgumentException("Invalid document ordinal: $ordinal")
+        }
+
+        val docVals = (documents.b(ordinal) as borg.trikeshed.lib.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries
+        val expectedCid = ContentId(docVals.b(MemvidDocumentColumn.DOCUMENT_CID.ordinal) as String)
+        val firstFrameOrd = docVals.b(MemvidDocumentColumn.FIRST_FRAME_ORDINAL.ordinal) as Int
+        val frameCount = docVals.b(MemvidDocumentColumn.FRAME_COUNT.ordinal) as Int
+
+        if (frameCount == 0) {
+            return ByteArray(0)
+        }
+
+        var totalBytes = 0
+        val chunks = mutableListOf<ByteArray>()
+
+        // Frames are stored sequentially
+        for (i in firstFrameOrd until firstFrameOrd + frameCount) {
+            val frame = frames.b(i) as borg.trikeshed.lib.ReifiedSplitSeries2<Any?, `ColumnMeta↻`>
+            val vals = frame.leftSeries
+
+            // PAYLOAD must expose resolved ByteArray bytes through CAS!
+            val chunkCid = ContentId(vals.b(MemvidFrameColumn.CHUNK_CID.ordinal) as String)
+            val chunk = cas.get(chunkCid) ?: throw IllegalStateException("CAS corruption: chunk $chunkCid not found")
+            chunks.add(chunk)
+            totalBytes += chunk.size
+        }
+
+        val result = ByteArray(totalBytes)
+        var offset = 0
+        for (chunk in chunks) {
+            chunk.copyInto(result, offset)
+            offset += chunk.size
+        }
+
+        val actualCid = ContentId.of(result)
+        if (actualCid != expectedCid) {
+            throw IllegalStateException("Restored document CID $actualCid does not match expected $expectedCid")
+        }
+
+        return result
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/memvid/MemvidStoragePipelineTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/memvid/MemvidStoragePipelineTest.kt
@@ -1,0 +1,127 @@
+package borg.trikeshed.memvid
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.lib.seriesOf
+import borg.trikeshed.lib.b
+import borg.trikeshed.lib.size
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.cursor.IOMemento
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import borg.trikeshed.lib.ReifiedSplitSeries2
+import borg.trikeshed.cursor.`ColumnMeta↻`
+
+class MemvidStoragePipelineTest {
+
+    @Test
+    fun testTwoDocsFrameSize4() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 4)
+
+        val docs = seriesOf(
+            MemvidDocument("doc1.txt", "text/plain", "abcdefgh".encodeToByteArray()),
+            MemvidDocument("doc2.txt", "text/plain", "xyz".encodeToByteArray())
+        )
+
+        val archive = pipeline.store(docs)
+
+        assertEquals(2, archive.b(MemvidK.DocumentCount.ordinal) as Int)
+        assertEquals(3, archive.b(MemvidK.FrameCount.ordinal) as Int)
+
+        val restored1 = pipeline.restoreDocument(archive, 0)
+        assertEquals("abcdefgh", restored1.decodeToString())
+
+        val restored2 = pipeline.restoreDocument(archive, 1)
+        assertEquals("xyz", restored2.decodeToString())
+    }
+
+    @Test
+    fun testFrameSize3GivesPayloadRowsWithSchema() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 3)
+
+        val docs = seriesOf(
+            MemvidDocument("doc1.txt", "text/plain", "abcdef".encodeToByteArray())
+        )
+
+        val archive = pipeline.store(docs)
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+
+        assertEquals(2, frames.size)
+
+        val frame0 = frames.b(0)
+        val metaSeries = (frame0 as ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).rightSeries
+        val schema0 = metaSeries.b(0).invoke()
+        val schemaPayload = metaSeries.b(MemvidFrameColumn.PAYLOAD.ordinal).invoke()
+        assertEquals("DOCUMENT_ORDINAL", schema0.name.toString())
+        assertEquals(IOMemento.IoInt, schema0.type)
+        assertEquals("PAYLOAD", schemaPayload.name.toString())
+        assertEquals(IOMemento.IoBytes, schemaPayload.type)
+
+        val restored = pipeline.restoreDocument(archive, 0)
+        assertEquals("abcdef", restored.decodeToString())
+    }
+
+    @Test
+    fun testUtf8BytesRestoreExactlyAndCasCorruptionThrows() {
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 2)
+
+        val bytes = "Hello, 世界".encodeToByteArray()
+        val docs = seriesOf(MemvidDocument("doc", "text/plain", bytes))
+
+        val archive = pipeline.store(docs)
+
+        val restored = pipeline.restoreDocument(archive, 0)
+        assertTrue(bytes.contentEquals(restored))
+
+        val frames = archive.b(MemvidK.Frames.ordinal) as Cursor
+        val firstCidStr = (frames.b(0) as ReifiedSplitSeries2<Any?, `ColumnMeta↻`>).leftSeries.b(MemvidFrameColumn.CHUNK_CID.ordinal) as String
+        cas.corrupt(ContentId(firstCidStr))
+
+        assertFailsWith<IllegalStateException> {
+            pipeline.restoreDocument(archive, 0)
+        }
+    }
+
+    @Test
+    fun testDeterministicArchiveAndManifestCid() {
+        val cas1 = CasStore.inMemory()
+        val pipeline1 = MemvidStoragePipeline(cas1, 4)
+        val docs1 = seriesOf(MemvidDocument("d", "text/plain", "abc".encodeToByteArray()))
+        val archive1 = pipeline1.store(docs1)
+
+        val cas2 = CasStore.inMemory()
+        val pipeline2 = MemvidStoragePipeline(cas2, 4)
+        val docs2 = seriesOf(MemvidDocument("d", "text/plain", "abc".encodeToByteArray()))
+        val archive2 = pipeline2.store(docs2)
+
+        val cid1 = archive1.b(MemvidK.ArchiveId.ordinal) as ContentId
+        val cid2 = archive2.b(MemvidK.ArchiveId.ordinal) as ContentId
+
+        assertEquals(cid1, cid2)
+        assertEquals(cid1, archive1.b(MemvidK.ManifestCid.ordinal))
+    }
+
+    @Test
+    fun testEmptyArchiveAndInvalidFrameSize() {
+        assertFailsWith<IllegalArgumentException> {
+            MemvidStoragePipeline(CasStore.inMemory(), 0)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            MemvidStoragePipeline(CasStore.inMemory(), -1)
+        }
+
+        val cas = CasStore.inMemory()
+        val pipeline = MemvidStoragePipeline(cas, 10)
+        val emptyDocs = seriesOf(emptyList<MemvidDocument>())
+
+        val archive = pipeline.store(emptyDocs)
+        assertEquals(0, archive.b(MemvidK.DocumentCount.ordinal))
+        assertEquals(0, archive.b(MemvidK.FrameCount.ordinal))
+    }
+}

--- a/test.kt
+++ b/test.kt
@@ -1,0 +1,4 @@
+import java.io.File
+fun main() {
+    println("Done")
+}


### PR DESCRIPTION
Implements the Memvid archive pipeline that stores document fragments deterministically into `CasStore` while correctly handling different frame column schemas. Uses custom KMP types (`Series`, `ConfixDoc`, etc) safely without invalid JSON imports.

---
*PR created automatically by Jules for task [17480733818428156638](https://jules.google.com/task/17480733818428156638) started by @jnorthrup*