### PR TITLE
feat: implement Kubernetes operator and CRD models

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/k8s/crd/TrikeShedResource.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/k8s/crd/TrikeShedResource.kt
@@ -1,0 +1,35 @@
+package borg.trikeshed.k8s.crd
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ObjectMeta(
+    val name: String,
+    val namespace: String = "default",
+    val resourceVersion: String? = null,
+    val uid: String? = null
+)
+
+@Serializable
+data class TrikeShedResourceSpec(
+    val replicas: Int = 1,
+    val image: String = "trikeshed:latest",
+    val configMapName: String? = null,
+    val connectToCcek: Boolean = true
+)
+
+@Serializable
+data class TrikeShedResourceStatus(
+    val phase: String = "Pending",
+    val readyReplicas: Int = 0,
+    val message: String? = null
+)
+
+@Serializable
+data class TrikeShedResource(
+    val apiVersion: String = "trikeshed.borg.io/v1alpha1",
+    val kind: String = "TrikeShedResource",
+    val metadata: ObjectMeta,
+    val spec: TrikeShedResourceSpec,
+    val status: TrikeShedResourceStatus? = null
+)

--- a/src/commonMain/kotlin/borg/trikeshed/k8s/operator/TrikeShedOperator.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/k8s/operator/TrikeShedOperator.kt
@@ -1,0 +1,72 @@
+package borg.trikeshed.k8s.operator
+
+import borg.trikeshed.k8s.crd.TrikeShedResource
+import borg.trikeshed.operator.BaseOperatorSdk
+import borg.trikeshed.operator.K8sEvent
+import borg.trikeshed.operator.Reconciler
+import borg.trikeshed.ccek.CCEK
+import borg.trikeshed.ccek.ForgeSignal
+import borg.trikeshed.forge.ForgeBlockKind
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class TrikeShedOperator(private val scope: CoroutineScope) : BaseOperatorSdk<TrikeShedResource>(scope) {
+    val dummyDocNode = borg.trikeshed.ccek.UserContext("dummy", scope).choreograph(
+        doc = borg.trikeshed.forge.ForgeDocument(borg.trikeshed.context.nuid.Nuid("doc"), emptyMap<String, String>())
+    )
+
+    init {
+        registerReconciler(object : Reconciler<TrikeShedResource> {
+            override suspend fun reconcile(event: K8sEvent<TrikeShedResource>) {
+                when (event) {
+                    is K8sEvent.Added -> handleAdded(event.resource)
+                    is K8sEvent.Modified -> handleModified(event.oldResource, event.newResource)
+                    is K8sEvent.Deleted -> handleDeleted(event.resource)
+                }
+            }
+        })
+    }
+
+    override suspend fun start() {
+        super.start()
+        dummyDocNode.start()
+    }
+
+    override suspend fun stop() {
+        dummyDocNode.stop()
+        super.stop()
+    }
+
+    private suspend fun handleAdded(resource: TrikeShedResource) {
+        if (resource.spec.connectToCcek) {
+            val signal = ForgeSignal.AppendBlock(
+                kind = ForgeBlockKind.TEXT,
+                text = "Resource added: ${resource.metadata.name}",
+                properties = emptyMap<String, String>()
+            )
+            dummyDocNode.sendSignal(signal)
+        }
+    }
+
+    private suspend fun handleModified(oldResource: TrikeShedResource, newResource: TrikeShedResource) {
+        if (newResource.spec.connectToCcek) {
+             val signal = ForgeSignal.AppendBlock(
+                kind = ForgeBlockKind.TEXT,
+                text = "Resource modified: ${newResource.metadata.name}",
+                properties = emptyMap<String, String>()
+            )
+            dummyDocNode.sendSignal(signal)
+        }
+    }
+
+    private suspend fun handleDeleted(resource: TrikeShedResource) {
+         if (resource.spec.connectToCcek) {
+             val signal = ForgeSignal.AppendBlock(
+                kind = ForgeBlockKind.TEXT,
+                text = "Resource deleted: ${resource.metadata.name}",
+                properties = emptyMap<String, String>()
+            )
+            dummyDocNode.sendSignal(signal)
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/operator/OperatorSdk.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/operator/OperatorSdk.kt
@@ -1,0 +1,50 @@
+package borg.trikeshed.operator
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+
+sealed class K8sEvent<T> {
+    data class Added<T>(val resource: T) : K8sEvent<T>()
+    data class Modified<T>(val oldResource: T, val newResource: T) : K8sEvent<T>()
+    data class Deleted<T>(val resource: T) : K8sEvent<T>()
+}
+
+interface Reconciler<T> {
+    suspend fun reconcile(event: K8sEvent<T>)
+}
+
+interface OperatorSdk<T> {
+    val events: Flow<K8sEvent<T>>
+    suspend fun start()
+    suspend fun stop()
+    fun registerReconciler(reconciler: Reconciler<T>)
+    suspend fun dispatchEvent(event: K8sEvent<T>)
+}
+
+open class BaseOperatorSdk<T>(private val scope: CoroutineScope) : OperatorSdk<T> {
+    private val _events = MutableSharedFlow<K8sEvent<T>>(replay = 64, extraBufferCapacity = 64)
+    override val events: Flow<K8sEvent<T>> = _events.asSharedFlow()
+    private val reconcilers = mutableListOf<Reconciler<T>>()
+
+    override suspend fun start() {
+        scope.launch {
+            _events.collect { event ->
+                reconcilers.forEach { it.reconcile(event) }
+            }
+        }
+    }
+
+    override suspend fun stop() {
+    }
+
+    override fun registerReconciler(reconciler: Reconciler<T>) {
+        reconcilers.add(reconciler)
+    }
+
+    override suspend fun dispatchEvent(event: K8sEvent<T>) {
+        _events.emit(event)
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/k8s/operator/TrikeShedOperatorTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/k8s/operator/TrikeShedOperatorTest.kt
@@ -1,0 +1,45 @@
+package borg.trikeshed.k8s.operator
+
+import borg.trikeshed.k8s.crd.ObjectMeta
+import borg.trikeshed.k8s.crd.TrikeShedResource
+import borg.trikeshed.k8s.crd.TrikeShedResourceSpec
+import borg.trikeshed.operator.K8sEvent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import borg.trikeshed.ccek.ForgeSignal
+
+class TrikeShedOperatorTest {
+
+    @Test
+    fun testOperatorReconciliationAddedEvent() = runTest {
+        val operator = TrikeShedOperator(CoroutineScope(Job() + Dispatchers.Default))
+        operator.start()
+
+        val resource = TrikeShedResource(
+            metadata = ObjectMeta(name = "test-resource"),
+            spec = TrikeShedResourceSpec(connectToCcek = true)
+        )
+        val event = K8sEvent.Added(resource)
+
+        operator.dispatchEvent(event)
+
+        // Give it a moment to process
+        delay(100)
+
+        // Verify that a signal was recorded in CCEK via the dummy doc node
+        val recording = operator.dummyDocNode.recording()
+        assertTrue(recording.isNotEmpty(), "Expected at least one signal to be recorded")
+
+        val lastSignal = recording.last()
+        assertTrue(lastSignal is ForgeSignal.AppendBlock, "Expected AppendBlock signal")
+        assertEquals("Resource added: test-resource", (lastSignal as ForgeSignal.AppendBlock).text)
+
+        operator.stop()
+    }
+}


### PR DESCRIPTION
Implements a Kubernetes operator for TrikeShed, defining CRD specifications and connecting Kubernetes events to the internal CCEK lifecycle via `ForgeSignal`s. The operator SDK provides asynchronous reconciliation through coroutine-based flows. Tested conceptually due to external commonMain dependencies with pre-existing build issues.

---
*PR created automatically by Jules for task [13616362518854846207](https://jules.google.com/task/13616362518854846207) started by @jnorthrup*