### PR TITLE
Implement T-REWIRE-3 cuts 1 and 7

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -500,3 +500,22 @@ under one `project(cid)` path.
     zero heap allocation on the read path.
 
 ## DRY / PRELOAD cuts already shipped (Jul 2026 audit pass)
+
+## T-REWIRE-3 Follow-up Cuts (from doc/rewire.md §9)
+
+These are the separated follow-up tasks from T-REWIRE-3 (Cuts 1 and 7 landed in T-REWIRE-3).
+
+- [ ] **T-REWIRE-3b. Modelmux kanban agent**
+  JobCommand handler routing cards through modelmux.
+
+- [ ] **T-REWIRE-3c. UPnP workspace discovery**
+  Workspace announce payload over mDNS/SSDP.
+
+- [ ] **T-REWIRE-3d. SSH mesh transport**
+  SSH tunnel over litebike Tls carrying Confix docs.
+
+- [ ] **T-REWIRE-3e. IPFS/IPNS bridge**
+  CAS blocks as IPFS blocks, IPNS names = manifest CIDs.
+
+- [ ] **T-REWIRE-3f. Progressive rendering**
+  Jules jobs reading TreeDoc archives into ForgeDoc.

--- a/src/commonMain/kotlin/borg/trikeshed/collections/btree/CowBPlusTree.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/collections/btree/CowBPlusTree.kt
@@ -426,4 +426,61 @@ class CowBPlusTree(
             }
         }
     }
+
+    /**
+     * Freeze the current root into an immutable snapshot.
+     * Since the tree is already COW, this just returns the CID.
+     */
+    fun snapshot(rootCid: ContentId): ContentId {
+        return rootCid
+    }
+
+    /**
+     * Serializes a delta between two CIDs. Returns a list of serialized blocks
+     * (the nodes reachable from `toCid` that are not reachable from `fromCid`).
+     */
+    fun send(fromCid: ContentId?, toCid: ContentId): List<ByteArray> {
+        val fromNodes = mutableSetOf<ContentId>()
+        if (fromCid != null) {
+            fun collectFrom(cid: ContentId) {
+                if (!fromNodes.add(cid)) return
+                val node = loadNode(cid)
+                if (node is BTreeNode.Internal) {
+                    for (child in node.children) {
+                        collectFrom(child)
+                    }
+                }
+            }
+            collectFrom(fromCid)
+        }
+
+        val delta = mutableListOf<ByteArray>()
+        fun collectTo(cid: ContentId) {
+            if (fromNodes.contains(cid)) return
+            val bytes = casStore.get(cid) ?: throw IllegalStateException("Node not found: $cid")
+            val node = CowBPlusTreeCodec.decode(bytes)
+            if (node is BTreeNode.Internal) {
+                for (child in node.children) {
+                    collectTo(child)
+                }
+            }
+            delta.add(bytes)
+        }
+        collectTo(toCid)
+        return delta
+    }
+
+    /**
+     * Applies a serialized delta to the target tree (inserts blocks into the CAS).
+     * The last block is typically the root of the delta, but we just insert all
+     * blocks into the CAS. Returns the ContentId of the last block inserted.
+     */
+    fun recv(delta: List<ByteArray>): ContentId {
+        require(delta.isNotEmpty()) { "Delta cannot be empty" }
+        var lastCid: ContentId? = null
+        for (bytes in delta) {
+            lastCid = casStore.put(bytes)
+        }
+        return lastCid!!
+    }
 }

--- a/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
@@ -56,6 +56,17 @@ object ForgeKanbanIngest {
         return reduce(source)
     }
 
+    fun persistArchive(userId: String, archive: borg.trikeshed.lib.Series<Any?>, pipeline: borg.trikeshed.treedoc.TreeDocPipeline): ForgeKanbanReduction {
+        val documents = archive.b(borg.trikeshed.treedoc.TreeDocK.Documents.ordinal) as borg.trikeshed.cursor.Cursor
+        val allMarkdown = StringBuilder()
+        for (i in 0 until documents.a) {
+            val bytes = pipeline.restoreDocument(archive, i)
+            allMarkdown.append(bytes.decodeToString()).append("\n\n")
+        }
+        val source = ForgeBoardPersistence.source(userId, allMarkdown.toString(), "archive:${(archive.b(borg.trikeshed.treedoc.TreeDocK.ArchiveId.ordinal) as borg.trikeshed.job.ContentId).value}")
+        return reduce(source)
+    }
+
     fun load(userId: String): ForgeKanbanReduction =
         reduce(ForgeBoardPersistence.load(userId).getOrThrow())
 

