### PR TITLE
feat: Add IPFS/IPNS bridge to CAS

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/IpfsBridge.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/IpfsBridge.kt
@@ -1,0 +1,31 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.collections.associative.LinearHashMap
+
+/**
+ * IpfsBridge maps IPFS concepts to TrikeShed's CAS and Manifests.
+ * - CAS blocks as IPFS blocks.
+ * - IPNS names resolve to CasManifest CIDs.
+ */
+class IpfsBridge(private val cas: CasStore) {
+    // Map of IPNS name to Manifest CID
+    private val ipnsRegistry = LinearHashMap<String, ContentId>()
+
+    fun putBlock(data: ByteArray): ContentId {
+        return cas.put(data)
+    }
+
+    fun getBlock(cid: ContentId): ByteArray? {
+        return cas.get(cid)
+    }
+
+    fun publishIpns(name: String, manifestCid: ContentId) {
+        ipnsRegistry[name] = manifestCid
+    }
+
+    fun resolveIpns(name: String): ContentId? {
+        return ipnsRegistry[name]
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/cas/IpfsBridgeTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/cas/IpfsBridgeTest.kt
@@ -1,0 +1,45 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.CasStore
+import borg.trikeshed.job.ContentId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class IpfsBridgeTest {
+
+    @Test
+    fun testIpfsBlocks() {
+        val cas = CasStore.inMemory()
+        val bridge = IpfsBridge(cas)
+
+        val data = "hello ipfs".encodeToByteArray()
+        val cid = bridge.putBlock(data)
+
+        val retrieved = bridge.getBlock(cid)
+        assertNotNull(retrieved)
+        assertEquals("hello ipfs", retrieved.decodeToString())
+
+        // Verify it's actually in CAS
+        val casRetrieved = cas.get(cid)
+        assertNotNull(casRetrieved)
+        assertEquals("hello ipfs", casRetrieved.decodeToString())
+    }
+
+    @Test
+    fun testIpnsResolution() {
+        val cas = CasStore.inMemory()
+        val bridge = IpfsBridge(cas)
+
+        // In this bridge, IPNS names map to CasManifest CIDs
+        val manifestCid = ContentId.of("dummy-manifest-content".encodeToByteArray())
+
+        bridge.publishIpns("my-node", manifestCid)
+
+        val resolved = bridge.resolveIpns("my-node")
+        assertEquals(manifestCid, resolved)
+
+        assertNull(bridge.resolveIpns("unknown-node"))
+    }
+}


### PR DESCRIPTION
This PR introduces an IPFS/IPNS bridge to the CAS module. It treats CAS blocks as IPFS blocks by directly utilizing the underlying `CasStore` for block storage and retrieval. Furthermore, it allows IPNS string names to be resolved directly into `CasManifest` CIDs via an internal registry. The development was done following TDD, with a new unit test class `IpfsBridgeTest` ensuring the functionality of both block storage and IPNS resolution.

---
*PR created automatically by Jules for task [2863008315942613171](https://jules.google.com/task/2863008315942613171) started by @jnorthrup*