### PR TITLE
TDD: Implement VolumeCasStore and MmapCasStoreJvm

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/BlockIndex.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/BlockIndex.kt
@@ -1,0 +1,133 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+
+data class LbaEntry(val lba: Long, val sizeBytes: Int, val refCount: Int = 1)
+
+class BlockIndex {
+    private val entries = mutableMapOf<ContentId, LbaEntry>()
+
+    fun put(cid: ContentId, entry: LbaEntry) {
+        entries[cid] = entry
+    }
+
+    fun get(cid: ContentId): LbaEntry? = entries[cid]
+
+    fun remove(cid: ContentId) {
+        entries.remove(cid)
+    }
+
+    fun getEntries(): Map<ContentId, LbaEntry> = entries.toMap()
+
+    fun encode(): ByteArray {
+        val entryCount = entries.size
+        val size = 12 + entryCount * 80
+        val buffer = ByteArray(size)
+
+        // Header
+        buffer.writeIntAt(0, 0xCA5B1001.toInt())
+        buffer.writeIntAt(4, 1)
+        buffer.writeIntAt(8, entryCount)
+
+        var offset = 12
+        for ((cid, entry) in entries) {
+            // cid hex: 64 bytes
+            val hex = cid.value.removePrefix("sha256:")
+            for (i in 0 until 64) {
+                buffer[offset + i] = if (i < hex.length) hex[i].code.toByte() else 0
+            }
+            offset += 64
+
+            // lba: 8 bytes
+            buffer.writeLongAt(offset, entry.lba)
+            offset += 8
+
+            // sizeBytes: 4 bytes
+            buffer.writeIntAt(offset, entry.sizeBytes)
+            offset += 4
+
+            // refCount: 4 bytes
+            buffer.writeIntAt(offset, entry.refCount)
+            offset += 4
+        }
+
+        return buffer
+    }
+
+    companion object {
+        fun decode(bytes: ByteArray): BlockIndex {
+            val index = BlockIndex()
+            if (bytes.size < 12) return index
+
+            val magic = bytes.readIntAt(0)
+            if (magic != 0xCA5B1001.toInt()) return index
+
+            val version = bytes.readIntAt(4)
+            if (version != 1) return index
+
+            val entryCount = bytes.readIntAt(8)
+            var offset = 12
+
+            for (i in 0 until entryCount) {
+                if (offset + 80 > bytes.size) break
+
+                val hexBytes = ByteArray(64)
+                bytes.copyInto(hexBytes, 0, offset, offset + 64)
+                val hexString = hexBytes.decodeToString().trimEnd('\u0000')
+                val cid = ContentId("sha256:${hexString}")
+                offset += 64
+
+                val lba = bytes.readLongAt(offset)
+                offset += 8
+
+                val sizeBytes = bytes.readIntAt(offset)
+                offset += 4
+
+                val refCount = bytes.readIntAt(offset)
+                offset += 4
+
+                index.put(cid, LbaEntry(lba, sizeBytes, refCount))
+            }
+
+            return index
+        }
+    }
+}
+
+// Helper functions for byte array operations (Little Endian/Big Endian)
+// Assuming Big Endian for simplicity, can adjust if needed
+internal fun ByteArray.writeIntAt(index: Int, value: Int) {
+    this[index] = (value shr 24).toByte()
+    this[index + 1] = (value shr 16).toByte()
+    this[index + 2] = (value shr 8).toByte()
+    this[index + 3] = value.toByte()
+}
+
+internal fun ByteArray.readIntAt(index: Int): Int {
+    return (this[index].toInt() and 0xFF shl 24) or
+           (this[index + 1].toInt() and 0xFF shl 16) or
+           (this[index + 2].toInt() and 0xFF shl 8) or
+           (this[index + 3].toInt() and 0xFF)
+}
+
+internal fun ByteArray.writeLongAt(index: Int, value: Long) {
+    this[index] = (value ushr 56).toByte()
+    this[index + 1] = (value ushr 48).toByte()
+    this[index + 2] = (value ushr 40).toByte()
+    this[index + 3] = (value ushr 32).toByte()
+    this[index + 4] = (value ushr 24).toByte()
+    this[index + 5] = (value ushr 16).toByte()
+    this[index + 6] = (value ushr 8).toByte()
+    this[index + 7] = value.toByte()
+}
+
+internal fun ByteArray.readLongAt(index: Int): Long {
+    return (this[index].toLong() and 0xFF shl 56) or
+           (this[index + 1].toLong() and 0xFF shl 48) or
+           (this[index + 2].toLong() and 0xFF shl 40) or
+           (this[index + 3].toLong() and 0xFF shl 32) or
+           (this[index + 4].toLong() and 0xFF shl 24) or
+           (this[index + 5].toLong() and 0xFF shl 16) or
+           (this[index + 6].toLong() and 0xFF shl 8) or
+           (this[index + 7].toLong() and 0xFF)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/cas/CasManifest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/CasManifest.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+
+data class CasManifest(
+    val cids: List<ContentId>,    // sorted lexicographically
+    val metadata: ByteArray = ByteArray(0),
+) {
+    fun contentId(): ContentId {
+        val sb = StringBuilder()
+        sb.append("MANIFEST1\n")
+        for (c in cids) sb.append(c.value).append('\n')
+        sb.append("META\n")
+        sb.append(metadata.size).append('\n')
+        sb.append(metadata.decodeToString())
+        return ContentId.of((sb.toString().length.toString() + ":" + sb.toString()).encodeToByteArray())
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CasManifest) return false
+        return cids == other.cids && metadata.contentEquals(other.metadata)
+    }
+
+    override fun hashCode(): Int = cids.hashCode() * 31 + metadata.contentHashCode()
+}

