### PR TITLE
🧹 Fix eager fd closure in readLinesSeq

### DIFF
--- a/src/linuxMain/kotlin/simple/LinuxPosixFile.kt
+++ b/src/linuxMain/kotlin/simple/LinuxPosixFile.kt
@@ -487,31 +487,57 @@ class LinuxPosixFile(
         fun exists(fname: String): Boolean = access(fname, F_OK).z
 
         /** lean on getline to read a file into a sequence of CharSeries */
-        fun readLinesSeq(path: String): Sequence<String> = memScoped {
-            val file = LinuxPosixFile(path)
-            val fp = fdopen(file.fd, "r")
-            try {
-                val line: CPointerVarOf<CPointer<ByteVarOf<Byte>>> = alloc()
-                val len: ULongVarOf<size_t> = alloc()
-                line.value = null
-                len.value = 0u
-                try {
-                    sequence {
-                        while (true) {
-                            val read = getline(line.ptr, len.ptr, fp)
-                            if (read == -1L) break
-                            yield(line.value!!.toKString().trim())
-                        }
+        fun readLinesSeq(path: String): Sequence<String> = Sequence {
+            object : Iterator<String> {
+                val file = LinuxPosixFile(path)
+                val fp = fdopen(file.fd, "r")
+                val lineArena = Arena()
+                val line: CPointerVarOf<CPointer<ByteVarOf<Byte>>> = lineArena.alloc()
+                val len: ULongVarOf<size_t> = lineArena.alloc()
+
+                init {
+                    HasPosixErr.posixRequires(fp != null) { "fdopen $path" }
+                    line.value = null
+                    len.value = 0u
+                }
+
+                var nextLine: String? = null
+                var isClosed = false
+
+                private fun fetchNext() {
+                    if (isClosed || nextLine != null) return
+                    val read = getline(line.ptr, len.ptr, fp)
+                    if (read != -1L) {
+                        nextLine = line.value!!.toKString().trim()
+                    } else {
                         if (ferror(fp) != 0) {
                             perror("ferror")
+                            close()
                             exit(1)
                         }
+                        close()
                     }
-                } finally {
-                    free(line.value)
                 }
-            } finally {
-                fclose(fp)
+
+                private fun close() {
+                    if (isClosed) return
+                    isClosed = true
+                    free(line.value)
+                    lineArena.clear()
+                    if (fp != null) fclose(fp)
+                }
+
+                override fun hasNext(): Boolean {
+                    fetchNext()
+                    return nextLine != null
+                }
+
+                override fun next(): String {
+                    fetchNext()
+                    val result = nextLine ?: throw NoSuchElementException()
+                    nextLine = null
+                    return result
+                }
             }
         }
 

--- a/src/posixMain/kotlin/simple/PosixFile.kt
+++ b/src/posixMain/kotlin/simple/PosixFile.kt
@@ -485,31 +485,57 @@ class PosixFile(
         fun exists(fname: String): Boolean = access(fname, F_OK).z
 
         /** lean on getline to read a file into a sequence of CharSeries */
-        fun readLinesSeq(path: String): Sequence<String> = memScoped {
-            val file = PosixFile(path)
-            val fp = fdopen(file.fd, "r")
-            try {
-                val line: CPointerVarOf<CPointer<ByteVarOf<Byte>>> = alloc()
-                val len: ULongVarOf<size_t> = alloc()
-                line.value = null
-                len.value = 0u
-                try {
-                    sequence {
-                        while (true) {
-                            val read = getline(line.ptr, len.ptr, fp)
-                            if (read == -1L) break
-                            yield(line.value!!.toKString().trim())
-                        }
+        fun readLinesSeq(path: String): Sequence<String> = Sequence {
+            object : Iterator<String> {
+                val file = PosixFile(path)
+                val fp = fdopen(file.fd, "r")
+                val lineArena = Arena()
+                val line: CPointerVarOf<CPointer<ByteVarOf<Byte>>> = lineArena.alloc()
+                val len: ULongVarOf<size_t> = lineArena.alloc()
+
+                init {
+                    HasPosixErr.posixRequires(fp != null) { "fdopen $path" }
+                    line.value = null
+                    len.value = 0u
+                }
+
+                var nextLine: String? = null
+                var isClosed = false
+
+                private fun fetchNext() {
+                    if (isClosed || nextLine != null) return
+                    val read = getline(line.ptr, len.ptr, fp)
+                    if (read != -1L) {
+                        nextLine = line.value!!.toKString().trim()
+                    } else {
                         if (ferror(fp) != 0) {
                             perror("ferror")
+                            close()
                             exit(1)
                         }
+                        close()
                     }
-                } finally {
-                    free(line.value)
                 }
-            } finally {
-                fclose(fp)
+
+                private fun close() {
+                    if (isClosed) return
+                    isClosed = true
+                    free(line.value)
+                    lineArena.clear()
+                    if (fp != null) fclose(fp)
+                }
+
+                override fun hasNext(): Boolean {
+                    fetchNext()
+                    return nextLine != null
+                }
+
+                override fun next(): String {
+                    fetchNext()
+                    val result = nextLine ?: throw NoSuchElementException()
+                    nextLine = null
+                    return result
+                }
             }
         }
 


### PR DESCRIPTION
🎯 **What:** Modified `readLinesSeq` in both `LinuxPosixFile.kt` and `PosixFile.kt` to use a custom Iterator pattern rather than `memScoped { sequence { ... } }`.
💡 **Why:** `Sequence` evaluation is lazy. The original code immediately closed the file descriptor (`fclose`) and freed memory in a `finally` block before the returned Sequence was iterated, leading to a crash or reading garbage.
✅ **Verification:** A custom iterator now cleanly manages the `FILE*`, `getline` buffers, and safely shuts them down upon either hitting EOF or an error, aligning with lazy sequence expectations in Kotlin/Native without leaking file descriptors.
✨ **Result:** Enhanced the safety and robustness of sequence-based file reads.

---
*PR created automatically by Jules for task [9823374582924809834](https://jules.google.com/task/9823374582924809834) started by @jnorthrup*