### PR TITLE
Define ForgeWindowManager SPI in commonMain

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/shell/spi/ForgeWindowManager.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/shell/spi/ForgeWindowManager.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.forge.shell.spi
+
+import kotlin.coroutines.CoroutineContext
+
+interface ForgeWindowManager : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+
+    companion object Key : CoroutineContext.Key<ForgeWindowManager>
+
+    fun bind(html: String)
+    fun injectScript(script: String)
+    fun dispatchEvent(event: String, payload: String)
+    suspend fun captureSnapshot(): ByteArray
+}

--- a/src/jsMain/kotlin/borg/trikeshed/forge/shell/spi/JsForgeWindowManager.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/forge/shell/spi/JsForgeWindowManager.kt
@@ -1,0 +1,29 @@
+package borg.trikeshed.forge.shell.spi
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.CustomEvent
+import org.w3c.dom.CustomEventInit
+import org.w3c.dom.HTMLScriptElement
+
+class JsForgeWindowManager : ForgeWindowManager {
+    override fun bind(html: String) {
+        document.body?.innerHTML = html
+    }
+
+    override fun injectScript(script: String) {
+        val scriptElement = document.createElement("script") as HTMLScriptElement
+        scriptElement.text = script
+        document.head?.appendChild(scriptElement)
+    }
+
+    override fun dispatchEvent(event: String, payload: String) {
+        val customEvent = CustomEvent(event, CustomEventInit(detail = payload))
+        window.dispatchEvent(customEvent)
+    }
+
+    override suspend fun captureSnapshot(): ByteArray {
+        // Simple no-op implementation for now since JS doesn't have a direct way to take screenshot of itself easily
+        return ByteArray(0)
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/shell/spi/JvmForgeWindowManager.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/shell/spi/JvmForgeWindowManager.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.forge.shell.spi
+
+class JvmForgeWindowManager : ForgeWindowManager {
+    override fun bind(html: String) {
+        // No-op for now
+    }
+
+    override fun injectScript(script: String) {
+        // No-op for now
+    }
+
+    override fun dispatchEvent(event: String, payload: String) {
+        // No-op for now
+    }
+
+    override suspend fun captureSnapshot(): ByteArray {
+        return ByteArray(0)
+    }
+}

--- a/src/linuxMain/kotlin/borg/trikeshed/forge/shell/spi/LinuxForgeWindowManager.kt
+++ b/src/linuxMain/kotlin/borg/trikeshed/forge/shell/spi/LinuxForgeWindowManager.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.forge.shell.spi
+
+class LinuxForgeWindowManager : ForgeWindowManager {
+    override fun bind(html: String) {
+        // No-op
+    }
+
+    override fun injectScript(script: String) {
+        // No-op
+    }
+
+    override fun dispatchEvent(event: String, payload: String) {
+        // No-op
+    }
+
+    override suspend fun captureSnapshot(): ByteArray {
+        return ByteArray(0)
+    }
+}

--- a/src/macosMain/kotlin/borg/trikeshed/forge/shell/spi/MacosForgeWindowManager.kt
+++ b/src/macosMain/kotlin/borg/trikeshed/forge/shell/spi/MacosForgeWindowManager.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.forge.shell.spi
+
+class MacosForgeWindowManager : ForgeWindowManager {
+    override fun bind(html: String) {
+        // No-op
+    }
+
+    override fun injectScript(script: String) {
+        // No-op
+    }
+
+    override fun dispatchEvent(event: String, payload: String) {
+        // No-op
+    }
+
+    override suspend fun captureSnapshot(): ByteArray {
+        return ByteArray(0)
+    }
+}

--- a/src/wasmJsMain/kotlin/borg/trikeshed/forge/shell/spi/WasmForgeWindowManager.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/forge/shell/spi/WasmForgeWindowManager.kt
@@ -1,0 +1,19 @@
+package borg.trikeshed.forge.shell.spi
+
+class WasmForgeWindowManager : ForgeWindowManager {
+    override fun bind(html: String) {
+        // No-op for now due to WasmJs interop complexities, or can add standard interop later
+    }
+
+    override fun injectScript(script: String) {
+        // No-op
+    }
+
+    override fun dispatchEvent(event: String, payload: String) {
+        // No-op
+    }
+
+    override suspend fun captureSnapshot(): ByteArray {
+        return ByteArray(0)
+    }
+}


### PR DESCRIPTION
This PR defines the `ForgeWindowManager` SPI in `commonMain` to support future UI bindings and testing frameworks across different platforms. The interface is integrated into the Kotlin Coroutine Context and includes basic, compliant stub and concrete implementations for all major targets (JS, JVM, Linux, MacOS, WASM JS). Compilation verifications have been conducted successfully across the targets.

---
*PR created automatically by Jules for task [4352604443870127161](https://jules.google.com/task/4352604443870127161) started by @jnorthrup*