### PR TITLE
Unify LCNC ingest layer with ForgeKanbanIngest

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
@@ -10,6 +10,14 @@ import borg.trikeshed.dag.ReteWorkingMemory
 import borg.trikeshed.graph.CausalGraphNode
 import borg.trikeshed.graph.causalGraphNode
 import borg.trikeshed.job.ContentId
+import borg.trikeshed.lcnc.isam.LcncEntity
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.emptySeriesOf
+import borg.trikeshed.lcnc.ccek.IngestStateElement
+import borg.trikeshed.lcnc.reactor.LcncIngestPipeline
+import borg.trikeshed.lcnc.reactor.IngestSource
+import borg.trikeshed.lcnc.reactor.IngestFormat
+import borg.trikeshed.runBlocking
 
 data class ForgeKanbanCorrelation(
     val taskId: String,
@@ -25,6 +33,7 @@ data class ForgeKanbanReduction(
     val causalNodes: List<CausalGraphNode>,
     val reteFacts: List<ReteStoredFact>,
     val correlations: List<ForgeKanbanCorrelation>,
+    val lcncEntities: Series<LcncEntity> = emptySeriesOf(),
 )
 
 private data class SourceTask(
@@ -53,11 +62,11 @@ object ForgeKanbanIngest {
         val markdown = borg.trikeshed.common.Files.readString(markdownPath)
         val source = ForgeBoardPersistence.source(userId, markdown, markdownPath)
         ForgeBoardPersistence.persist(source).getOrThrow()
-        return reduce(source)
+        return reduce(source, markdown.encodeToByteArray())
     }
 
     fun load(userId: String): ForgeKanbanReduction =
-        reduce(ForgeBoardPersistence.load(userId).getOrThrow())
+        reduce(ForgeBoardPersistence.load(userId).getOrThrow(), null)
 
     /**
      * Browser-safe fallback — builds a minimal reduction entirely in memory
@@ -88,10 +97,19 @@ object ForgeKanbanIngest {
             """.trimIndent(),
             contentId = "fallback",
         )
-        return reduce(source)
+        return reduce(source, null)
     }
 
-    fun reduce(source: ForgeKanbanSource): ForgeKanbanReduction {
+    fun reduce(source: ForgeKanbanSource, rawBytes: ByteArray? = null): ForgeKanbanReduction {
+        val bytesToParse = rawBytes ?: source.description.encodeToByteArray()
+        val stateElement = IngestStateElement("run-${source.contentId}")
+        val pipeline = LcncIngestPipeline(stateElement)
+        val lcncEntities = runBlocking {
+            val entities = pipeline.decode(IngestSource.FileStream(bytesToParse), IngestFormat.MARKDOWN)
+            pipeline.drain()
+            pipeline.close()
+            entities
+        }
         val tasks = parseWorkPackages(source.description)
         require(tasks.isNotEmpty()) { "no work packages found in source description" }
         require(tasks.map { it.id }.toSet().size == tasks.size) { "duplicate work package id" }
@@ -230,6 +248,7 @@ object ForgeKanbanIngest {
             causalNodes = causalNodes,
             reteFacts = taskFacts + dependencyFacts,
             correlations = correlations,
+            lcncEntities = lcncEntities,
         )
     }
 

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/ccek/IngestStateElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/ccek/IngestStateElement.kt
@@ -23,12 +23,18 @@ class IngestStateElement(
     // In a real system, this might use a mutable thread-safe structure or Channel.
     private val parsedEntities = mutableListOf<LcncEntity>()
 
+    var lifecycleState: borg.trikeshed.lcnc.reactor.IngestLifecycle = borg.trikeshed.lcnc.reactor.IngestLifecycle.CREATED
+        private set
+
     /**
      * Called by codecs to publish a newly parsed entity into the context scope.
      */
     fun publishEntity(entity: LcncEntity) {
         parsedEntities.add(entity)
-        // Here we could fan out to a PointcutEventProducer or other bus
+    }
+
+    fun transition(state: borg.trikeshed.lcnc.reactor.IngestLifecycle) {
+        lifecycleState = state
     }
 
     /**

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/IngestCodec.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/IngestCodec.kt
@@ -29,14 +29,6 @@ enum class IngestFormat {
 /**
  * A codec capable of decoding an IngestSource into Lcnc entities.
  * In the Reactor model, this can be an asynchronous operation yielding events.
- *
- * Concrete implementations (notably [LcncIngestPipeline]) override
- * [decode] to dispatch on [source] / [format]. The default body
- * here is intentionally non-empty so the symbol resolves to a
- * single concrete signature even when callers treat the interface as
- * an event-streaming point: implementations that don't need
- * reactor lifecycle may simply return [emptySeriesOf] and let
- * downstream pipelines handle the empty Series.
  */
 interface IngestCodec {
     val supportedFormats: Set<IngestFormat>
@@ -44,25 +36,12 @@ interface IngestCodec {
     /**
      * Parses the source and emits a Series of parsed Lcnc entities.
      * In a full reactive implementation, this might return a Flow or emit via CCEK.
-     *
-     * Default body: returns an empty [Series] when [format] isn't in
-     * [supportedFormats]; otherwise delegates to [decodeText], which
-     * subclasses override. Real-world codecs override this directly.
      */
-    suspend fun decode(source: IngestSource, format: IngestFormat): Series<LcncEntity> {
-        if (format !in supportedFormats) return emptySeriesOf()
-        val text = when (source) {
-            is IngestSource.Paste -> source.content
-            is IngestSource.FileStream -> source.data.decodeToString()
-            is IngestSource.Link -> source.uri
-        }
-        return decodeText(text, format)
-    }
+    suspend fun decode(source: IngestSource, format: IngestFormat): Series<LcncEntity>
 
     /**
      * Subclass hook. Receives already-materialized text bytes; emits
-     * the parsed entities as a [Series]. Default returns an empty series.
+     * the parsed entities as a [Series].
      */
-    suspend fun decodeText(text: String, format: IngestFormat): Series<LcncEntity> =
-        emptySeriesOf()
+    suspend fun decodeText(text: String, format: IngestFormat): Series<LcncEntity>
 }

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/LcncIngestPipeline.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/LcncIngestPipeline.kt
@@ -139,8 +139,12 @@ class LcncIngestPipeline(
         fanoutScope.launch {
             try {
                 channel.consumeEach { action ->
-                    if (action is ReactorAction.PublishEntity) {
-                        state.publishEntity(action.entity)
+                    when (action) {
+                        is ReactorAction.PublishEntity -> state.publishEntity(action.entity)
+                        is ReactorAction.Opened -> state.transition(IngestLifecycle.OPEN)
+                        is ReactorAction.Activated -> state.transition(IngestLifecycle.ACTIVE)
+                        is ReactorAction.Draining -> state.transition(IngestLifecycle.DRAINING)
+                        is ReactorAction.Closed -> state.transition(IngestLifecycle.CLOSED)
                     }
                 }
             } finally {
@@ -195,6 +199,10 @@ class LcncIngestPipeline(
         }
 
         return entities.size j { i -> entities[i] }
+    }
+
+    override suspend fun decodeText(text: String, format: IngestFormat): Series<LcncEntity> {
+        return decode(IngestSource.Paste(text), format)
     }
 
     /** Stop accepting new work; transition ACTIVE → DRAINING. */

--- a/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestTest.kt
@@ -46,7 +46,8 @@ class ForgeKanbanIngestTest {
     @Test
     fun ingestReducesHermesStyleTasksLinksReteCorrelationsAndCausality() {
         val reduction = ForgeKanbanIngest.reduce(
-            ForgeBoardPersistence.source("jim", markdown, "/tmp/hi")
+            ForgeBoardPersistence.source("jim", markdown, "/tmp/hi"),
+            markdown.encodeToByteArray()
         )
 
         assertEquals(listOf("G0", "F0", "S1"), reduction.board.cards.map { it.id.value })
@@ -64,5 +65,6 @@ class ForgeKanbanIngestTest {
         assertEquals(2, reduction.reteFacts.count { it.fields["kind"] == "link" })
         assertEquals(listOf("G0"), reduction.causalNodes.first { it.nodeId == "F0" }.parentNodeIds)
         assertEquals(f0.causalKey, reduction.causalNodes.first { it.nodeId == "F0" }.causalKey)
+        assertTrue(reduction.lcncEntities.size > 0, "LCNC entities should not be empty")
     }
 }


### PR DESCRIPTION
This submission wires the LcncIngestPipeline into the ForgeKanbanIngest process. It modifies `ForgeKanbanReduction` to accept the produced `Series<LcncEntity>`, replacing the default empty series. It also removes the empty default body from `IngestCodec` forcing actual implementations. Lastly, it wires `IngestStateElement` to consume and mirror lifecycle events from the `LcncIngestPipeline` so its state matches CREATED->OPEN->ACTIVE->DRAINING->CLOSED over time without manual accumulation loops. Tests pass for JVM targets.

---
*PR created automatically by Jules for task [5250342011519026500](https://jules.google.com/task/5250342011519026500) started by @jnorthrup*