### PR TITLE
feat: Configuration hot-reload, feature flags, and schema definitions

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,17 +1,26 @@
-1. **Modify `NuidFanoutElement.kt`**
-   - Replace the `pollForWinner(...)` loop inside `NuidFanoutElement` with a `MutableSharedFlow<Claim>` mechanism to avoid scalar polling and spin-loops.
-   - We will replace `accepted: Channel<Claim>` in `WorkgroupSlot` with `acceptedFlow: MutableSharedFlow<Claim>`.
-   - Update `pollForWinner` to merge the `acceptedFlow`s of all candidates and use `first()` with `withTimeoutOrNull` to find the exact winner.
+1. **Config schema and values (`borg.trikeshed.config`)**
+   - Create `ConfigSchema`, `ConfigType`, and `ConfigValue` definitions.
+   - We will put them in `src/commonMain/kotlin/borg/trikeshed/config/Config.kt`.
 
-2. **Add Unit Test**
-   - Add a unit test in `src/commonTest/kotlin/borg/trikeshed/context/nuid/NuidFanoutElementTest.kt` for 16+ candidates expecting sub-100ms selection under fanout.
+2. **Feature flags (`borg.trikeshed.flags`)**
+   - Create `FeatureFlag` with `rolloutPercentage`.
+   - Create `FeatureFlagManager` for percentage-based rollout using a stable hash function over a string like user ID or context ID.
+   - We will put them in `src/commonMain/kotlin/borg/trikeshed/flags/FeatureFlags.kt`.
 
-3. **Verify Pre-commit**
-   - Run tests to ensure changes are correct and regressions are not introduced. Note: If the Gradle build is broken due to unrelated compilation errors, the prompt states it is acceptable to remove uncompilable test files. However, if the error is in source files (`src/commonMain`), we cannot run tests fully but we can still compile and run the specific test we added (if we remove all other uncompilable files).
-   - I will do my best to verify the code visually and conceptually, and then submit.
+3. **Hot-reload (`borg.trikeshed.reload`)**
+   - Create `HotReloader` using coroutines to poll or watch a config file.
+   - Given `FileOperations` SPI, we can check file modification times or hash codes periodically.
+   - We will put them in `src/commonMain/kotlin/borg/trikeshed/reload/HotReload.kt`.
 
-4. **Complete Pre-commit steps**
-   - Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+4. **ISAM/Persistence connection (`borg.trikeshed.config`)**
+   - Connect the configuration model to the ISAM persistence layer (e.g. read/write to `IsamDataFile`).
+   - Create `IsamConfigStore` in `src/commonMain/kotlin/borg/trikeshed/config/IsamConfigStore.kt`.
 
-5. **Submit the change**
-   - Once all steps are completed, I will submit the change with a descriptive commit message.
+5. **Testing (TDD)**
+   - Run tests that I already created in `src/commonTest/kotlin/borg/trikeshed/{config,flags,reload}/`.
+   - Iterate to make sure the tests compile and run properly. Note there are unrelated compilation errors in other files that should not block us, but we can compile just our test sources if needed.
+
+6. **Pre-commit instructions**
+   - Complete pre-commit steps to make sure proper testing, verifications, reviews and reflections are done.
+
+7. **Submit**

