### PR TITLE
feat: per-target window managers

### DIFF
--- a/src/commonTest/kotlin/borg/trikeshed/forge/window/WindowManagerContractTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/forge/window/WindowManagerContractTest.kt
@@ -1,0 +1,45 @@
+package borg.trikeshed.forge.window
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+abstract class WindowManagerContractTest {
+    abstract fun getManager(): ForgeWindowManager
+
+    @Test
+    fun `test launch sets dom`() {
+        val manager = getManager()
+        val html = "<html><body><h1>Hello</h1></body></html>"
+        manager.launch(html)
+        val snapshot = manager.captureSnapshot()
+        assertEquals(html, snapshot.dom)
+    }
+
+    @Test
+    fun `test bind sets dom`() {
+        val manager = getManager()
+        val html = "<html><body><h1>Hello bound</h1></body></html>"
+        manager.bind(html)
+        val snapshot = manager.captureSnapshot()
+        assertEquals(html, snapshot.dom)
+    }
+
+    @Test
+    fun `test injectScript updates boundScripts`() {
+        val manager = getManager()
+        val script = ScriptSnippet(id = "test-script", source = "console.log('test');")
+        manager.injectScript(script)
+        val snapshot = manager.captureSnapshot()
+        assertTrue(snapshot.boundScripts.contains(script.source))
+    }
+
+    @Test
+    fun `test dispatchEvent updates dispatchedEvents`() {
+        val manager = getManager()
+        val event = WindowEvent("TestEvent", "TestPayload", 0L)
+        manager.dispatchEvent(event)
+        val snapshot = manager.captureSnapshot()
+        assertTrue(snapshot.dispatchedEvents.contains(event))
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/window/JvmForgeWindowManager.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/window/JvmForgeWindowManager.kt
@@ -10,7 +10,12 @@ import java.net.InetSocketAddress
  * Serves the HTML over local HTTP and opens it in the system's default browser.
  */
 class JvmForgeWindowManager : ForgeWindowManager {
+    private var currentHtml: String = ""
+    private val scripts = mutableListOf<String>()
+    private val events = mutableListOf<WindowEvent>()
+
     override fun launch(html: String) {
+        currentHtml = html
         val server = HttpServer.create(InetSocketAddress(0), 0)
         server.createContext("/") { exchange ->
             val bytes = html.toByteArray(Charsets.UTF_8)
@@ -30,5 +35,27 @@ class JvmForgeWindowManager : ForgeWindowManager {
         } else {
             println("Desktop browsing not supported. Open this URL manually: $url")
         }
+    }
+
+    override fun bind(html: String) {
+        currentHtml = html
+    }
+
+    override fun injectScript(snippet: ScriptSnippet) {
+        scripts.add(snippet.source)
+    }
+
+    override fun dispatchEvent(event: WindowEvent) {
+        events.add(event)
+    }
+
+    override fun captureSnapshot(): WindowSnapshot {
+        return WindowSnapshot(
+            timestampMillis = 0L,
+            dom = currentHtml,
+            boundScripts = scripts.toList(),
+            dispatchedEvents = events.toList(),
+            isNoop = false
+        )
     }
 }

--- a/src/jvmTest/kotlin/borg/trikeshed/forge/window/JvmForgeWindowManagerTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/forge/window/JvmForgeWindowManagerTest.kt
@@ -1,12 +1,5 @@
 package borg.trikeshed.forge.window
 
-import kotlin.test.Test
-import kotlin.test.assertNotNull
-
-class JvmForgeWindowManagerTest {
-    @Test
-    fun testInitialization() {
-        val wm = JvmForgeWindowManager()
-        assertNotNull(wm)
-    }
+class JvmForgeWindowManagerTest : WindowManagerContractTest() {
+    override fun getManager(): ForgeWindowManager = JvmForgeWindowManager()
 }

--- a/src/nativeMain/kotlin/borg/trikeshed/forge/window/NativeForgeWindowManager.kt
+++ b/src/nativeMain/kotlin/borg/trikeshed/forge/window/NativeForgeWindowManager.kt
@@ -1,18 +1,12 @@
 package borg.trikeshed.forge.window
 
-/**
- * WASM/JS Browser-based Window Manager that writes HTML directly into the document.
- */
-class BrowserForgeWindowManager : ForgeWindowManager {
+class NativeForgeWindowManager : ForgeWindowManager {
     private var currentHtml: String = ""
     private val scripts = mutableListOf<String>()
     private val events = mutableListOf<WindowEvent>()
 
     override fun launch(html: String) {
         currentHtml = html
-        if (isBrowser()) {
-            writeHtml(html)
-        }
     }
 
     override fun bind(html: String) {
@@ -37,7 +31,3 @@ class BrowserForgeWindowManager : ForgeWindowManager {
         )
     }
 }
-
-fun isBrowser(): Boolean = js("typeof window !== 'undefined' && typeof document !== 'undefined'")
-
-fun writeHtml(html: String): Unit = js("document.open(); document.write(html); document.close();")

--- a/src/posixTest/kotlin/borg/trikeshed/forge/window/NativeForgeWindowManagerTest.kt
+++ b/src/posixTest/kotlin/borg/trikeshed/forge/window/NativeForgeWindowManagerTest.kt
@@ -1,12 +1,5 @@
 package borg.trikeshed.forge.window
 
-import kotlin.test.Test
-import kotlin.test.assertNotNull
-
-class NativeForgeWindowManagerTest {
-    @Test
-    fun testInitialization() {
-        val wm = NativeForgeWindowManager()
-        assertNotNull(wm)
-    }
+class NativeForgeWindowManagerTest : WindowManagerContractTest() {
+    override fun getManager(): ForgeWindowManager = NativeForgeWindowManager()
 }

--- a/src/wasmJsTest/kotlin/borg/trikeshed/forge/window/BrowserForgeWindowManagerTest.kt
+++ b/src/wasmJsTest/kotlin/borg/trikeshed/forge/window/BrowserForgeWindowManagerTest.kt
@@ -1,12 +1,5 @@
 package borg.trikeshed.forge.window
 
-import kotlin.test.Test
-import kotlin.test.assertNotNull
-
-class BrowserForgeWindowManagerTest {
-    @Test
-    fun testInitialization() {
-        val wm = BrowserForgeWindowManager()
-        assertNotNull(wm)
-    }
+class BrowserForgeWindowManagerTest : WindowManagerContractTest() {
+    override fun getManager(): ForgeWindowManager = BrowserForgeWindowManager()
 }


### PR DESCRIPTION
Implemented `ForgeWindowManager` for `jvmMain`, `nativeMain`, and `wasmJsMain`. Adhered to TDD by writing `WindowManagerContractTest` in `commonTest` to verify that `launch`, `bind`, `injectScript`, and `dispatchEvent` modify internal state appropriately, which is then returned by `captureSnapshot`. Test suites for each target now extend this base contract test.

---
*PR created automatically by Jules for task [15013224584018093498](https://jules.google.com/task/15013224584018093498) started by @jnorthrup*