### PR TITLE
Implement ProjectionRegistry with project(cid) function

### DIFF
--- a/run_test_local.sh
+++ b/run_test_local.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew compileTestKotlinJvm jvmTest --tests '*ProjectionRegistryTest*' -x compileKotlinJvm

--- a/src/commonMain/kotlin/borg/trikeshed/job/ProjectionRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/ProjectionRegistry.kt
@@ -1,0 +1,43 @@
+package borg.trikeshed.job
+
+import borg.trikeshed.parse.confix.confixDoc
+import borg.trikeshed.parse.confix.Syntax
+import borg.trikeshed.parse.confix.value
+
+class ProjectionRegistry(val store: CasStore) {
+    fun project(cid: ContentId): Lens {
+        val bytes = store.get(cid) ?: return Raw
+
+        if (bytes.isEmpty()) {
+            return Raw
+        }
+
+        var firstNonWhitespace = -1
+        for (i in bytes.indices) {
+            val char = bytes[i].toInt().toChar()
+            if (!char.isWhitespace()) {
+                firstNonWhitespace = i
+                break
+            }
+        }
+
+        if (firstNonWhitespace == -1) {
+            return Raw
+        }
+
+        val syntax = if (bytes[firstNonWhitespace].toInt().toChar() in setOf('{', '[', '"')) Syntax.JSON else Syntax.CBOR
+        val doc = try {
+            confixDoc(bytes, syntax)
+        } catch (e: Exception) {
+            return Raw
+        }
+
+        val tagStr = doc.value("tag")?.toString() ?: doc.value("kind")?.toString()
+
+        return if (tagStr != null) {
+            LENS_TAG_MAP[tagStr] ?: Raw
+        } else {
+            Raw
+        }
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/job/ProjectionRegistryTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/job/ProjectionRegistryTest.kt
@@ -1,0 +1,36 @@
+package borg.trikeshed.job
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ProjectionRegistryTest {
+    @Test
+    fun testProject() {
+        val store = CasStore.inMemory()
+
+        val btreeBytes = """{"tag": "btree-page", "data": "dummy"}""".encodeToByteArray()
+        val causalBytes = """{"tag": "causal-node", "data": "dummy"}""".encodeToByteArray()
+        val manifestBytes = """{"tag": "treedoc-manifest", "data": "dummy"}""".encodeToByteArray()
+        val cursorBytes = """{"tag": "cursor", "data": "dummy"}""".encodeToByteArray()
+        val unknownBytes = """{"tag": "unknown-tag", "data": "dummy"}""".encodeToByteArray()
+        val noTagBytes = """{"other": "data"}""".encodeToByteArray()
+
+        val btreeCid = store.put(btreeBytes)
+        val causalCid = store.put(causalBytes)
+        val manifestCid = store.put(manifestBytes)
+        val cursorCid = store.put(cursorBytes)
+        val unknownCid = store.put(unknownBytes)
+        val noTagCid = store.put(noTagBytes)
+
+        val registry = ProjectionRegistry(store)
+
+        assertEquals(BtreePage, registry.project(btreeCid))
+        assertEquals(CausalNode, registry.project(causalCid))
+        assertEquals(Manifest, registry.project(manifestCid))
+        assertEquals(Cursor, registry.project(cursorCid))
+
+        assertEquals(Raw, registry.project(unknownCid))
+        assertEquals(Raw, registry.project(noTagCid))
+    }
+}


### PR DESCRIPTION
Implements projection registry with `project(cid): Lens` functionality.
The registry retrieves content bytes, detects the format, and maps the internal tag or kind to a Lens type like `BtreePage`, `CausalNode`, `Manifest`, `Cursor`, or defaults to `Raw`. Tests have been written following TDD.

---
*PR created automatically by Jules for task [7316193719413186668](https://jules.google.com/task/7316193719413186668) started by @jnorthrup*