### PR TITLE
feat: native volume backend with liburing fallback

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/volume/BlockArray.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/volume/BlockArray.kt
@@ -1,0 +1,16 @@
+package borg.trikeshed.userspace.volume
+
+class BlockArray(val volume: Volume, val startLba: Long, val endLba: Long) {
+    suspend fun read(index: Long): ByteArray {
+        val lba = startLba + index
+        if (lba >= endLba) throw IndexOutOfBoundsException("LBA $lba out of bounds")
+        return volume.read(lba, 1)
+    }
+
+    suspend fun write(index: Long, data: ByteArray) {
+        val lba = startLba + index
+        if (lba >= endLba) throw IndexOutOfBoundsException("LBA $lba out of bounds")
+        if (data.size != volume.blockSize) throw IllegalArgumentException("Data size must match blockSize")
+        volume.write(lba, data)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/volume/BootBlock.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/volume/BootBlock.kt
@@ -1,0 +1,12 @@
+package borg.trikeshed.userspace.volume
+
+class BootBlock(val volume: Volume) {
+    suspend fun read(): ByteArray {
+        return volume.read(0, 1)
+    }
+
+    suspend fun write(data: ByteArray) {
+        if (data.size != volume.blockSize) throw IllegalArgumentException("Data size must match blockSize")
+        volume.write(0, data)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/volume/Volume.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/volume/Volume.kt
@@ -1,0 +1,10 @@
+package borg.trikeshed.userspace.volume
+
+interface Volume {
+    val blockSize: Int
+    val capacity: Long
+
+    suspend fun read(lba: Long, count: Int): ByteArray
+    suspend fun write(lba: Long, data: ByteArray)
+    suspend fun sync()
+}

--- a/src/linuxMain/kotlin/borg/trikeshed/userspace/volume/LiburingVolume.kt
+++ b/src/linuxMain/kotlin/borg/trikeshed/userspace/volume/LiburingVolume.kt
@@ -1,0 +1,21 @@
+package borg.trikeshed.userspace.volume
+
+class LiburingVolume(val path: String, override val blockSize: Int = 4096) : Volume {
+    // Falls back to PosixVolume due to missing io_uring integration in target platform test setup.
+    private val posixVolume = PosixVolume(path, blockSize)
+
+    override val capacity: Long
+        get() = posixVolume.capacity
+
+    override suspend fun read(lba: Long, count: Int): ByteArray {
+        return posixVolume.read(lba, count)
+    }
+
+    override suspend fun write(lba: Long, data: ByteArray) {
+        posixVolume.write(lba, data)
+    }
+
+    override suspend fun sync() {
+        posixVolume.sync()
+    }
+}

--- a/src/nativeTest/kotlin/borg/trikeshed/userspace/volume/NativeVolumeTest.kt
+++ b/src/nativeTest/kotlin/borg/trikeshed/userspace/volume/NativeVolumeTest.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.userspace.volume
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+class NativeVolumeTest {
+    @Test
+    fun testPosixVolume() = runBlocking {
+        val path = "test_posix_volume.bin"
+        val volume = PosixVolume(path, blockSize = 512)
+
+        val testData = ByteArray(512) { it.toByte() }
+        volume.write(0, testData)
+        volume.sync()
+
+        val readData = volume.read(0, 1)
+        assertEquals(512, readData.size)
+        for (i in 0 until 512) {
+            assertEquals(testData[i], readData[i])
+        }
+
+        platform.posix.remove(path)
+    }
+}

--- a/src/posixMain/kotlin/borg/trikeshed/userspace/volume/PosixVolume.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/userspace/volume/PosixVolume.kt
@@ -1,0 +1,60 @@
+package borg.trikeshed.userspace.volume
+
+import borg.trikeshed.userspace.nio.file.spi.PosixFileOperations
+import platform.posix.*
+import kotlinx.cinterop.*
+
+class PosixVolume(val path: String, override val blockSize: Int = 4096) : Volume {
+    private val fileOps = PosixFileOperations()
+    private var fd: Int = -1
+
+    init {
+        fd = fileOps.open(path, readOnly = false)
+        if (fd < 0) {
+            val file = fopen(path, "wb")
+            if (file != null) {
+                fclose(file)
+            }
+            fd = fileOps.open(path, readOnly = false)
+            if (fd < 0) {
+                throw RuntimeException("Failed to open or create file $path")
+            }
+        }
+    }
+
+    override val capacity: Long
+        get() = fileOps.size(fd) / blockSize
+
+    override suspend fun read(lba: Long, count: Int): ByteArray {
+        val offset = lba * blockSize
+        val bytesToRead = count * blockSize
+        val buf = ByteArray(bytesToRead)
+
+        memScoped {
+            val result = pread(fd, buf.refTo(0), bytesToRead.convert(), offset.convert())
+            if (result < 0L) {
+                throw RuntimeException("pread failed: $result")
+            }
+        }
+        return buf
+    }
+
+    override suspend fun write(lba: Long, data: ByteArray) {
+        val offset = lba * blockSize
+        val bytesToWrite = data.size
+
+        memScoped {
+            val result = pwrite(fd, data.refTo(0), bytesToWrite.convert(), offset.convert())
+            if (result < 0L) {
+                throw RuntimeException("pwrite failed: $result")
+            }
+        }
+    }
+
+    override suspend fun sync() {
+        val result = fsync(fd)
+        if (result < 0) {
+            throw RuntimeException("fsync failed: $result")
+        }
+    }
+}


### PR DESCRIPTION
Implement native `Volume` backend with `PosixVolume` using `PosixFileOperations`. Provide `LiburingVolume` for Linux which acts as a fallback to `PosixVolume` due to broken `linux_uring` cinterop in this branch. Included tests in `nativeTest` that verify read and write block operations correctly. Addressed code review feedback to use synchronous blocking inside `PosixVolume` rather than `suspendCoroutine`, and correctly format runtime exception messages.

---
*PR created automatically by Jules for task [14987125133351475353](https://jules.google.com/task/14987125133351475353) started by @jnorthrup*