### PR TITLE
feat: litebike tunnel and protocol interface port

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/litebike/Protocol.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/litebike/Protocol.kt
@@ -1,0 +1,5 @@
+package borg.trikeshed.litebike
+
+interface Protocol {
+    val id: UByte
+}

--- a/src/commonMain/kotlin/borg/trikeshed/litebike/Tunnel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/litebike/Tunnel.kt
@@ -1,0 +1,15 @@
+package borg.trikeshed.litebike
+
+import kotlinx.coroutines.flow.Flow
+
+interface Tunnel {
+    val id: String
+    val protocol: Protocol
+    val remoteHost: String
+    val remotePort: Int
+
+    suspend fun connect()
+    suspend fun close()
+    fun read(): Flow<ByteArray>
+    suspend fun write(data: ByteArray)
+}

--- a/src/commonTest/kotlin/borg/trikeshed/litebike/TunnelTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/litebike/TunnelTest.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.litebike
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.emptyFlow
+
+class TunnelTest {
+    @Test
+    fun testInterfaces() {
+        val p = object : Protocol {
+            override val id: UByte = 1u
+        }
+        val t = object : Tunnel {
+            override val id: String = "t1"
+            override val protocol: Protocol = p
+            override val remoteHost: String = "localhost"
+            override val remotePort: Int = 8080
+            override suspend fun connect() {}
+            override suspend fun close() {}
+            override fun read() = emptyFlow<ByteArray>()
+            override suspend fun write(data: ByteArray) {}
+        }
+        assertEquals("t1", t.id)
+        assertEquals(1u, t.protocol.id)
+    }
+}

--- a/src/nativeMain/kotlin/borg/trikeshed/litebike/SshTunnel.kt
+++ b/src/nativeMain/kotlin/borg/trikeshed/litebike/SshTunnel.kt
@@ -1,0 +1,23 @@
+package borg.trikeshed.litebike
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+class SshTunnel(
+    override val id: String,
+    override val protocol: Protocol,
+    override val remoteHost: String,
+    override val remotePort: Int
+) : Tunnel {
+    override suspend fun connect() {
+        println("Connecting SSH Tunnel to $remoteHost:$remotePort")
+    }
+
+    override suspend fun close() {
+        println("Closing SSH Tunnel to $remoteHost:$remotePort")
+    }
+
+    override fun read(): Flow<ByteArray> = emptyFlow()
+
+    override suspend fun write(data: ByteArray) {}
+}


### PR DESCRIPTION
This PR introduces the litebike `Protocol` and `Tunnel` interfaces into Kotlin `commonMain`, adapting them cleanly without bringing in Rust-specific implementations. It also implements the native backend stub for `SshTunnel` and unit tests in `commonTest` to ensure structural typing matches.

---
*PR created automatically by Jules for task [9882800292707186354](https://jules.google.com/task/9882800292707186354) started by @jnorthrup*