### PR TITLE
Refactor Forge lcncEntities to use typed LcncBlock content

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
@@ -298,18 +298,7 @@ private fun defaultForgeAppState(): ForgeAppState {
         // Legacy DTO view retained unchanged for existing seed consumers.
         lcncEntities = reduction.correlations.map { correlation ->
             val card = board.cards.first { it.id.value == correlation.taskId }
-            borg.trikeshed.lcnc.isam.LcncBlock(
-                id = "task:${correlation.taskId}",
-                type = "work-package",
-                parentId = null,
-                content = mapOf(
-                    "lane" to card.columnId.value,
-                    "facet" to if (correlation.ready) "ready" else "dependency-gated",
-                    "causalKey" to correlation.causalKey,
-                    "title" to card.title,
-                    "description" to card.description,
-                )
-            )
+            correlationToBlock(correlation, card)
         },
         blackboardId = board.id.value,
         surfaceRows = surface.rows,
@@ -370,15 +359,14 @@ private fun ForgeAppState.toJsonValue(): Map<String, Any?> = linkedMapOf(
         )
     },
     "lcncEntities" to lcncEntities.map {
-        val content = it.content as? Map<*, *>
         linkedMapOf(
             "entityId" to it.id,
             "lcncKind" to it.type,
-            "lane" to content?.get("lane"),
-            "facet" to content?.get("facet"),
-            "causalKey" to content?.get("causalKey"),
-            "title" to content?.get("title"),
-            "description" to content?.get("description"),
+            "lane" to it.lane,
+            "facet" to it.facet,
+            "causalKey" to it.causalKey,
+            "title" to it.title,
+            "description" to it.description,
         )
     },
     "blackboardId" to blackboardId,

--- a/src/commonMain/kotlin/borg/trikeshed/forge/forgeAppStateLcnc.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/forgeAppStateLcnc.kt
@@ -1,0 +1,34 @@
+package borg.trikeshed.forge
+
+import borg.trikeshed.kanban.ForgeKanbanCorrelation
+import borg.trikeshed.kanban.KanbanCard
+import borg.trikeshed.lcnc.isam.LcncBlock
+
+data class LcncWorkPackageContent(
+    val lane: String,
+    val facet: String,
+    val causalKey: String,
+    val title: String,
+    val description: String
+)
+
+val LcncBlock.lane: String? get() = (content as? LcncWorkPackageContent)?.lane
+val LcncBlock.facet: String? get() = (content as? LcncWorkPackageContent)?.facet
+val LcncBlock.causalKey: String? get() = (content as? LcncWorkPackageContent)?.causalKey
+val LcncBlock.title: String? get() = (content as? LcncWorkPackageContent)?.title
+val LcncBlock.description: String? get() = (content as? LcncWorkPackageContent)?.description
+
+fun correlationToBlock(correlation: ForgeKanbanCorrelation, card: KanbanCard): LcncBlock {
+    return LcncBlock(
+        id = "task:${correlation.taskId}",
+        type = "work-package",
+        parentId = null,
+        content = LcncWorkPackageContent(
+            lane = card.columnId.value,
+            facet = if (correlation.ready) "ready" else "dependency-gated",
+            causalKey = correlation.causalKey,
+            title = card.title,
+            description = card.description,
+        )
+    )
+}


### PR DESCRIPTION
Resolves T-KANBAN-LCNC-2 by replacing the raw `Map<String, Any?>` structure used in `ForgeApp.lcncEntities` construction with a typed representation, preserving the serialized contract without modifying the canonical generic `LcncBlock` type.

---
*PR created automatically by Jules for task [4351332426928572405](https://jules.google.com/task/4351332426928572405) started by @jnorthrup*