### PR TITLE
Refactor LcncFanoutElement to extend NuidFanoutElement and extract ReducerRegistry

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
@@ -1,44 +1,22 @@
 package borg.trikeshed.context.lcnc
 
-import borg.trikeshed.context.AsyncContextElement
 import borg.trikeshed.context.AsyncContextKey
-import borg.trikeshed.context.ElementState
-import borg.trikeshed.context.nuid.Capability
 import borg.trikeshed.context.nuid.Nuid
 import borg.trikeshed.context.nuid.NuidFanoutElement
-import borg.trikeshed.lcnc.reduction.LcncCarrierAlg
-import borg.trikeshed.lcnc.reduction.LcncReduction
-import borg.trikeshed.lcnc.reduction.LcncReductions
+import borg.trikeshed.lcnc.reduction.ReducerRegistry
 import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
 
 class LcncFanoutElement(
-    private val nuidFanout: NuidFanoutElement,
-    private val reducerRegistry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
-        "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),
-        "cas" to LcncReductions.confixParse(),
-        "wireproto" to LcncReductions.crmsFold()
-    ),
     parentJob: Job? = null
-) : AsyncContextElement(ElementState.CREATED, parentJob) {
+) : NuidFanoutElement(parentJob) {
 
     companion object Key : AsyncContextKey<LcncFanoutElement>()
-    override val key: AsyncContextKey<LcncFanoutElement> = Key
+    override val key: CoroutineContext.Key<*> = Key
 
     suspend fun dispatch(nuid: Nuid, payload: Any?): Any? {
-        val winningCapability = nuidFanout.claimWinnerCapability(nuid, payload)
+        val winningCapability = claimWinnerCapability(nuid, payload)
             ?: return null
-        val reduction = reducerRegistry[winningCapability.category] ?: return null
-
-        @Suppress("UNCHECKED_CAST")
-        val typedReduction = reduction as LcncReduction<Any, Any, Any, Any>
-        val typedCarrierAlg = typedReduction.carrierAlg
-
-        val carrier = if (payload != null) {
-            typedCarrierAlg.carrier(payload)
-        } else {
-            borg.trikeshed.lcnc.reduction.emptySeriesCarrier()
-        }
-
-        return typedReduction.execute(carrier)
+        return ReducerRegistry.runFor(winningCapability, payload)
     }
 }

--- a/src/commonMain/kotlin/borg/trikeshed/context/nuid/NuidFanoutElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/nuid/NuidFanoutElement.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.yield
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.TimeSource
 
 /**
@@ -47,13 +48,13 @@ import kotlin.time.TimeSource
  *   DRAINING  ⇒ registry frozen; no new dispatches; in-flight claims finish.
  *   CLOSED    ⇒ registry empty; supervisor cancelled.
  */
-class NuidFanoutElement(
+open class NuidFanoutElement(
     parentJob: Job? = null,
     val escalationBudget: Int = 3,
 ) : AsyncContextElement(ElementState.CREATED, parentJob) {
 
     companion object Key : AsyncContextKey<NuidFanoutElement>()
-    override val key: AsyncContextKey<NuidFanoutElement> = Key
+    override open val key: CoroutineContext.Key<*> = Key
 
     /** Per-workgroup claim slot. Claim intake belongs to the dispatcher;
      *  production workers receive accepted claims through [consume]. */

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
@@ -1,0 +1,27 @@
+package borg.trikeshed.lcnc.reduction
+
+import borg.trikeshed.context.nuid.Capability
+
+object ReducerRegistry {
+    var registry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
+        "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),
+        "cas" to LcncReductions.confixParse(),
+        "wireproto" to LcncReductions.crmsFold()
+    )
+
+    fun runFor(winningCapability: Capability, payload: Any?): Any? {
+        val reduction = registry[winningCapability.category] ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val typedReduction = reduction as LcncReduction<Any, Any, Any, Any>
+        val typedCarrierAlg = typedReduction.carrierAlg
+
+        val carrier = if (payload != null) {
+            typedCarrierAlg.carrier(payload)
+        } else {
+            emptySeriesCarrier()
+        }
+
+        return typedReduction.execute(carrier)
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
@@ -21,8 +21,8 @@ class LcncFanoutElementTest {
 
     @Test
     fun testDispatchCallsReducerRegistryWithWinningCapability() = runTest {
-        val nuidFanout = NuidFanoutElement()
-        nuidFanout.open()
+        val lcncFanout = LcncFanoutElement()
+        lcncFanout.open()
 
         val processWorkgroup = Workgroup(
             name = "process-worker",
@@ -36,8 +36,8 @@ class LcncFanoutElementTest {
             traits = TraitSpace { 1 j { Capability.Cas("test_cas") } }
         )
 
-        nuidFanout.register(processWorkgroup)
-        nuidFanout.register(casWorkgroup)
+        lcncFanout.register(processWorkgroup)
+        lcncFanout.register(casWorkgroup)
 
         var runForCalled = false
 
@@ -62,14 +62,14 @@ class LcncFanoutElementTest {
 
         val stubRegistry = mapOf("process" to stubReduction)
 
-        val lcncFanout = LcncFanoutElement(nuidFanout, stubRegistry)
-        lcncFanout.open()
+        val originalRegistry = borg.trikeshed.lcnc.reduction.ReducerRegistry.registry
+        borg.trikeshed.lcnc.reduction.ReducerRegistry.registry = stubRegistry
 
         val testPayload = emptyArray<Any>()
         val nuid = nuid(Capability.Process("test_process"), Nonce.RandomBytes(), Subnet.core)
 
-        // Launch consumer so that nuidFanout polling loop can actually complete
-        val slot = nuidFanout.slotOf("process-worker")
+        // Launch consumer so that lcncFanout polling loop can actually complete
+        val slot = lcncFanout.slotOf("process-worker")
         assertNotNull(slot)
 
         val job = launch {
@@ -77,11 +77,14 @@ class LcncFanoutElementTest {
             // Simulating successful dispatch inside the dispatcher
         }
 
-        val result = lcncFanout.dispatch(nuid, testPayload)
+        try {
+            val result = lcncFanout.dispatch(nuid, testPayload)
 
-        assertTrue(runForCalled, "execute should have been called on the reduction")
-        assertEquals("success", result)
-
-        job.cancel()
+            assertTrue(runForCalled, "execute should have been called on the reduction")
+            assertEquals("success", result)
+        } finally {
+            job.cancel()
+            borg.trikeshed.lcnc.reduction.ReducerRegistry.registry = originalRegistry
+        }
     }
 }


### PR DESCRIPTION
Refactor LcncFanoutElement to extend NuidFanoutElement and extract ReducerRegistry

- Made NuidFanoutElement class and its key open for extension
- Changed LcncFanoutElement to extend NuidFanoutElement instead of composing it
- Extracted reducerRegistry map and reduction execution logic into a new ReducerRegistry object
- Updated LcncFanoutElement.dispatch to directly return ReducerRegistry.runFor()
- Updated tests to safely patch ReducerRegistry and verify LcncFanoutElement behavior
- Closes G10 in the same cut

---
*PR created automatically by Jules for task [14470741644967495841](https://jules.google.com/task/14470741644967495841) started by @jnorthrup*