--- a/src/commonMain/kotlin/borg/trikeshed/cas/CasReplicationHook.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/CasReplicationHook.kt
@@ -1,0 +1,11 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+
+interface CasReplicationHook {
+    suspend fun onPut(cid: ContentId, payload: ByteArray) {}
+
+    object NoOp : CasReplicationHook {
+        override suspend fun onPut(cid: ContentId, payload: ByteArray) {}
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/cas/VolumeCasStore.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/VolumeCasStore.kt
@@ -1,0 +1,147 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.userspace.volume.Volume
+import kotlinx.coroutines.runBlocking
+
+class VolumeCasStore(
+    private val volume: Volume,
+    private val replicationHook: CasReplicationHook = CasReplicationHook.NoOp,
+    private val blockSize: Int = volume.blockSize,
+) {
+    private var index: BlockIndex
+    private val lock = Any()
+
+    // Simple bump allocator for LBAs starting at 1 (since 0 is the index)
+    private var nextFreeLba = 1L
+
+    init {
+        require(blockSize == volume.blockSize) { "blockSize mismatch" }
+        // Attempt to load index from LBA 0
+        index = runBlocking {
+            val headerBytes = volume.read(0, 1) // read first block to get header
+            val magic = if (headerBytes.size >= 4) headerBytes.readIntAt(0) else 0
+            if (magic == 0xCA5B1001.toInt()) {
+                // Determine how many blocks we need for the full index
+                val entryCount = headerBytes.readIntAt(8)
+                val totalBytes = 12 + entryCount * 80
+                val blocksNeeded = (totalBytes + blockSize - 1) / blockSize
+
+                val fullIndexBytes = if (blocksNeeded > 1) {
+                    val full = ByteArray(blocksNeeded * blockSize)
+                    headerBytes.copyInto(full, 0, 0, blockSize)
+                    for (i in 1 until blocksNeeded) {
+                        val chunk = volume.read(i.toLong(), 1)
+                        chunk.copyInto(full, i * blockSize, 0, blockSize)
+                    }
+                    full
+                } else {
+                    headerBytes
+                }
+
+                val decoded = BlockIndex.decode(fullIndexBytes)
+
+                // Update nextFreeLba based on existing entries
+                var maxLba = 0L
+                for ((_, entry) in decoded.getEntries()) {
+                    val entryBlocks = (entry.sizeBytes + blockSize - 1) / blockSize
+                    val entryEndLba = entry.lba + entryBlocks - 1
+                    if (entryEndLba > maxLba) {
+                        maxLba = entryEndLba
+                    }
+                }
+                // Determine index size in blocks to start free LBAs
+                val indexBlocks = (12 + decoded.getEntries().size * 80 + blockSize - 1) / blockSize
+                val maxReserved = maxOf(maxLba, indexBlocks.toLong() - 1)
+                nextFreeLba = maxReserved + 1L
+
+                decoded
+            } else {
+                BlockIndex()
+            }
+        }
+    }
+
+    fun put(bytes: ByteArray): ContentId = runBlocking {
+        val cid = ContentId.of(bytes)
+
+        synchronized(lock) {
+            val existing = index.get(cid)
+            if (existing != null) {
+                index.put(cid, existing.copy(refCount = existing.refCount + 1))
+                return@runBlocking cid
+            }
+
+            val blocksNeeded = (bytes.size + blockSize - 1) / blockSize
+            val lba = nextFreeLba
+            nextFreeLba += blocksNeeded
+
+            index.put(cid, LbaEntry(lba, bytes.size, 1))
+        }
+
+        // Write to volume outside the lock
+        val blocksNeeded = (bytes.size + blockSize - 1) / blockSize
+        val lba = synchronized(lock) { index.get(cid)?.lba } ?: return@runBlocking cid
+
+        val paddedBytes = if (bytes.size % blockSize == 0 && bytes.isNotEmpty()) {
+            bytes
+        } else {
+            val padded = ByteArray(blocksNeeded * blockSize)
+            bytes.copyInto(padded)
+            padded
+        }
+
+        // Write block by block to avoid large arrays if volume requires it,
+        // but here we can just write the whole array if volume supports it.
+        // Assuming volume.write handles paddedBytes.size bytes starting at lba.
+        // The tests use FakeVolume which expects to write `paddedBytes.size / blockSize` blocks.
+        volume.write(lba, paddedBytes)
+        replicationHook.onPut(cid, bytes)
+
+        cid
+    }
+
+    fun get(cid: ContentId): ByteArray? = runBlocking {
+        val entry = synchronized(lock) { index.get(cid) } ?: return@runBlocking null
+
+        val blocksNeeded = (entry.sizeBytes + blockSize - 1) / blockSize
+        val paddedBytes = volume.read(entry.lba, blocksNeeded)
+
+        val result = ByteArray(entry.sizeBytes)
+        paddedBytes.copyInto(result, 0, 0, entry.sizeBytes)
+
+        val actualCid = ContentId.of(result)
+        if (actualCid != cid) {
+            throw IllegalStateException("digest mismatch")
+        }
+
+        result
+    }
+
+    fun delete(cid: ContentId): Boolean {
+        synchronized(lock) {
+            val entry = index.get(cid) ?: return false
+            if (entry.refCount > 1) {
+                index.put(cid, entry.copy(refCount = entry.refCount - 1))
+            } else {
+                index.remove(cid)
+            }
+            return true
+        }
+    }
+
+    fun manifest(cids: List<ContentId>): CasManifest {
+        val sortedCids = cids.sortedBy { it.value }
+        return CasManifest(sortedCids)
+    }
+
+    fun sync() = runBlocking {
+        val encoded = synchronized(lock) { index.encode() }
+        val blocksNeeded = (encoded.size + blockSize - 1) / blockSize
+        val paddedBytes = ByteArray(blocksNeeded * blockSize)
+        encoded.copyInto(paddedBytes)
+
+        volume.write(0L, paddedBytes)
+        volume.sync()
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/cas/CasManifestTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/cas/CasManifestTest.kt
@@ -1,0 +1,46 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+import kotlin.test.*
+
+class CasManifestTest {
+
+    @Test
+    fun manifestIsContentEqualWhenOrderDiffers() {
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+        val cid3 = ContentId.of(byteArrayOf(3))
+
+        val manifest1 = CasManifest(listOf(cid1, cid2, cid3).sortedBy { it.value })
+        val manifest2 = CasManifest(listOf(cid3, cid1, cid2).sortedBy { it.value })
+
+        assertEquals(manifest1.contentId(), manifest2.contentId())
+        assertEquals(manifest1, manifest2)
+    }
+
+    @Test
+    fun manifestMetadataAffectsCid() {
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+        val cid3 = ContentId.of(byteArrayOf(3))
+
+        val manifest1 = CasManifest(listOf(cid1, cid2, cid3).sortedBy { it.value }, byteArrayOf(1))
+        val manifest2 = CasManifest(listOf(cid1, cid2, cid3).sortedBy { it.value }, byteArrayOf(2))
+
+        assertNotEquals(manifest1.contentId(), manifest2.contentId())
+        assertNotEquals(manifest1, manifest2)
+    }
+
+    @Test
+    fun manifestEqualsHashCode() {
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+        val cid3 = ContentId.of(byteArrayOf(3))
+
+        val manifest1 = CasManifest(listOf(cid1, cid2, cid3).sortedBy { it.value })
+        val manifest2 = CasManifest(listOf(cid1, cid2, cid3).sortedBy { it.value })
+
+        assertEquals(manifest1, manifest2)
+        assertEquals(manifest1.hashCode(), manifest2.hashCode())
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/cas/VolumeCasStoreTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/cas/VolumeCasStoreTest.kt
@@ -1,0 +1,178 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.userspace.volume.Volume
+import kotlinx.coroutines.runBlocking
+import kotlin.random.Random
+import kotlin.test.*
+
+class FakeVolume(override val blockSize: Int = 4096) : Volume {
+    override val capacity: Long = 100 * blockSize.toLong()
+    private val blocks = mutableMapOf<Long, ByteArray>()
+
+    override suspend fun read(lba: Long, count: Int): ByteArray {
+        val res = ByteArray(count * blockSize)
+        for (i in 0 until count) {
+            val b = blocks[lba + i]
+            if (b != null) {
+                b.copyInto(res, i * blockSize)
+            }
+        }
+        return res
+    }
+
+    override suspend fun write(lba: Long, data: ByteArray) {
+        val blocksToWrite = (data.size + blockSize - 1) / blockSize
+        for (i in 0 until blocksToWrite) {
+            val end = minOf(data.size, (i + 1) * blockSize)
+            val chunk = ByteArray(blockSize)
+            data.copyInto(chunk, 0, i * blockSize, end)
+            blocks[lba + i] = chunk
+        }
+    }
+
+    override suspend fun sync() {}
+}
+
+class FakeCasReplicationHook : CasReplicationHook {
+    var count = 0
+    override suspend fun onPut(cid: ContentId, payload: ByteArray) {
+        count++
+    }
+}
+
+class VolumeCasStoreTest {
+
+    @Test
+    fun putThenGetRoundTrip() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val data = Random.nextBytes(1024)
+        val cid = store.put(data)
+        val retrieved = store.get(cid)
+        assertNotNull(retrieved)
+        assertTrue(data.contentEquals(retrieved))
+    }
+
+    @Test
+    fun cidIsDeterministic() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val data = Random.nextBytes(1024)
+        val cid1 = store.put(data)
+        val cid2 = store.put(data)
+        assertEquals(cid1, cid2)
+    }
+
+    @Test
+    fun getMissingReturnsNull() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val cid = ContentId.of(ByteArray(10))
+        assertNull(store.get(cid))
+    }
+
+    @Test
+    fun manifestCidIsDeterministicAcrossRuns() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+        val cid3 = ContentId.of(byteArrayOf(3))
+
+        val manifest1 = store.manifest(listOf(cid1, cid2, cid3))
+        val manifest2 = store.manifest(listOf(cid3, cid1, cid2))
+
+        assertEquals(manifest1.contentId(), manifest2.contentId())
+    }
+
+    @Test
+    fun manifestCidChangesWhenCidsChange() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+        val cid3 = ContentId.of(byteArrayOf(3))
+        val cid4 = ContentId.of(byteArrayOf(4))
+
+        val manifest1 = store.manifest(listOf(cid1, cid2, cid3))
+        val manifest2 = store.manifest(listOf(cid1, cid2, cid3, cid4))
+
+        assertNotEquals(manifest1.contentId(), manifest2.contentId())
+    }
+
+    @Test
+    fun replicationHookCalledOnPut() = runBlocking {
+        val volume = FakeVolume()
+        val hook = FakeCasReplicationHook()
+        val store = VolumeCasStore(volume, hook)
+
+        store.put(byteArrayOf(1))
+        store.put(byteArrayOf(2))
+        store.put(byteArrayOf(3))
+
+        assertEquals(3, hook.count)
+    }
+
+    @Test
+    fun deleteDecrementsRefcount() = runBlocking {
+        val volume = FakeVolume()
+        val store = VolumeCasStore(volume)
+        val data = Random.nextBytes(10)
+        val cid1 = store.put(data)
+        val cid2 = store.put(data) // refcount=2
+        assertEquals(cid1, cid2)
+
+        assertNotNull(store.get(cid1))
+        assertTrue(store.delete(cid1)) // deletes 1 ref, refcount=1
+        assertNotNull(store.get(cid1)) // still there
+        assertTrue(store.delete(cid1)) // deletes 1 ref, refcount=0
+        assertNull(store.get(cid1))    // gone
+    }
+
+    @Test
+    fun syncPersistsIndex() = runBlocking {
+        val volume = FakeVolume()
+        val store1 = VolumeCasStore(volume)
+        val data = Random.nextBytes(100)
+        val cid = store1.put(data)
+        store1.put(byteArrayOf(1))
+        store1.put(byteArrayOf(2))
+
+        store1.sync()
+
+        val store2 = VolumeCasStore(volume)
+        val retrieved = store2.get(cid)
+        assertNotNull(retrieved)
+        assertTrue(data.contentEquals(retrieved))
+    }
+
+    @Test
+    fun blockIndexEncodeRoundTrip() {
+        val index = BlockIndex()
+        val cid1 = ContentId.of(byteArrayOf(1))
+        val cid2 = ContentId.of(byteArrayOf(2))
+
+        index.put(cid1, LbaEntry(10, 100, 1))
+        index.put(cid2, LbaEntry(20, 200, 2))
+
+        val encoded = index.encode()
+        val decoded = BlockIndex.decode(encoded)
+
+        assertEquals(10, decoded.get(cid1)?.lba)
+        assertEquals(100, decoded.get(cid1)?.sizeBytes)
+        assertEquals(1, decoded.get(cid1)?.refCount)
+
+        assertEquals(20, decoded.get(cid2)?.lba)
+        assertEquals(200, decoded.get(cid2)?.sizeBytes)
+        assertEquals(2, decoded.get(cid2)?.refCount)
+    }
+
+    @Test
+    fun rejectsBlockSizeMismatch() {
+        val volume = FakeVolume(4096)
+        assertFailsWith<IllegalArgumentException> {
+            VolumeCasStore(volume, blockSize = 8192)
+        }
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/cas/MmapCasStoreJvm.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/cas/MmapCasStoreJvm.kt
@@ -1,0 +1,131 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.userspace.volume.Volume
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.MappedByteBuffer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class MmapCasStoreJvm(
+    private val file: File,
+    private val replicationHook: CasReplicationHook = CasReplicationHook.NoOp,
+    blockSize: Int = 4096
+) {
+    private val volume = MmapVolume(file, blockSize)
+    private val store = VolumeCasStore(volume, replicationHook, blockSize)
+
+    fun put(bytes: ByteArray): ContentId = store.put(bytes)
+
+    fun get(cid: ContentId): ByteArray? = store.get(cid)
+
+    fun delete(cid: ContentId): Boolean = store.delete(cid)
+
+    fun manifest(cids: List<ContentId>): CasManifest = store.manifest(cids)
+
+    fun sync() {
+        store.sync()
+    }
+}
+
+class MmapVolume(private val file: File, override val blockSize: Int) : Volume {
+    override val capacity: Long
+        get() = file.length()
+
+    private val randomAccessFile = RandomAccessFile(file, "rw")
+    private val channel = randomAccessFile.channel
+
+    // Simplistic approach: map 100MB at a time
+    private val MAP_SIZE = 100 * 1024 * 1024L
+    private val lock = Any()
+    private var mappedBuffer: MappedByteBuffer? = null
+    private var mappedOffset = 0L
+    private var mappedSize = 0L
+
+    private fun getBufferFor(position: Long, size: Long): MappedByteBuffer {
+        synchronized(lock) {
+            val endPosition = position + size
+
+            // If file is not large enough, extend it
+            if (endPosition > channel.size()) {
+                randomAccessFile.setLength(endPosition)
+                // Invalidate buffer to force remap
+                mappedBuffer = null
+            }
+
+            val buf = mappedBuffer
+            if (buf != null && position >= mappedOffset && endPosition <= mappedOffset + mappedSize) {
+                return buf
+            }
+
+            // Need to map a new region
+            val mapStart = position - (position % MAP_SIZE)
+            // Ensure we map enough to cover the requested size, min MAP_SIZE
+            val newMappedSize = maxOf(MAP_SIZE, size + (position % MAP_SIZE))
+
+            // Don't map past end of file if we don't have to, but we just extended it if needed
+            val actualSize = minOf(newMappedSize, channel.size() - mapStart)
+
+            val newBuf = channel.map(FileChannel.MapMode.READ_WRITE, mapStart, actualSize)
+            mappedBuffer = newBuf
+            mappedOffset = mapStart
+            mappedSize = actualSize
+            return newBuf
+        }
+    }
+
+    override suspend fun read(lba: Long, count: Int): ByteArray = withContext(Dispatchers.IO) {
+        val position = lba * blockSize
+        val size = count * blockSize
+
+        // Ensure file is large enough to map
+        if (position >= channel.size()) {
+            return@withContext ByteArray(size)
+        }
+
+        // If the requested bytes overlap with end of file, we need to read what we can
+        if (position + size > channel.size()) {
+            val readableSize = (channel.size() - position).toInt()
+            val result = ByteArray(size)
+
+            val buffer = getBufferFor(position, readableSize.toLong())
+
+            synchronized(buffer) {
+                buffer.position((position - mappedOffset).toInt())
+                buffer.get(result, 0, readableSize)
+            }
+
+            return@withContext result
+        }
+
+        val buffer = getBufferFor(position, size.toLong())
+        val result = ByteArray(size)
+
+        synchronized(buffer) {
+            buffer.position((position - mappedOffset).toInt())
+            buffer.get(result)
+        }
+
+        result
+    }
+
+    override suspend fun write(lba: Long, data: ByteArray) = withContext(Dispatchers.IO) {
+        val position = lba * blockSize
+        val buffer = getBufferFor(position, data.size.toLong())
+
+        synchronized(buffer) {
+            buffer.position((position - mappedOffset).toInt())
+            buffer.put(data)
+            Unit
+        }
+    }
+
+    override suspend fun sync() = withContext(Dispatchers.IO) {
+        synchronized(lock) {
+            mappedBuffer?.force()
+            Unit
+        }
+    }
+}

--- a/src/jvmTest/kotlin/borg/trikeshed/cas/MmapCasStoreJvmTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/cas/MmapCasStoreJvmTest.kt
@@ -1,0 +1,61 @@
+package borg.trikeshed.cas
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.random.Random
+import kotlin.test.*
+
+class MmapCasStoreJvmTest {
+
+    @Test
+    fun mmapRoundTrip(@TempDir tempDir: File) = runBlocking {
+        val file = File(tempDir, "store.db")
+        val store = MmapCasStoreJvm(file)
+
+        val data = Random.nextBytes(64 * 1024) // 64 KiB
+        val cid = store.put(data)
+
+        val retrieved = store.get(cid)
+        assertNotNull(retrieved)
+        assertTrue(data.contentEquals(retrieved))
+    }
+
+    @Test
+    fun mmapSyncAcrossInstances(@TempDir tempDir: File) = runBlocking {
+        val file = File(tempDir, "store.db")
+        val store1 = MmapCasStoreJvm(file)
+
+        val data = Random.nextBytes(1024)
+        val cid = store1.put(data)
+        store1.sync()
+        // Wait just in case, but MmapCasStoreJvm.sync() should write to file synchronously
+
+        val store2 = MmapCasStoreJvm(file)
+        val retrieved = store2.get(cid)
+
+        assertNotNull(retrieved)
+        assertTrue(data.contentEquals(retrieved))
+    }
+
+    @Test
+    fun mmapConcurrentPuts(@TempDir tempDir: File) = runBlocking {
+        val file = File(tempDir, "store.db")
+        val store = MmapCasStoreJvm(file)
+
+        val dataList = (0 until 8).map { Random.nextBytes(1024) }
+
+        val cids = dataList.map { data ->
+            async(Dispatchers.IO) {
+                store.put(data)
+            }
+        }.awaitAll()
+
+        for (i in 0 until 8) {
+            val retrieved = store.get(cids[i])
+            assertNotNull(retrieved)
+            assertTrue(dataList[i].contentEquals(retrieved))
+        }
+    }
+}


### PR DESCRIPTION
Implements VolumeCasStore (commonMain) and MmapCasStoreJvm (jvmMain) to support CAS storage on top of raw Volumes, allowing persistent chunk allocation and deterministic Manifest ContentIDs. TDD principles observed and comprehensive test suites implemented.

---
*PR created automatically by Jules for task [6719119381933539177](https://jules.google.com/task/6719119381933539177) started by @jnorthrup*