### PR TITLE
Typed LcncWorkPackageContent for ForgeApp

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
@@ -298,18 +298,7 @@ private fun defaultForgeAppState(): ForgeAppState {
         // Legacy DTO view retained unchanged for existing seed consumers.
         lcncEntities = reduction.correlations.map { correlation ->
             val card = board.cards.first { it.id.value == correlation.taskId }
-            borg.trikeshed.lcnc.isam.LcncBlock(
-                id = "task:${correlation.taskId}",
-                type = "work-package",
-                parentId = null,
-                content = mapOf(
-                    "lane" to card.columnId.value,
-                    "facet" to if (correlation.ready) "ready" else "dependency-gated",
-                    "causalKey" to correlation.causalKey,
-                    "title" to card.title,
-                    "description" to card.description,
-                )
-            )
+            correlationToBlock(correlation, card)
         },
         blackboardId = board.id.value,
         surfaceRows = surface.rows,
@@ -370,15 +359,14 @@ private fun ForgeAppState.toJsonValue(): Map<String, Any?> = linkedMapOf(
         )
     },
     "lcncEntities" to lcncEntities.map {
-        val content = it.content as? Map<*, *>
         linkedMapOf(
             "entityId" to it.id,
             "lcncKind" to it.type,
-            "lane" to content?.get("lane"),
-            "facet" to content?.get("facet"),
-            "causalKey" to content?.get("causalKey"),
-            "title" to content?.get("title"),
-            "description" to content?.get("description"),
+            "lane" to it.lane,
+            "facet" to it.facet,
+            "causalKey" to it.causalKey,
+            "title" to it.title,
+            "description" to it.description,
         )
     },
     "blackboardId" to blackboardId,

--- a/src/commonMain/kotlin/borg/trikeshed/forge/forgeAppStateLcnc.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/forgeAppStateLcnc.kt
@@ -1,0 +1,49 @@
+package borg.trikeshed.forge
+
+import borg.trikeshed.kanban.ForgeKanbanCorrelation
+import borg.trikeshed.kanban.KanbanCard
+import borg.trikeshed.lcnc.isam.LcncBlock
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface LcncBlockContent
+
+@Serializable
+data class LcncWorkPackageContent(
+    val lane: String,
+    val facet: String,
+    val causalKey: String,
+    val title: String,
+    val description: String
+) : LcncBlockContent
+
+val LcncBlock.lane: String?
+    get() = (content as? LcncWorkPackageContent)?.lane ?: (content as? Map<*, *>)?.get("lane") as? String
+
+val LcncBlock.facet: String?
+    get() = (content as? LcncWorkPackageContent)?.facet ?: (content as? Map<*, *>)?.get("facet") as? String
+
+val LcncBlock.causalKey: String?
+    get() = (content as? LcncWorkPackageContent)?.causalKey ?: (content as? Map<*, *>)?.get("causalKey") as? String
+
+val LcncBlock.title: String?
+    get() = (content as? LcncWorkPackageContent)?.title ?: (content as? Map<*, *>)?.get("title") as? String
+
+val LcncBlock.description: String?
+    get() = (content as? LcncWorkPackageContent)?.description ?: (content as? Map<*, *>)?.get("description") as? String
+
+fun correlationToBlock(correlation: ForgeKanbanCorrelation, card: KanbanCard): LcncBlock {
+    return LcncBlock(
+        id = "task:${correlation.taskId}",
+        type = "work-package",
+        parentId = null,
+        content = LcncWorkPackageContent(
+            lane = card.columnId.value,
+            facet = if (correlation.ready) "ready" else "dependency-gated",
+            causalKey = correlation.causalKey,
+            title = card.title,
+            description = card.description
+        )
+    )
+}


### PR DESCRIPTION
Replaces the raw Map used for `content` in `LcncBlock` within `ForgeApp.kt` with a strongly typed `LcncWorkPackageContent` class that correctly handles Kotlin serialization via `@Serializable`. A new file `forgeAppStateLcnc.kt` is added containing the typed extensions for `LcncBlock` and a `correlationToBlock` helper function.

---
*PR created automatically by Jules for task [15103290226454989785](https://jules.google.com/task/15103290226454989785) started by @jnorthrup*