### PR TITLE
feat(kanban): Server-side reactive push to PWA via WebSocket

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/server/KanbanPushBus.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/server/KanbanPushBus.kt
@@ -1,0 +1,18 @@
+package borg.trikeshed.forge.server
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Event bus for pushing Kanban updates to connected clients over WebSockets.
+ */
+object KanbanPushBus {
+    private val _patches = MutableSharedFlow<String>(extraBufferCapacity = 64)
+
+    val patches: SharedFlow<String> = _patches.asSharedFlow()
+
+    fun publish(patch: String) {
+        _patches.tryEmit(patch)
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -222,6 +222,41 @@ object JvmKanbanServer {
         scope.launch {
             listener.fanoutChannels { protocol, msg ->
                 System.err.println("fanout: $protocol seq=${msg.sequenceId} ${msg.payload.size} bytes")
+                if (protocol == Protocol.Http) {
+                    val text = String(msg.payload, StandardCharsets.UTF_8)
+                    if (text.startsWith("GET /api/stream ") && text.contains("Upgrade: websocket", ignoreCase = true)) {
+                        val keyLine = text.lineSequence().find { it.startsWith("Sec-WebSocket-Key: ", ignoreCase = true) }
+                        if (keyLine != null && msg.respond != null) {
+                            val key = keyLine.substringAfter(":").trim()
+                            val magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+                            val digest = java.security.MessageDigest.getInstance("SHA-1")
+                            val acceptHash = java.util.Base64.getEncoder().encodeToString(digest.digest((key + magic).toByteArray()))
+
+                            val response = buildString {
+                                append("HTTP/1.1 101 Switching Protocols\r\n")
+                                append("Upgrade: websocket\r\n")
+                                append("Connection: Upgrade\r\n")
+                                append("Sec-WebSocket-Accept: $acceptHash\r\n")
+                                append("\r\n")
+                            }
+                            msg.respond.invoke(response.toByteArray(StandardCharsets.UTF_8))
+
+                            scope.launch {
+                                try {
+                                    borg.trikeshed.forge.server.KanbanPushBus.patches.collect { patch ->
+                                        val frame = borg.trikeshed.ws.WebSocketFrame.buildFrame(
+                                            opcode = borg.trikeshed.ws.WebSocketFrame.OpCode.TEXT,
+                                            payload = patch.toByteArray(StandardCharsets.UTF_8)
+                                        )
+                                        msg.respond.invoke(frame)
+                                    }
+                                } catch (e: Exception) {
+                                    System.err.println("ws push disconnected: ${e.message}")
+                                }
+                            }
+                        }
+                    }
+                }
                 true // keep listening
             }
         }
@@ -281,6 +316,10 @@ object JvmKanbanServer {
             val tmp = "/tmp/hi"
             writeStringJvm(tmp, payload)
             val reduction = ForgeKanbanIngest.persistMarkdown("jim", tmp)
+
+            // Push board update to connected WS clients
+            borg.trikeshed.forge.server.KanbanPushBus.publish(boardJson())
+
             HttpResponse(
                 201,
                 JsonSupport.stringify(


### PR DESCRIPTION
Implements the server-side reactive push to PWA.

Every successful `POST /api/submit` now publishes a `BlackboardSurface` patch over the `/api/stream` WebSocket endpoint using the newly introduced `KanbanPushBus`. This ensures that connected PWA instances receive live board updates without a page reload.

---
*PR created automatically by Jules for task [17796430853771508194](https://jules.google.com/task/17796430853771508194) started by @jnorthrup*