### PR TITLE
Replace LcncFanoutElement tests and inject registry

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
@@ -9,12 +9,16 @@ import borg.trikeshed.context.nuid.NuidFanoutElement
 import borg.trikeshed.lcnc.reduction.LcncCarrierAlg
 import borg.trikeshed.lcnc.reduction.LcncReduction
 import borg.trikeshed.lcnc.reduction.LcncReductions
-import borg.trikeshed.lcnc.reduction.ReducerRegistry
 import borg.trikeshed.lcnc.reduction.category
 import kotlinx.coroutines.Job
 
 class LcncFanoutElement(
     private val nuidFanout: NuidFanoutElement,
+    private val reducerRegistry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
+        "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),
+        "cas" to LcncReductions.confixParse(),
+        "wireproto" to LcncReductions.crmsFold()
+    ),
     parentJob: Job? = null
 ) : AsyncContextElement(ElementState.CREATED, parentJob) {
 
@@ -24,6 +28,18 @@ class LcncFanoutElement(
     suspend fun dispatch(nuid: Nuid, payload: Any?): Any? {
         val winningCapability = nuidFanout.claimWinnerCapability(nuid, payload)
             ?: return null
-        return ReducerRegistry.runFor(winningCapability, payload)
+        val reduction = reducerRegistry[winningCapability.category] ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val typedReduction = reduction as LcncReduction<Any, Any, Any, Any>
+        val typedCarrierAlg = typedReduction.carrierAlg
+
+        val carrier = if (payload != null) {
+            typedCarrierAlg.carrier(payload)
+        } else {
+            borg.trikeshed.lcnc.reduction.emptySeriesCarrier()
+        }
+
+        return typedReduction.execute(carrier)
     }
 }

--- a/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
@@ -1,0 +1,131 @@
+package borg.trikeshed.context.lcnc
+
+import borg.trikeshed.context.nuid.*
+import borg.trikeshed.lcnc.reduction.LcncReduction
+import borg.trikeshed.lcnc.reduction.ReductionCarrier
+import borg.trikeshed.lcnc.reduction.ReductionResult
+import borg.trikeshed.lcnc.reduction.KeyAlg
+import borg.trikeshed.lcnc.reduction.ValueAlg
+import borg.trikeshed.lcnc.reduction.PhaseAlg
+import borg.trikeshed.lcnc.reduction.CarrierAlg
+import borg.trikeshed.lib.j
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.assertNull
+
+class LcncFanoutElementTest {
+
+    @Test
+    fun testDispatchCallsReducerRegistryWithWinningCapability() = runTest {
+        val nuidFanout = NuidFanoutElement()
+        nuidFanout.open()
+
+        val processWorkgroup = Workgroup(
+            name = "process-worker",
+            scope = Subnet.core,
+            traits = TraitSpace { 1 j { Capability.Process("test_process") } }
+        )
+
+        nuidFanout.register(processWorkgroup)
+
+        var runForCalled = false
+
+        val stubReduction = object : LcncReduction<Any, Any, Any, Any> {
+            override val keyAlg: KeyAlg<Any> get() = TODO("Not yet implemented")
+            override val valueAlg: ValueAlg<Any, Any> get() = TODO("Not yet implemented")
+            override val phaseAlg: PhaseAlg get() = TODO("Not yet implemented")
+            override val carrierAlg: CarrierAlg<Any>
+                get() = object : CarrierAlg<Any> {
+                    override val carrier: (Any) -> ReductionCarrier<Any> = { borg.trikeshed.lcnc.reduction.emptySeriesCarrier() }
+                }
+
+            override fun execute(input: ReductionCarrier<*>): Any {
+                runForCalled = true
+                return "success"
+            }
+
+            override fun executeWithCheckpoints(input: ReductionCarrier<*>): ReductionResult<Any> {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val stubRegistry = mapOf("process" to stubReduction)
+
+        val lcncFanout = LcncFanoutElement(nuidFanout, stubRegistry)
+        lcncFanout.open()
+
+        val testPayload = emptyArray<Any>()
+        val nuid = nuid(Capability.Process("test_process"), Nonce.RandomBytes(), Subnet.core)
+
+        // Launch consumer so that nuidFanout polling loop can actually complete
+        val slot = nuidFanout.slotOf("process-worker")
+        assertNotNull(slot)
+
+        val job = launch {
+            val claim = slot.consume()
+            // Simulating successful dispatch inside the dispatcher
+        }
+
+        val result = lcncFanout.dispatch(nuid, testPayload)
+
+        assertTrue(runForCalled, "execute should have been called on the reduction")
+        assertEquals("success", result)
+
+        job.cancel()
+    }
+
+    @Test
+    fun testDispatchWithoutWinningCapabilityReturnsNull() = runTest {
+        val nuidFanout = NuidFanoutElement()
+        nuidFanout.open()
+
+        val lcncFanout = LcncFanoutElement(nuidFanout, emptyMap())
+        lcncFanout.open()
+
+        // Missing workgroup -> no claim
+        val testPayload = emptyArray<Any>()
+        val nuid = nuid(Capability.Process("test_process"), Nonce.RandomBytes(), Subnet.core)
+
+        val result = lcncFanout.dispatch(nuid, testPayload)
+
+        assertNull(result, "Expected null since no workgroup claims the NUID")
+    }
+
+    @Test
+    fun testDispatchWinningCapabilityWithNoReducerReturnsNull() = runTest {
+        val nuidFanout = NuidFanoutElement()
+        nuidFanout.open()
+
+        val processWorkgroup = Workgroup(
+            name = "process-worker",
+            scope = Subnet.core,
+            traits = TraitSpace { 1 j { Capability.Process("test_process") } }
+        )
+
+        nuidFanout.register(processWorkgroup)
+
+        // Empty registry means we have a winning capability, but no reducer mapped for its category
+        val lcncFanout = LcncFanoutElement(nuidFanout, emptyMap())
+        lcncFanout.open()
+
+        val testPayload = emptyArray<Any>()
+        val nuid = nuid(Capability.Process("test_process"), Nonce.RandomBytes(), Subnet.core)
+
+        val slot = nuidFanout.slotOf("process-worker")
+        assertNotNull(slot)
+
+        val job = launch {
+            slot.consume()
+        }
+
+        val result = lcncFanout.dispatch(nuid, testPayload)
+
+        assertNull(result, "Expected null since no reducer is mapped in the registry")
+
+        job.cancel()
+    }
+}


### PR DESCRIPTION
* Implemented tests covering `LcncFanoutElement` in `src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt`.
* Updated `LcncFanoutElement` to accept a `reducerRegistry` map in its constructor, with defaults pointing to the expected reductions. This breaks the hard dependency on `ReducerRegistry` during testing and dispatch.
* Added missing-capability and unmapped-reducer boundary tests.

---
*PR created automatically by Jules for task [17261368136240186027](https://jules.google.com/task/17261368136240186027) started by @jnorthrup*