### PR TITLE
🧪 [testing improvement] Enhance `toKeyPath` assertions and isolate string formatting tests

### DIFF
--- a/src/commonTest/kotlin/keymux/KeyMuxTest.kt
+++ b/src/commonTest/kotlin/keymux/KeyMuxTest.kt
@@ -49,26 +49,53 @@ class KeyMuxTest {
     @Test
     fun toKeyPath_parsesStringCorrectly() {
         val path = "a.b.c".toKeyPath()
+        assertEquals(3, path.size)
+        assertEquals("a", path[0])
+        assertEquals("b", path[1])
+        assertEquals("c", path[2])
         assertEquals(listOf("a", "b", "c"), path.iterable().toList())
-        assertEquals("a.b.c", path.asString())
-        assertEquals(listOf("single"), "single".toKeyPath().iterable().toList())
+
+        val singlePath = "single".toKeyPath()
+        assertEquals(1, singlePath.size)
+        assertEquals("single", singlePath[0])
+        assertEquals(listOf("single"), singlePath.iterable().toList())
 
         // Edge cases
         val emptyPath = "".toKeyPath()
+        assertEquals(1, emptyPath.size)
+        assertEquals("", emptyPath[0])
         assertEquals(listOf(""), emptyPath.iterable().toList())
-        assertEquals("", emptyPath.asString())
 
         val trailingPath = "a.b.".toKeyPath()
+        assertEquals(3, trailingPath.size)
+        assertEquals("a", trailingPath[0])
+        assertEquals("b", trailingPath[1])
+        assertEquals("", trailingPath[2])
         assertEquals(listOf("a", "b", ""), trailingPath.iterable().toList())
-        assertEquals("a.b.", trailingPath.asString())
 
         val leadingPath = ".a.b".toKeyPath()
+        assertEquals(3, leadingPath.size)
+        assertEquals("", leadingPath[0])
+        assertEquals("a", leadingPath[1])
+        assertEquals("b", leadingPath[2])
         assertEquals(listOf("", "a", "b"), leadingPath.iterable().toList())
-        assertEquals(".a.b", leadingPath.asString())
 
         val consecutivePath = "a..b".toKeyPath()
+        assertEquals(3, consecutivePath.size)
+        assertEquals("a", consecutivePath[0])
+        assertEquals("", consecutivePath[1])
+        assertEquals("b", consecutivePath[2])
         assertEquals(listOf("a", "", "b"), consecutivePath.iterable().toList())
-        assertEquals("a..b", consecutivePath.asString())
+    }
+
+    @Test
+    fun asString_formatsKeyPathCorrectly() {
+        assertEquals("a.b.c", "a.b.c".toKeyPath().asString())
+        assertEquals("single", "single".toKeyPath().asString())
+        assertEquals("", "".toKeyPath().asString())
+        assertEquals("a.b.", "a.b.".toKeyPath().asString())
+        assertEquals(".a.b", ".a.b".toKeyPath().asString())
+        assertEquals("a..b", "a..b".toKeyPath().asString())
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Improved the assertions and test isolation for the `toKeyPath` mapping extension in `KeyMux`.
📊 **Coverage:** Explicitly asserts indexing and `.size` for properties mapped from a string representation to a `KeyPath` object. Evaluates standard scenarios alongside established edge cases, while giving `.asString()` its own distinct test case.
✨ **Result:** A more rigorous and isolated test suite for this string-to-series mapping function that covers edge-case permutations more robustly.

---
*PR created automatically by Jules for task [11878903855081575438](https://jules.google.com/task/11878903855081575438) started by @jnorthrup*