### PR TITLE
feat: Implement ReducerRegistry for the fanout mix

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,3 @@
-All requested steps are done:
-1. `WireprotoCodec.kt` is implemented using `ActionEncoder` and `ActionDecoder` and exposed to commonMain.
-2. `PathCursorTransport.kt` is implemented mapping the Cursor inside the payload when `pathCursor` is non-null.
-3. `WireprotoRoundTripTest.kt` validates the encoding logic.
-4. Conflicting git merge markers and compilation issues within these scopes are successfully removed.
-
-I will mark the pre-commit step as complete and submit the changes.
+1. Implement the requested feature. Since the prompt states "Implement ReducerRegistry for mixing reducers in fanout" and there is no file containing the requested feature. I will provide `ReducerRegistry` map definition and `ReducerRegistry.runFor` function. I will add `Capability.category` so `winningCapability.category` works. I will also make sure `ReducerRegistryTest` properly tests it.
+2. Complete pre commit step.
+3. Submit PR.

--- a/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
@@ -9,15 +9,12 @@ import borg.trikeshed.context.nuid.NuidFanoutElement
 import borg.trikeshed.lcnc.reduction.LcncCarrierAlg
 import borg.trikeshed.lcnc.reduction.LcncReduction
 import borg.trikeshed.lcnc.reduction.LcncReductions
