### PR TITLE
Add `navigate` primitive to `TreeCursor`

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cursor/TreeCursor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cursor/TreeCursor.kt
@@ -10,4 +10,12 @@ data class TreeCursor(
             yieldAll(child.flatten())
         }
     }
+
+    fun navigate(path: IntArray): TreeCursor {
+        var current = this
+        for (index in path) {
+            current = current.children.elementAt(index)
+        }
+        return current
+    }
 }

--- a/src/commonTest/kotlin/borg/trikeshed/cursor/TreeCursorTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/cursor/TreeCursorTest.kt
@@ -1,0 +1,53 @@
+package borg.trikeshed.cursor
+
+import borg.trikeshed.lib.j
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TreeCursorTest {
+
+    private fun dummyRow(id: Int): RowVec {
+        val meta: () -> ColumnMeta = { ColumnMeta("id", IOMemento.IoInt) }
+        return 1 j { id j meta }
+    }
+
+    @Test
+    fun `navigate descends into children based on path`() {
+        val leaf1 = TreeCursor(row = dummyRow(3))
+        val leaf2 = TreeCursor(row = dummyRow(4))
+
+        val child1 = TreeCursor(
+            row = dummyRow(1),
+            children = sequenceOf(leaf1, leaf2)
+        )
+
+        val child2 = TreeCursor(
+            row = dummyRow(2)
+        )
+
+        val root = TreeCursor(
+            row = dummyRow(0),
+            children = sequenceOf(child1, child2)
+        )
+
+        val target = root.navigate(intArrayOf(0, 1))
+
+        assertEquals(4, target.row.b(0).a, "Should navigate to leaf2 which has id=4")
+    }
+
+    @Test
+    fun `navigate returns this for empty path`() {
+        val root = TreeCursor(row = dummyRow(0))
+        val target = root.navigate(intArrayOf())
+        assertEquals(root, target)
+    }
+
+    @Test
+    fun `navigate throws on out of bounds path`() {
+        val root = TreeCursor(row = dummyRow(0))
+        assertFailsWith<IndexOutOfBoundsException> {
+            root.navigate(intArrayOf(0))
+        }
+    }
+}


### PR DESCRIPTION
Implements a `navigate(path: IntArray)` primitive on `TreeCursor` as specified by the rescoped T-TASTE-6 requirements. Included a unit test to verify path resolution for deeply nested nodes.

---
*PR created automatically by Jules for task [12831915021650895622](https://jules.google.com/task/12831915021650895622) started by @jnorthrup*