--- a/src/commonTest/kotlin/borg/trikeshed/collections/btree/CowBPlusTreeBtrfsTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/collections/btree/CowBPlusTreeBtrfsTest.kt
@@ -1,0 +1,52 @@
+package borg.trikeshed.collections.btree
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.job.JobId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class CowBPlusTreeBtrfsTest {
+
+    @Test
+    fun testSnapshotSendRecv() {
+        val cas1 = CasStore.inMemory()
+        val tree1 = CowBPlusTree(cas1, maxDegree = 3)
+
+        var root1: ContentId? = null
+        for (i in 1..5) {
+            val key = BTreeKey("f1", byteArrayOf(i.toByte()), JobId.of("j1"), i.toLong())
+            val value = BTreeValue(ContentId("sha256:00000000000000000000000000000000000000000000000000000000000000" + i.toString().padStart(2, '0')), i.toLong())
+            root1 = tree1.insert(root1, key, value)
+        }
+
+        val snapshot1 = tree1.snapshot(root1!!)
+
+        var root2 = snapshot1
+        for (i in 6..10) {
+            val key = BTreeKey("f1", byteArrayOf(i.toByte()), JobId.of("j1"), i.toLong())
+            val value = BTreeValue(ContentId("sha256:00000000000000000000000000000000000000000000000000000000000000" + i.toString().padStart(2, '0')), i.toLong())
+            root2 = tree1.insert(root2, key, value)
+        }
+
+        val snapshot2 = tree1.snapshot(root2)
+
+        val delta = tree1.send(snapshot1, snapshot2)
+
+        val cas2 = CasStore.inMemory()
+        val tree2 = CowBPlusTree(cas2, maxDegree = 3)
+
+        val delta0 = tree1.send(null, snapshot1)
+        val recvSnapshot1 = tree2.recv(delta0)
+
+        assertEquals(snapshot1, recvSnapshot1)
+
+        val recvSnapshot2 = tree2.recv(delta)
+        assertEquals(snapshot2, recvSnapshot2)
+
+        val val10 = tree2.get(recvSnapshot2, BTreeKey("f1", byteArrayOf(10.toByte()), JobId.of("j1"), 10L))
+        assertNotNull(val10)
+        assertEquals(10L, val10.sequence)
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestArchiveTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestArchiveTest.kt
@@ -1,0 +1,54 @@
+package borg.trikeshed.kanban
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.lib.seriesOf
+import borg.trikeshed.treedoc.TreeDocPipeline
+import borg.trikeshed.treedoc.TreeDocument
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ForgeKanbanIngestArchiveTest {
+    private val markdown1 = """
+        TARGET: Target One
+
+        6. Work packages
+
+        A1 — First task
+        Objective
+
+        Make the graph real.
+    """.trimIndent()
+
+    private val markdown2 = """
+        TARGET: Target Two
+
+        6. Work packages
+
+        B1 — Second task
+        Depends on: A1.
+
+        Prove one vertical cut.
+
+        7. Production-rule behavior tied to Kanban
+    """.trimIndent()
+
+    @Test
+    fun ingestReducesArchive() {
+        val cas = CasStore.inMemory()
+        val pipeline = TreeDocPipeline(cas, 1024)
+        val docs = seriesOf(listOf(
+            TreeDocument("doc1.md", "text/markdown", markdown1.encodeToByteArray()),
+            TreeDocument("doc2.md", "text/markdown", markdown2.encodeToByteArray())
+        ))
+
+        val archive = pipeline.store(docs)
+
+        val reduction = ForgeKanbanIngest.persistArchive("jim", archive, pipeline)
+
+        assertEquals(listOf("A1", "B1"), reduction.board.cards.map { it.id.value })
+        assertEquals("ready", reduction.board.cards.first { it.id.value == "A1" }.columnId.value)
+        assertEquals("todo", reduction.board.cards.first { it.id.value == "B1" }.columnId.value)
+        assertEquals(listOf("A1"), reduction.board.cards.first { it.id.value == "B1" }.dependencies.map { it.value })
+    }
+}


### PR DESCRIPTION
This PR fulfills the instructions for T-REWIRE-3 by completing cut 1 and cut 7.

1. **Confix ingest adapter:** Extended `ForgeKanbanIngest` to parse `TreeDoc` archives and added a test `ForgeKanbanIngestArchiveTest.kt`.
2. **btrfs snapshot/restore:** Extended `CowBPlusTree` with `snapshot`, `send`, and `recv` functionality for CIDs, along with a test `CowBPlusTreeBtrfsTest.kt`.
3. **Follow-ups:** Added the remaining 5 cuts as follow-up tasks to `doc/todo.md`.
4. Addressed feedback by not deleting any unrelated pre-existing failing test files, while ensuring the modified target tests pass successfully.

---
*PR created automatically by Jules for task [17044315937086926031](https://jules.google.com/task/17044315937086926031) started by @jnorthrup*