### PR TITLE
T09 - Mesh / SCTP transport

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/reactor/MeshActionFrame.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/MeshActionFrame.kt
@@ -1,0 +1,35 @@
+package borg.trikeshed.reactor
+
+import borg.trikeshed.lcnc.reactor.ReactorAction
+
+class MeshActionFrame(val payload: ByteArray) {
+    companion object {
+        fun encode(action: ReactorAction): MeshActionFrame {
+            val payloadBytes = action.toString().encodeToByteArray()
+            return MeshActionFrame(payloadBytes)
+        }
+
+        fun decode(bytes: ByteArray): MeshActionFrame {
+            if (bytes.size < 4) throw IllegalArgumentException("truncated frame")
+            val length = ((bytes[0].toInt() and 0xFF) shl 24) or
+                         ((bytes[1].toInt() and 0xFF) shl 16) or
+                         ((bytes[2].toInt() and 0xFF) shl 8) or
+                         (bytes[3].toInt() and 0xFF)
+            if (length > 100_000_000) throw IllegalArgumentException("payload too large")
+            if (bytes.size < 4 + length) throw IllegalArgumentException("truncated frame")
+            val payload = bytes.copyOfRange(4, 4 + length)
+            return MeshActionFrame(payload)
+        }
+
+        fun encodeBytes(payloadBytes: ByteArray): ByteArray {
+            val length = payloadBytes.size
+            val frameBytes = ByteArray(4 + length)
+            frameBytes[0] = (length ushr 24).toByte()
+            frameBytes[1] = (length ushr 16).toByte()
+            frameBytes[2] = (length ushr 8).toByte()
+            frameBytes[3] = length.toByte()
+            payloadBytes.copyInto(frameBytes, 4)
+            return frameBytes
+        }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/MeshActionResult.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/MeshActionResult.kt
@@ -1,0 +1,17 @@
+package borg.trikeshed.reactor
+
+sealed class MeshActionResult {
+    data class Ok(val payload: ByteArray) : MeshActionResult() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+            other as Ok
+            return payload.contentEquals(other.payload)
+        }
+        override fun hashCode(): Int {
+            return payload.contentHashCode()
+        }
+    }
+    data class Failed(val code: MeshErrorCode) : MeshActionResult()
+    data object TimedOut : MeshActionResult()
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/MeshConfig.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/MeshConfig.kt
@@ -1,0 +1,13 @@
+package borg.trikeshed.reactor
+
+data class MeshConfig(
+    val timeoutMs: Long = 5_000,
+    val maxRetries: Int = 3,
+    val maxPayloadBytes: Int = 65_536,
+) {
+    init {
+        require(timeoutMs >= 0) { "timeoutMs must be >= 0" }
+        require(maxRetries >= 0) { "maxRetries must be >= 0" }
+        require(maxPayloadBytes in 1..16_777_216) { "maxPayloadBytes out of range" }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/MeshErrorCode.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/MeshErrorCode.kt
@@ -1,0 +1,13 @@
+package borg.trikeshed.reactor
+
+enum class MeshErrorCode(val code: Int) {
+    PEER_NOT_FOUND(-1),
+    TIMEOUT(-2),
+    PAYLOAD_TOO_LARGE(-3),
+    BAD_FRAME(-4),
+    EMPTY_PAYLOAD(-5);
+
+    companion object {
+        fun fromInt(i: Int): MeshErrorCode? = entries.firstOrNull { it.code == i }
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/MeshReactorEndpoint.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/MeshReactorEndpoint.kt
@@ -1,0 +1,64 @@
+package borg.trikeshed.reactor
+
+import borg.trikeshed.lcnc.reactor.ReactorAction
+import borg.trikeshed.context.nuid.subnet
+import borg.trikeshed.context.nuid.Nuid
+import kotlinx.coroutines.withTimeout
+
+// Stub for KademliaNode as it isn't in master yet
+interface KademliaNode {
+    suspend fun lookup(subnet: String): List<PeerAddress>
+}
+
+open class MeshReactorEndpoint(
+    private val dht: KademliaNode,
+    private val config: MeshConfig = MeshConfig(),
+) {
+    suspend fun invoke(action: ReactorAction): MeshActionResult {
+        // Find NUID according to ReactorAction format
+        // This handles both the legacy Join and the sealed class (which the prompt implies with action.a.a.subnet)
+        // Wait, action is explicitly of type ReactorAction.
+        // We handle sealed class.
+        val nuid = when(action) {
+            is ReactorAction.Opened -> action.nuid
+            is ReactorAction.Activated -> action.nuid
+            is ReactorAction.PublishEntity -> action.nuid
+            is ReactorAction.Draining -> action.nuid
+            is ReactorAction.Closed -> action.nuid
+        }
+
+        val subnetStr = nuid.subnet.toString()
+        val actualPeers = dht.lookup(subnetStr)
+
+        if (actualPeers.isEmpty()) return MeshActionResult.Failed(MeshErrorCode.PEER_NOT_FOUND)
+
+        val frame = MeshActionFrame.encode(action)
+        if (frame.payload.size > config.maxPayloadBytes) {
+            return MeshActionResult.Failed(MeshErrorCode.PAYLOAD_TOO_LARGE)
+        }
+
+        repeat(config.maxRetries) { attempt ->
+            val peer = actualPeers[attempt % actualPeers.size]
+            val response = try {
+                withTimeout(config.timeoutMs) {
+                    sendFrame(peer, frame)
+                }
+            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+                MeshActionResult.TimedOut
+            }
+            when (response) {
+                is MeshActionResult.Ok -> return response
+                is MeshActionResult.Failed -> {
+                    if (response.code == MeshErrorCode.TIMEOUT) return@repeat
+                    return response
+                }
+                MeshActionResult.TimedOut -> return@repeat
+            }
+        }
+        return MeshActionResult.Failed(MeshErrorCode.TIMEOUT)
+    }
+
+    protected open suspend fun sendFrame(peer: PeerAddress, frame: MeshActionFrame): MeshActionResult {
+        return MeshActionResult.Failed(MeshErrorCode.BAD_FRAME)
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/SctpReactorEndpoint.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/SctpReactorEndpoint.kt
@@ -1,0 +1,12 @@
+package borg.trikeshed.reactor
+
+import borg.trikeshed.lcnc.reactor.ReactorAction
+
+interface SctpReactorEndpoint {
+    suspend fun bind(port: Int): Int
+    suspend fun send(peer: PeerAddress, action: ReactorAction): MeshActionResult
+    suspend fun receive(): Pair<PeerAddress, ReactorAction>
+    suspend fun close()
+}
+
+data class PeerAddress(val host: String, val port: Int)

--- a/src/commonTest/kotlin/borg/trikeshed/reactor/MeshReactorEndpointTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/reactor/MeshReactorEndpointTest.kt
@@ -1,0 +1,196 @@
+package borg.trikeshed.reactor
+
+import kotlin.test.*
+
+class MeshReactorEndpointTest {
+
+    @Test
+    fun meshConfigRejectsNegativeTimeout() {
+        assertFailsWith<IllegalArgumentException> {
+            MeshConfig(timeoutMs = -1)
+        }
+    }
+
+    @Test
+    fun meshConfigRejectsNegativeRetries() {
+        assertFailsWith<IllegalArgumentException> {
+            MeshConfig(maxRetries = -1)
+        }
+    }
+
+    @Test
+    fun meshErrorCodeRoundTrip() {
+        for (error in MeshErrorCode.entries) {
+            assertTrue(error.code < 0)
+            assertEquals(error, MeshErrorCode.fromInt(error.code))
+        }
+    }
+
+    @Test
+    fun meshFrameRoundTrip() {
+        val payloadBytes = ByteArray(256) { it.toByte() }
+        val encodedBytes = MeshActionFrame.encodeBytes(payloadBytes)
+        val decoded = MeshActionFrame.decode(encodedBytes)
+        assertTrue(payloadBytes.contentEquals(decoded.payload))
+    }
+
+    @Test
+    fun meshFrameRejectsTruncatedFrame() {
+        val bytes = ByteArray(4)
+        bytes[0] = 0
+        bytes[1] = 0
+        bytes[2] = 4
+        bytes[3] = 0
+
+        val e = assertFailsWith<IllegalArgumentException> {
+            MeshActionFrame.decode(bytes)
+        }
+        assertEquals("truncated frame", e.message)
+    }
+
+    @Test
+    fun meshFrameRejectsOversizeFrame() {
+        val bytes = ByteArray(4)
+        bytes[0] = 0x3B
+        bytes[1] = 0x9A.toByte()
+        bytes[2] = 0xCA.toByte()
+        bytes[3] = 0x00
+
+        val e = assertFailsWith<IllegalArgumentException> {
+            MeshActionFrame.decode(bytes)
+        }
+        assertEquals("payload too large", e.message)
+    }
+
+    class FakeKademliaNode(val peersToReturn: List<PeerAddress>) : KademliaNode {
+        override suspend fun lookup(subnet: String): List<PeerAddress> = peersToReturn
+    }
+
+    class TestMeshReactorEndpoint(
+        dht: KademliaNode,
+        config: MeshConfig,
+        var fakeResponse: MeshActionResult = MeshActionResult.Failed(MeshErrorCode.BAD_FRAME),
+        var failsBeforeSuccess: Int = 0
+    ) : MeshReactorEndpoint(dht, config) {
+        var attempts = 0
+        override suspend fun sendFrame(peer: PeerAddress, frame: MeshActionFrame): MeshActionResult {
+            attempts++
+            if (failsBeforeSuccess > 0) {
+                failsBeforeSuccess--
+                return MeshActionResult.TimedOut
+            }
+            return fakeResponse
+        }
+    }
+
+    @Test
+    fun meshEndpointSendsActionAndReturnsOk() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(listOf(PeerAddress("127.0.0.1", 8080), PeerAddress("127.0.0.1", 8081)))
+        val ep = TestMeshReactorEndpoint(dht, MeshConfig())
+        ep.fakeResponse = MeshActionResult.Ok(ByteArray(10) { 1 })
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test"),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Ok)
+        assertTrue((result as MeshActionResult.Ok).payload.size > 0)
+    }
+
+    @Test
+    fun meshEndpointReturnsPeerNotFoundWhenDhtEmpty() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(emptyList())
+        val ep = TestMeshReactorEndpoint(dht, MeshConfig())
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test"),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Failed)
+        assertEquals(MeshErrorCode.PEER_NOT_FOUND, (result as MeshActionResult.Failed).code)
+    }
+
+    @Test
+    fun meshEndpointReturnsTimedOutAfterRetries() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(listOf(PeerAddress("127.0.0.1", 8080)))
+        val config = MeshConfig(maxRetries = 3)
+        val ep = TestMeshReactorEndpoint(dht, config)
+        ep.fakeResponse = MeshActionResult.TimedOut
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test"),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Failed)
+        assertEquals(MeshErrorCode.TIMEOUT, (result as MeshActionResult.Failed).code)
+        assertEquals(3, ep.attempts)
+    }
+
+    @Test
+    fun meshEndpointRejectsOversizedPayload() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(listOf(PeerAddress("127.0.0.1", 8080)))
+        val config = MeshConfig(maxPayloadBytes = 100)
+        val ep = TestMeshReactorEndpoint(dht, config)
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test".padEnd(200, 'x')),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Failed)
+        assertEquals(MeshErrorCode.PAYLOAD_TOO_LARGE, (result as MeshActionResult.Failed).code)
+    }
+
+    @Test
+    fun meshEndpointRetriesOnTimeout() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(listOf(PeerAddress("127.0.0.1", 8080)))
+        val ep = TestMeshReactorEndpoint(dht, MeshConfig(maxRetries = 3))
+        ep.failsBeforeSuccess = 2
+        ep.fakeResponse = MeshActionResult.Ok(ByteArray(1))
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test"),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Ok)
+        assertEquals(3, ep.attempts)
+    }
+
+    @Test
+    fun meshEndpointDoesNotRetryOnBadFrame() = kotlinx.coroutines.test.runTest {
+        val dht = FakeKademliaNode(listOf(PeerAddress("127.0.0.1", 8080)))
+        val ep = TestMeshReactorEndpoint(dht, MeshConfig(maxRetries = 3))
+        ep.fakeResponse = MeshActionResult.Failed(MeshErrorCode.BAD_FRAME)
+
+        val nuid = borg.trikeshed.context.nuid.nuid(
+            borg.trikeshed.context.nuid.Capability.Custom("test", "test"),
+            borg.trikeshed.context.nuid.Nonce.RandomBytes(),
+            borg.trikeshed.context.nuid.Subnet.core
+        )
+        val action = borg.trikeshed.lcnc.reactor.ReactorAction.opened(nuid)
+
+        val result = ep.invoke(action)
+        assertTrue(result is MeshActionResult.Failed)
+        assertEquals(MeshErrorCode.BAD_FRAME, (result as MeshActionResult.Failed).code)
+        assertEquals(1, ep.attempts)
+    }
+}


### PR DESCRIPTION
TDD PR Deliver
Implement Mesh/SCTP transport initial structures. Includes `MeshErrorCode`, `MeshConfig`, `MeshActionResult`, `MeshActionFrame`, `SctpReactorEndpoint` and `MeshReactorEndpoint`. Added `MeshReactorEndpointTest` inline with TDD approach.

---
*PR created automatically by Jules for task [13098165998827396591](https://jules.google.com/task/13098165998827396591) started by @jnorthrup*