### PR TITLE
Feat: Implement LCNC Block and Database Views

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockView.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockView.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.lcnc.editor
+
+import borg.trikeshed.lcnc.isam.LcncBlock
+
+class BlockView(val block: LcncBlock) {
+    fun renderHtml(): String {
+        val contentStr = block.content?.toString() ?: ""
+        return """
+            <div class="lcnc-block" data-block-id="${block.id}" data-block-type="${block.type}">
+                <div class="block-content">$contentStr</div>
+            </div>
+        """.trimIndent()
+    }
+}

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
@@ -1,0 +1,27 @@
+package borg.trikeshed.lcnc.editor
+
+import borg.trikeshed.lcnc.isam.LcncDatabase
+
+class DatabaseView(val database: LcncDatabase) {
+    fun renderHtml(): String {
+        val rowsHtml = StringBuilder()
+        for (i in 0 until database.pages.a) {
+            val page = database.pages.b(i)
+            rowsHtml.append("<tr><td>${page.title}</td></tr>\n")
+        }
+
+        return """
+            <div class="lcnc-database" data-database-id="${database.id}">
+                <h2>${database.title}</h2>
+                <table class="lcnc-database-table">
+                    <thead>
+                        <tr><th>Title</th></tr>
+                    </thead>
+                    <tbody>
+                        $rowsHtml
+                    </tbody>
+                </table>
+            </div>
+        """.trimIndent()
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/editor/LcncVisualEditorTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/editor/LcncVisualEditorTest.kt
@@ -1,0 +1,46 @@
+package borg.trikeshed.lcnc.editor
+
+import borg.trikeshed.lcnc.isam.*
+import borg.trikeshed.lib.j
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LcncVisualEditorTest {
+    @Test
+    fun testBlockViewRendersBlock() {
+        val block = LcncBlock(
+            id = "b1",
+            type = "paragraph",
+            parentId = "p1",
+            content = "Hello LCNC"
+        )
+        val view = BlockView(block)
+        val html = view.renderHtml()
+        assertTrue(html.contains("class=\"lcnc-block\""))
+        assertTrue(html.contains("data-block-id=\"b1\""))
+        assertTrue(html.contains("data-block-type=\"paragraph\""))
+        assertTrue(html.contains("Hello LCNC"))
+    }
+
+    @Test
+    fun testDatabaseViewRendersTable() {
+        val page1 = LcncPage(id = "page1", title = "Row 1", parentId = "db1", contentBlocks = 0 j { null!! })
+        val page2 = LcncPage(id = "page2", title = "Row 2", parentId = "db1", contentBlocks = 0 j { null!! })
+        val db = LcncDatabase(
+            id = "db1",
+            title = "My Database",
+            parentId = "ws1",
+            pages = 2 j { i -> if (i == 0) page1 else page2 }
+        )
+
+        val view = DatabaseView(db)
+        val html = view.renderHtml()
+
+        assertTrue(html.contains("class=\"lcnc-database\""))
+        assertTrue(html.contains("data-database-id=\"db1\""))
+        assertTrue(html.contains("<th>Title</th>"))
+        assertTrue(html.contains("<td>Row 1</td>"))
+        assertTrue(html.contains("<td>Row 2</td>"))
+    }
+}

--- a/src/wasmJsMain/kotlin/borg/trikeshed/forge/shell/HtmlShellWasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/forge/shell/HtmlShellWasm.kt
@@ -1,7 +1,6 @@
 package borg.trikeshed.forge.shell
 
 actual object HtmlShell {
-<<<<<<< HEAD
     actual fun load(): String {
         throw UnsupportedOperationException("Synchronous fetch not supported in JS. Use async.")
     }
@@ -13,9 +12,4 @@ actual object HtmlShell {
     actual fun jsAsset(name: String): String {
         throw UnsupportedOperationException("Synchronous fetch not supported in JS. Use async.")
     }
-=======
-    actual fun load(): String = TODO("Implement fetch via kotlinx.browser.window.fetch")
-    actual fun cssAsset(name: String): String = TODO("Implement fetch via kotlinx.browser.window.fetch")
-    actual fun jsAsset(name: String): String = TODO("Implement fetch via kotlinx.browser.window.fetch")
->>>>>>> origin/add-html-shell-assets-10555369453043646034
 }


### PR DESCRIPTION
Implemented the visual editor components for LCNC Block View and Database View. These views consume the previously implemented ISAM entities (LcncBlock and LcncDatabase) and generate HTML string representations for them. I also added a test class to verify their rendered outputs. Also fixed a pre-existing merge conflict issue in the `HtmlShellWasm.kt` file.

---
*PR created automatically by Jules for task [5886620823265023500](https://jules.google.com/task/5886620823265023500) started by @jnorthrup*