+import borg.trikeshed.lcnc.reduction.ReducerRegistry
+import borg.trikeshed.lcnc.reduction.category
 import kotlinx.coroutines.Job
 
 class LcncFanoutElement(
     private val nuidFanout: NuidFanoutElement,
-    private val reducerRegistry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
-        "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),
-        "cas" to LcncReductions.confixParse(),
-        "wireproto" to LcncReductions.crmsFold()
-    ),
     parentJob: Job? = null
 ) : AsyncContextElement(ElementState.CREATED, parentJob) {
 
@@ -27,18 +24,6 @@ class LcncFanoutElement(
     suspend fun dispatch(nuid: Nuid, payload: Any?): Any? {
         val winningCapability = nuidFanout.claimWinnerCapability(nuid, payload)
             ?: return null
-        val reduction = reducerRegistry[winningCapability.category] ?: return null
-
-        @Suppress("UNCHECKED_CAST")
-        val typedReduction = reduction as LcncReduction<Any, Any, Any, Any>
-        val typedCarrierAlg = typedReduction.carrierAlg
-
-        val carrier = if (payload != null) {
-            typedCarrierAlg.carrier(payload)
-        } else {
-            borg.trikeshed.lcnc.reduction.emptySeriesCarrier()
-        }
-
-        return typedReduction.execute(carrier)
+        return ReducerRegistry.runFor(winningCapability, payload)
     }
 }

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
@@ -2,6 +2,16 @@ package borg.trikeshed.lcnc.reduction
 
 import borg.trikeshed.context.nuid.Capability
 
+val Capability.category: String
+    get() = when (this) {
+        is Capability.Process -> "process"
+        is Capability.Cas -> "cas"
+        is Capability.Wireproto -> "wireproto"
+        is Capability.Mesh -> "mesh"
+        is Capability.ModelMux -> "modelmux"
+        else -> "custom"
+    }
+
 object ReducerRegistry {
     var registry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
         "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),

--- a/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
@@ -9,6 +9,7 @@ import borg.trikeshed.lcnc.reduction.KeyAlg
 import borg.trikeshed.lcnc.reduction.ValueAlg
 import borg.trikeshed.lcnc.reduction.PhaseAlg
 import borg.trikeshed.lcnc.reduction.CarrierAlg
+import borg.trikeshed.lcnc.reduction.ReducerRegistry
 import borg.trikeshed.lib.j
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -27,17 +28,10 @@ class LcncFanoutElementTest {
         val processWorkgroup = Workgroup(
             name = "process-worker",
             scope = Subnet.core,
-            traits = TraitSpace { 1 j { Capability.Process("test_process") } }
-        )
-
-        val casWorkgroup = Workgroup(
-            name = "cas-worker",
-            scope = Subnet.core,
-            traits = TraitSpace { 1 j { Capability.Cas("test_cas") } }
+            traits = TraitSpace { 1 j { Capability.Process } }
         )
 
         nuidFanout.register(processWorkgroup)
-        nuidFanout.register(casWorkgroup)
 
         var runForCalled = false
 
@@ -60,28 +54,33 @@ class LcncFanoutElementTest {
             }
         }
 
-        val stubRegistry = mapOf("process" to stubReduction)
+        // Mock ReducerRegistry temporarily to verify fanout
+        val originalRegistry = ReducerRegistry.registry
+        try {
+            ReducerRegistry.registry = mapOf("process" to stubReduction)
 
-        val lcncFanout = LcncFanoutElement(nuidFanout, stubRegistry)
-        lcncFanout.open()
+            val lcncFanout = LcncFanoutElement(nuidFanout)
+            lcncFanout.open()
 
-        val testPayload = emptyArray<Any>()
-        val nuid = nuid(Capability.Process("test_process"), Nonce.RandomBytes(), Subnet.core)
+            val testPayload = emptyArray<Any>()
+            val nuid = nuid(Capability.Process, Nonce.RandomBytes(), Subnet.core)
 
-        // Launch consumer so that nuidFanout polling loop can actually complete
-        val slot = nuidFanout.slotOf("process-worker")
-        assertNotNull(slot)
+            // Launch consumer so that nuidFanout polling loop can actually complete
+            val slot = nuidFanout.slotOf("process-worker")
+            assertNotNull(slot)
 
-        val job = launch {
-            val claim = slot.consume()
-            // Simulating successful dispatch inside the dispatcher
+            val job = launch {
+                val claim = slot.consume()
+            }
+
+            val result = lcncFanout.dispatch(nuid, testPayload)
+
+            assertTrue(runForCalled, "execute should have been called on the reduction")
+            assertEquals("success", result)
+
+            job.cancel()
+        } finally {
+            ReducerRegistry.registry = originalRegistry
         }
-
-        val result = lcncFanout.dispatch(nuid, testPayload)
-
-        assertTrue(runForCalled, "execute should have been called on the reduction")
-        assertEquals("success", result)
-
-        job.cancel()
     }
 }

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistryTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistryTest.kt
@@ -1,0 +1,34 @@
+package borg.trikeshed.lcnc.reduction
+
+import borg.trikeshed.context.nuid.Capability
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertEquals
+
+class ReducerRegistryTest {
+    @Test
+    fun testRegistryKeysForFanoutMix() {
+        assertNotNull(ReducerRegistry.registry["process"])
+        assertNotNull(ReducerRegistry.registry["cas"])
+        assertNotNull(ReducerRegistry.registry["wireproto"])
+    }
+
+    @Test
+    fun testCategoryExtension() {
+        assertEquals("process", Capability.Process.category)
+        assertEquals("cas", Capability.Cas.category)
+        assertEquals("wireproto", Capability.Wireproto.category)
+        assertEquals("mesh", Capability.Mesh.category)
+        assertEquals("modelmux", Capability.ModelMux.category)
+    }
+
+    @Test
+    fun testRunForMix() {
+        val res = ReducerRegistry.runFor(Capability.Process, null)
+        assertNotNull(res)
+
+        val meshRes = ReducerRegistry.runFor(Capability.Mesh, null)
+        assertNull(meshRes)
+    }
+}


### PR DESCRIPTION
Adds `.category` to Capability algebra. Routes `winningCapability` in `LcncFanoutElement.dispatch` to `ReducerRegistry.runFor`. Tested via `ReducerRegistryTest`.

---
*PR created automatically by Jules for task [4717587000565956998](https://jules.google.com/task/4717587000565956998) started by @jnorthrup*