### PR TITLE
fix: eagerly materialize row values from GraalVM cursor before Context closes

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHost.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHost.kt
@@ -93,17 +93,17 @@ object GraalVmCursorHost {
             defaultMeta
         }
 
-        return size j { i: Int ->
+        val metaList = mutableListOf<ColumnMeta>()
+        var current: ColumnMeta? = exemplarMeta()
+        while (current != null) {
+            metaList.add(current)
+            current = current.child
+        }
+
+        // Eagerly materialize all row values before context closes
+        val eagerlyEvaluatedRows = Array(size) { i ->
             val rowVal = value.getArrayElement(i.toLong())
-
-            val metaList = mutableListOf<ColumnMeta>()
-            var current: ColumnMeta? = exemplarMeta()
-            while (current != null) {
-                metaList.add(current)
-                current = current.child
-            }
-
-            val rowValues = Array<Any?>(metaList.size) { colIdx ->
+            Array<Any?>(metaList.size) { colIdx ->
                 val meta = metaList[colIdx]
                 val memberVal = rowVal.getMember(meta.name.toString())
                 when (meta.type) {
@@ -114,7 +114,10 @@ object GraalVmCursorHost {
                     else -> null // Simplification for test
                 }
             }
+        }
 
+        return size j { i: Int ->
+            val rowValues = eagerlyEvaluatedRows[i]
             val rowA = (rowValues.size j { idx: Int -> rowValues[idx] })
             val res = rowA j exemplarMeta
             res as RowVec

--- a/src/jvmTest/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHostTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHostTest.kt
@@ -1,0 +1,65 @@
+package borg.trikeshed.couch.viewserver
+
+import borg.trikeshed.cursor.ColumnMeta
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.cursor.IOMemento
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.`ColumnMeta↻`
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import borg.trikeshed.lib.get
+import borg.trikeshed.lib.size
+
+class GraalVmCursorHostTest {
+    @Test
+    fun testReduceCursor() {
+        // Create 50 rows, each with one Double and one String column
+        val exemplarMeta: `ColumnMeta↻` = {
+            ColumnMeta("value", IOMemento.IoDouble,
+                ColumnMeta("name", IOMemento.IoString)
+            )
+        }
+
+        val rows = 50
+        val cursor: Cursor = rows j { i: Int ->
+            val vals: Series<Any?> = 2 j { col: Int ->
+                when (col) {
+                    0 -> i.toDouble()
+                    1 -> "row_$i"
+                    else -> null
+                }
+            }
+            val rowVec = vals j exemplarMeta
+            rowVec as RowVec
+        }
+
+        // JS Script to double the 'value' column
+        val jsScript = """
+            (function(cursor) {
+                var out = [];
+                for (var i = 0; i < cursor.length; i++) {
+                    var row = cursor[i];
+                    out.push({
+                        value: row.value * 2,
+                        name: row.name
+                    });
+                }
+                return out;
+            })
+        """.trimIndent()
+
+        val resultCursor = GraalVmCursorHost.reduceCursor(cursor, jsScript)
+
+        assertEquals(50, resultCursor.size) // Assert size
+
+        // Check contents
+        for (i in 0 until 50) {
+            val resRow: RowVec = resultCursor[i]
+            val vals = resRow.a as Series<Any?>
+            assertEquals(i.toDouble() * 2.0, vals[0])
+            assertEquals("row_$i", vals[1])
+        }
+    }
+}


### PR DESCRIPTION
The `reduceCursor` function previously evaluated `Value` elements on-demand in a lazy `Cursor` after the polyglot `Context` was closed, throwing `IllegalStateException`.
This fix eagerly resolves all arrays from the host into a Kotlin `Array` buffer within the active context block before constructing the final lazy `Cursor`, solving the problem while preserving `j` algebra invariants.

---
*PR created automatically by Jules for task [834676480458987635](https://jules.google.com/task/834676480458987635) started by @jnorthrup*