### PR TITLE
fix(blackboard): ensure lcnc block titles map to kanban card titles

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,3 +1,0 @@
-1. Implement the requested feature. Since the prompt states "Implement ReducerRegistry for mixing reducers in fanout" and there is no file containing the requested feature. I will provide `ReducerRegistry` map definition and `ReducerRegistry.runFor` function. I will add `Capability.category` so `winningCapability.category` works. I will also make sure `ReducerRegistryTest` properly tests it.
-2. Complete pre commit step.
-3. Submit PR.

--- a/src/commonMain/kotlin/borg/trikeshed/blackboard/BlackboardSurface.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/blackboard/BlackboardSurface.kt
@@ -27,6 +27,7 @@ import borg.trikeshed.lcnc.isam.LcncBlock
 import borg.trikeshed.forge.causalKey
 import borg.trikeshed.forge.facet
 import borg.trikeshed.forge.lane
+import borg.trikeshed.forge.title
 
 /**
  * One row of the visual blackboard.
@@ -43,6 +44,7 @@ data class BlackboardSurfaceRow(
     val provenance: String?,
     val causalKey: String,
     val lcncKind: String,
+    val title: String?,
 )
 
 /**
@@ -81,6 +83,7 @@ class BlackboardSurface private constructor(
             "provenance" to IOMemento.IoString,
             "causalKey" to IOMemento.IoString,
             "lcncKind" to IOMemento.IoString,
+            "title" to IOMemento.IoString,
         )
 
         fun project(
@@ -128,6 +131,7 @@ class BlackboardSurface private constructor(
                     provenance = context.provenance?.source,
                     causalKey = causalKey ?: node?.causalKey ?: "lcnc:${entity.id}",
                     lcncKind = entity.type,
+                    title = entity.title,
                 )
             }
 
@@ -139,7 +143,7 @@ class BlackboardSurface private constructor(
                 }
                 KanbanCard(
                     id = KanbanCardId(row.cardId),
-                    title = rows[order].cardId,
+                    title = row.title ?: rows[order].cardId,
                     description = "lcnc:${rows[order].lcncKind}",
                     columnId = KanbanColumnId(row.lane),
                     order = order,
@@ -212,6 +216,7 @@ class BlackboardSurface private constructor(
                 row.provenance,
                 row.causalKey,
                 row.lcncKind,
+                row.title,
             )
             return SURFACE_COLUMNS.size j { col: Int ->
                 values[col] j { ColumnMeta(SURFACE_COLUMNS[col].first, SURFACE_COLUMNS[col].second) }

--- a/src/commonTest/kotlin/borg/trikeshed/blackboard/BlackboardSurfaceProjectionTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/blackboard/BlackboardSurfaceProjectionTest.kt
@@ -1,0 +1,71 @@
+package borg.trikeshed.blackboard
+
+import borg.trikeshed.cursor.blackboardContext
+import borg.trikeshed.graph.CausalGraphNodeIndex
+import borg.trikeshed.graph.causalGraphNode
+import borg.trikeshed.lib.get
+import borg.trikeshed.lib.size
+import borg.trikeshed.lcnc.isam.LcncBlock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BlackboardSurfaceProjectionTest {
+
+    @Test fun lcncEntitiesProjectFirstAndCausalNodesAttachByCausalKey() {
+        val index = CausalGraphNodeIndex()
+        val boardA = blackboardContext(id = "board-a")
+        val boardB = blackboardContext(id = "board-b")
+
+        index.addOrGet(causalGraphNode("root", "plan", "v1", emptyList(), "seed", boardA, 1L, 0, "out:root"))
+        index.addOrGet(causalGraphNode("child", "agent-work", "v1", listOf("root"), "seed+root", boardA, 2L, 1, "out:child"))
+        index.addOrGet(causalGraphNode("other", "plan", "v1", emptyList(), "seed", boardB, 3L, 0, "out:other"))
+
+        val rootKey = index.byNodeId("root")?.let { index[it].causalKey } ?: error("root causalKey missing")
+        val childKey = index.byNodeId("child")?.let { index[it].causalKey } ?: error("child causalKey missing")
+
+        val entities = listOf(
+            LcncBlock(id = "e-child", type = "Facet", parentId = null, content = mapOf("lane" to "col-causal-blocked", "facet" to "facet/A", "causalKey" to childKey, "title" to "Child Node Title")),
+            LcncBlock(id = "e-other", type = "Taxonomy", parentId = null, content = mapOf("lane" to "col-causal-blocked", "facet" to "facet/B", "title" to "Other Node Title")),
+            LcncBlock(id = "e-root", type = "Facet", parentId = null, content = mapOf("lane" to "col-causal-ready", "facet" to "facet/A", "causalKey" to rootKey, "title" to "Root Node Title")),
+        )
+
+        val surface = BlackboardSurface.project("board-a", index, entities)
+
+        assertEquals(3, surface.rows.size, "one row per lcnc entity, even when no causal node matches")
+        assertEquals(listOf("e-child", "e-other", "e-root"), surface.rows.map { it.cardId })
+        assertEquals(listOf("Facet", "Taxonomy", "Facet"), surface.rows.map { it.lcncKind })
+
+        val byCard = surface.rows.associateBy { it.cardId }
+
+        assertEquals("col-causal-blocked", byCard.getValue("e-child").lane)
+        assertEquals("pre-agent", byCard.getValue("e-child").phase)
+        assertEquals("facet/A", byCard.getValue("e-child").facet)
+        assertEquals(childKey, byCard.getValue("e-child").causalKey)
+        assertEquals("Facet", byCard.getValue("e-child").lcncKind)
+
+        assertEquals("col-causal-blocked", byCard.getValue("e-other").lane)
+        assertEquals("lcnc:e-other", byCard.getValue("e-other").causalKey)
+
+        assertEquals("col-causal-ready", byCard.getValue("e-root").lane)
+        assertEquals(rootKey, byCard.getValue("e-root").causalKey)
+
+        val cursor = surface.asCursor()
+        assertEquals(3, cursor.size)
+        assertEquals("e-child", cursor[0][0].a)
+        assertEquals("card_id", cursor[0][0].b().name)
+
+        val board = surface.board
+        assertEquals(listOf("Causal Ready", "Causal Blocked", "Agentic Work"), board.columns.map { it.name })
+        val cardsById = board.cards.associateBy { it.id.value }
+        assertTrue(cardsById.containsKey("e-child"))
+        assertTrue(cardsById.containsKey("e-root"))
+        assertTrue(cardsById.containsKey("e-other"))
+        assertEquals("Facet", cardsById.getValue("e-root").tags.first { it != "lcnc-entity" })
+
+        // Ensure card titles are projected correctly, not falling back to cardId
+        assertEquals("Child Node Title", cardsById.getValue("e-child").title)
+        assertEquals("Root Node Title", cardsById.getValue("e-root").title)
+        assertEquals("Other Node Title", cardsById.getValue("e-other").title)
+    }
+}


### PR DESCRIPTION
Restore comprehensive executable coverage for BlackboardSurface in TDD RED replacement, and ensure `LcncBlock` titles project accurately to Kanban boards. 

*   Added `val title: String?` to `BlackboardSurfaceRow`.
*   Propagated `entity.title` from `borg.trikeshed.forge.title` inside `BlackboardSurface.project()`.
*   Fixed `KanbanCard` construction to use `row.title ?: rows[order].cardId`.
*   Registered `"title" to IOMemento.IoString` in `SURFACE_COLUMNS` and added `row.title` to the `rowToRowVec` value builder logic. 
*   Added replacement suite `BlackboardSurfaceProjectionTest`.

---
*PR created automatically by Jules for task [11399310386810426572](https://jules.google.com/task/11399310386810426572) started by @jnorthrup*