--- a/src/commonMain/kotlin/borg/trikeshed/config/Config.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/config/Config.kt
@@ -1,0 +1,28 @@
+package borg.trikeshed.config
+
+enum class ConfigType {
+    STRING, INT, BOOLEAN, DOUBLE
+}
+
+sealed class ConfigValue {
+    abstract val value: Any
+
+    data class StringValue(override val value: String) : ConfigValue()
+    data class IntValue(override val value: Int) : ConfigValue()
+    data class BooleanValue(override val value: Boolean) : ConfigValue()
+    data class DoubleValue(override val value: Double) : ConfigValue()
+}
+
+data class ConfigSchema(
+    val properties: Map<String, ConfigType>
+) {
+    fun validate(key: String, value: ConfigValue): Boolean {
+        val expectedType = properties[key] ?: return false
+        return when (expectedType) {
+            ConfigType.STRING -> value is ConfigValue.StringValue
+            ConfigType.INT -> value is ConfigValue.IntValue
+            ConfigType.BOOLEAN -> value is ConfigValue.BooleanValue
+            ConfigType.DOUBLE -> value is ConfigValue.DoubleValue
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/config/IsamConfigStore.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/config/IsamConfigStore.kt
@@ -1,0 +1,55 @@
+package borg.trikeshed.config
+
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.ColumnMeta
+import borg.trikeshed.cursor.IOMemento
+import borg.trikeshed.isam.IsamDataFile
+import borg.trikeshed.isam.IsamOperations
+import borg.trikeshed.isam.defaultIsamOperations
+import borg.trikeshed.lib.EmptySeries
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.Series2
+import borg.trikeshed.cursor.`ColumnMeta↻`
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+
+class IsamConfigStore(
+    private val dataFilename: String,
+    private val isamOperations: IsamOperations = defaultIsamOperations()
+) {
+
+    fun saveConfig(configValues: Map<String, ConfigValue>) {
+        val rows = configValues.entries.mapIndexed { index, (key, value) ->
+            val typeStr = when (value) {
+                is ConfigValue.StringValue -> "STRING"
+                is ConfigValue.IntValue -> "INT"
+                is ConfigValue.BooleanValue -> "BOOLEAN"
+                is ConfigValue.DoubleValue -> "DOUBLE"
+            }
+            val valStr = value.value.toString()
+
+            val list = listOf<Any?>(key, typeStr, valStr)
+            val columns = listOf("key", "type", "value")
+
+            val metaFuncs = columns.map { colName ->
+                val f: `ColumnMeta↻` = { ColumnMeta(colName, IOMemento.IoString) }
+                f
+            }
+
+            val rowVec = object : Join<Series<Any?>, Series<`ColumnMeta↻`>> {
+                override val a: Series<Any?> = list.size j { i -> list[i] }
+                override val b: Series<`ColumnMeta↻`> = metaFuncs.size j { i -> metaFuncs[i] }
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            rowVec as RowVec
+        }
+
+        IsamDataFile.append(
+            msf = rows,
+            datafilename = dataFilename,
+            operations = isamOperations
+        )
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/flags/FeatureFlags.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/flags/FeatureFlags.kt
@@ -1,0 +1,33 @@
+package borg.trikeshed.flags
+
+import kotlin.math.abs
+
+data class FeatureFlag(
+    val key: String,
+    val rolloutPercentage: Int // 0 to 100
+) {
+    init {
+        require(rolloutPercentage in 0..100) { "Rollout percentage must be between 0 and 100" }
+    }
+}
+
+class FeatureFlagManager {
+    private val flags = mutableMapOf<String, FeatureFlag>()
+
+    fun setFlag(flag: FeatureFlag) {
+        flags[flag.key] = flag
+    }
+
+    fun getFlag(key: String): FeatureFlag? = flags[key]
+
+    fun isEnabled(key: String, contextId: String): Boolean {
+        val flag = flags[key] ?: return false
+
+        if (flag.rolloutPercentage == 0) return false
+        if (flag.rolloutPercentage == 100) return true
+
+        // Stable hash function for contextId to distribute buckets
+        val hash = abs(contextId.hashCode().toLong() % 100).toInt()
+        return hash < flag.rolloutPercentage
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reload/HotReload.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reload/HotReload.kt
@@ -1,0 +1,39 @@
+package borg.trikeshed.reload
+
+import borg.trikeshed.userspace.nio.file.spi.FileOperations
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.coroutineScope
+
+class HotReloader(
+    private val fileOps: FileOperations,
+    private val filePath: String,
+    private val onReload: () -> Unit
+) {
+    companion object {
+        const val POLL_INTERVAL_MS = 1000L
+    }
+
+    private var lastHash: Int = 0
+
+    suspend fun start() = coroutineScope {
+        if (fileOps.exists(filePath)) {
+            lastHash = fileOps.readAllBytes(filePath).contentHashCode()
+        }
+
+        while (isActive) {
+            delay(POLL_INTERVAL_MS)
+            if (fileOps.exists(filePath)) {
+                val currentHash = fileOps.readAllBytes(filePath).contentHashCode()
+                if (currentHash != lastHash) {
+                    lastHash = currentHash
+                    onReload()
+                }
+            } else if (lastHash != 0) {
+                // File was deleted
+                lastHash = 0
+                onReload()
+            }
+        }
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/config/ConfigTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/config/ConfigTest.kt
@@ -1,0 +1,21 @@
+package borg.trikeshed.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class ConfigTest {
+    @Test
+    fun testConfigSchemaAndValue() {
+        val schema = ConfigSchema(mapOf("port" to ConfigType.INT, "host" to ConfigType.STRING))
+        val portValue = ConfigValue.IntValue(8080)
+        assertEquals(8080, portValue.value)
+
+        assertTrue(schema.validate("port", portValue))
+        assertTrue(schema.validate("host", ConfigValue.StringValue("localhost")))
+
+        assertFalse(schema.validate("port", ConfigValue.StringValue("8080")))
+        assertFalse(schema.validate("unknown", ConfigValue.IntValue(1)))
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/flags/FeatureFlagsTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/flags/FeatureFlagsTest.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.flags
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class FeatureFlagsTest {
+    @Test
+    fun testPercentageRollout() {
+        val manager = FeatureFlagManager()
+
+        manager.setFlag(FeatureFlag("always_on", 100))
+        manager.setFlag(FeatureFlag("always_off", 0))
+        manager.setFlag(FeatureFlag("fifty_fifty", 50))
+
+        assertTrue(manager.isEnabled("always_on", "user1"))
+        assertFalse(manager.isEnabled("always_off", "user1"))
+
+        // Let's test stable hashing. We can rely on deterministic strings for tests.
+        val onCount = (1..100).count { manager.isEnabled("fifty_fifty", "user$it") }
+
+        // Distribution might not be exactly 50% for 100 iterations due to hash collisions,
+        // but it should be somewhere in the middle (e.g. between 30 and 70).
+        assertTrue(onCount in 30..70, "Distribution should be somewhat even, got $onCount")
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/reload/HotReloadTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/reload/HotReloadTest.kt
@@ -1,0 +1,31 @@
+package borg.trikeshed.reload
+
+import borg.trikeshed.userspace.nio.file.spi.InMemoryFileOperations
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class HotReloadTest {
+    @Test
+    fun testHotReload() = runTest {
+        val ops = InMemoryFileOperations()
+        ops.write("config.txt", "v1")
+
+        var reloads = 0
+        val reloader = HotReloader(ops, "config.txt") {
+            reloads++
+        }
+
+        val job = launch { reloader.start() }
+
+        delay(10)
+        ops.write("config.txt", "v2")
+        delay(HotReloader.POLL_INTERVAL_MS * 2)
+
+        job.cancel()
+
+        assertEquals(1, reloads, "Should have reloaded once")
+    }
+}


### PR DESCRIPTION
Implement configuration hot-reload and feature flags in borg.trikeshed.config, borg.trikeshed.flags, borg.trikeshed.reload. Define ConfigSchema, ConfigValue types. Build hot-reload with file system watching. Implement feature flag system with percentage-based rollout. Connect config to existing ISAM/persistence.

---
*PR created automatically by Jules for task [18374439031630797515](https://jules.google.com/task/18374439031630797515) started by @jnorthrup*