### PR TITLE
Refactor: Remove aspirational LCNC PropertyType values

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/collections/associative/LcncAssociative.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/collections/associative/LcncAssociative.kt
@@ -12,7 +12,7 @@ import borg.trikeshed.lib.j
  * Defines the type of a property (column) in a Lcnc Database.
  */
 enum class PropertyType {
-    TITLE, TEXT, NUMBER, SELECT, MULTI_SELECT, DATE, PEOPLE, FILES, CHECKBOX, URL, EMAIL, PHONE_NUMBER, FORMULA, RELATION, ROLLUP, CREATED_TIME, CREATED_BY, LAST_EDITED_TIME, LAST_EDITED_BY
+    TITLE, TEXT, NUMBER, SELECT, CHECKBOX, DATE
 }
 
 /**

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/collections/associative/LcncAssociativeTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/collections/associative/LcncAssociativeTest.kt
@@ -1,0 +1,15 @@
+package borg.trikeshed.lcnc.collections.associative
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LcncAssociativeTest {
+    @Test
+    fun testSupportedPropertyTypesOnly() {
+        val expectedTypes = setOf(
+            "TITLE", "TEXT", "NUMBER", "SELECT", "CHECKBOX", "DATE"
+        )
+        val actualTypes = PropertyType.values().map { it.name }.toSet()
+        assertEquals(expectedTypes, actualTypes, "PropertyType should only contain supported types")
+    }
+}


### PR DESCRIPTION
Removes unimplemented/aspirational `PropertyType` enum values in the associative mapping gems for the LCNC taxonomy to match the exact set of supported features downstream. Also includes the required tests following TDD principles.

---
*PR created automatically by Jules for task [912477639506635357](https://jules.google.com/task/912477639506635357) started by @jnorthrup*