### PR TITLE
Fix RGA debt: route JvmKanbanServer responses to AsynchronousSocketChannel

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/litebike/LitebikeListenerElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/litebike/LitebikeListenerElement.kt
@@ -53,7 +53,30 @@ class LitebikeListenerElement(
         val protocolId: UByte,
         val sequenceId: Long,
         val payload: ByteArray,
-    )
+        val respond: (suspend (ByteArray) -> Unit)? = null,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as ChannelMessage
+
+            if (protocolId != other.protocolId) return false
+            if (sequenceId != other.sequenceId) return false
+            if (!payload.contentEquals(other.payload)) return false
+            if (respond != other.respond) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = protocolId.hashCode()
+            result = 31 * result + sequenceId.hashCode()
+            result = 31 * result + payload.contentHashCode()
+            result = 31 * result + (respond?.hashCode() ?: 0)
+            return result
+        }
+    }
 
     /** Per-protocol inbox. Each registered worker drains via [ChannelWorkgroupSlot.consume]. */
     class ChannelWorkgroupSlot(val protocol: Protocol) {
@@ -153,14 +176,14 @@ class LitebikeListenerElement(
      * CCEK subscriber — this is the bridge SCTP / HTX elements use to
      * observe inbound protocol traffic.
      */
-    suspend fun accept(protocolId: UByte, payload: ByteArray): Boolean {
+    suspend fun accept(protocolId: UByte, payload: ByteArray, respond: (suspend (ByteArray) -> Unit)? = null): Boolean {
         check(state == ElementState.OPEN || state == ElementState.ACTIVE) {
             "LitebikeListenerElement must be OPEN/ACTIVE before accept() (was $state)"
         }
         val slot = registry[protocolId] ?: return false
         val proto = Protocol.fromId(protocolId)
         val sequenceId = nextSequenceId()
-        val msg = ChannelMessage(protocolId, sequenceId, payload)
+        val msg = ChannelMessage(protocolId, sequenceId, payload, respond)
         slot.offer(msg)
         // Bridge: notify every CCEK subscriber of the fanout event.
         val event = LitebikeFanoutEvent(
@@ -179,8 +202,8 @@ class LitebikeListenerElement(
      * Convenience overload: caller did the protocol detection and has a
      * `Protocol` enum value. Same behavior.
      */
-    suspend fun accept(protocol: Protocol, payload: ByteArray): Boolean =
-        accept(protocol.id, payload)
+    suspend fun accept(protocol: Protocol, payload: ByteArray, respond: (suspend (ByteArray) -> Unit)? = null): Boolean =
+        accept(protocol.id, payload, respond)
 
     /**
      * Notify every CCEK subscriber of [event]. Subscribers may implement

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -123,12 +123,6 @@ object JvmKanbanServer {
             while (true) {
                 val msg = runCatching { httpSlot.consume() }.getOrNull() ?: continue
                 val resp = routeHttp(msg.payload)
-                // Echo the response back into the same listener on the
-                // Json slot — the bind adapter will eventually learn to
-                // echo through the original connection. For now this is
-                // a "log the response" surface, so the daemon isn't a
-                // black hole: we surface the response as a Json message
-                // downstream.
                 val out = buildString {
                     append("HTTP/1.1 ${resp.status} ${statusReason(resp.status)}\r\n")
                     append("Content-Length: ${resp.body.toByteArray(StandardCharsets.UTF_8).size}\r\n")
@@ -136,7 +130,17 @@ object JvmKanbanServer {
                     append("Access-Control-Allow-Origin: *\r\n\r\n")
                     append(resp.body)
                 }
-                listener.accept(Protocol.Json, out.toByteArray(StandardCharsets.UTF_8))
+                val outBytes = out.toByteArray(StandardCharsets.UTF_8)
+                if (msg.respond != null) {
+                    try {
+                        msg.respond.invoke(outBytes)
+                    } catch (e: Exception) {
+                        System.err.println("Failed to write response to originating channel: ${e.message}")
+                    }
+                } else {
+                    // Fallback: surface the response as a Json message downstream
+                    listener.accept(Protocol.Json, outBytes)
+                }
             }
         }
         scope.launch {

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
@@ -113,6 +113,24 @@ object JvmLitebikeBindAdapter {
         element: LitebikeListenerElement,
     ) {
         val buf = ByteBuffer.allocate(8 * 1024)
+        val respondCallback: suspend (ByteArray) -> Unit = { responseBytes ->
+            withContext(Dispatchers.IO) {
+                val writeBuf = ByteBuffer.wrap(responseBytes)
+                while (writeBuf.hasRemaining()) {
+                    val written = kotlin.coroutines.suspendCoroutine { cont ->
+                        ch.write(writeBuf, null, object : CompletionHandler<Int, Any?> {
+                            override fun completed(result: Int, attachment: Any?) {
+                                cont.resumeWith(Result.success(result))
+                            }
+                            override fun failed(exc: Throwable, attachment: Any?) {
+                                cont.resumeWith(Result.failure(exc))
+                            }
+                        })
+                    }
+                    if (written < 0) break
+                }
+            }
+        }
         ch.read(
             buf, null,
             object : CompletionHandler<Int, Any?> {
@@ -126,7 +144,7 @@ object JvmLitebikeBindAdapter {
                     val proto: Protocol = ProtocolDetector.detect(head, bytes.size)
                     // runBlocking is OK from a JDK CompletionHandler because
                     // those callbacks are pure Java threads, not coroutines.
-                    val ok = runBlocking { element.accept(proto, bytes) }
+                    val ok = runBlocking { element.accept(proto, bytes, respondCallback) }
                     if (!ok) runCatching { ch.close() }
                     // Continue draining while data remains.
                     buf.clear()


### PR DESCRIPTION
This change addresses an architectural RGA debt in `JvmKanbanServer`.

Previously, the `JvmKanbanServer` would echo HTTP responses back into the multiprotocol listener using `Protocol.Json`, which caused the responses to not be written back to the client that originated the request.

With this PR:
1. `LitebikeListenerElement` and its `ChannelMessage` type are updated to optionally accept a suspendable `respond: (ByteArray) -> Unit` callback.
2. `JvmLitebikeBindAdapter` is updated to inject a callback using `suspendCoroutine` to wrap `AsynchronousSocketChannel.write`, ensuring that the response writes back securely without spinning.
3. `JvmKanbanServer` invokes `msg.respond` directly to handle requests asynchronously, correctly maintaining the socket connection lifecycle.

---
*PR created automatically by Jules for task [11746398939824232520](https://jules.google.com/task/11746398939824232520) started by @jnorthrup*