### PR TITLE
Fix CouchStore test coverage and logic

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/couch/CouchStore.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/CouchStore.kt
@@ -66,8 +66,8 @@ class CouchStore(
     /**
      * Put a document — insert or replace.
      */
-    fun put(document: Document): Boolean {
-        return ingress.putIntent(document, null)
+    fun put(document: Document, expectedRev: String? = null): Boolean {
+        return ingress.putIntent(document, expectedRev)
     }
     
     /**
@@ -80,8 +80,8 @@ class CouchStore(
     /**
      * Delete a document by id.
      */
-    fun delete(docId: String): Boolean {
-        return ingress.deleteIntent(docId, null)
+    fun delete(docId: String, expectedRev: String? = null): Boolean {
+        return ingress.deleteIntent(docId, expectedRev)
     }
 
     /**
@@ -130,7 +130,7 @@ class CouchStore(
                 if (frame.deleted) {
                     observer(MutationEvent.Deleted(frame.docId))
                 } else if (frame.doc != null) {
-                    if (frame.rev.startsWith("uuid-0-")) {
+                    if (frame.rev.startsWith("1-")) {
                          observer(MutationEvent.Inserted(frame.doc))
                     } else {
                          observer(MutationEvent.Updated(frame.doc))
@@ -148,7 +148,7 @@ class CouchStore(
             val mapped: Series<MutationEvent> = src.size j { i: Int ->
                 val f = src[i]
                 if (f.deleted) MutationEvent.Deleted(f.docId)
-                else if (f.rev.startsWith("uuid-0-")) MutationEvent.Inserted(f.doc!!)
+                else if (f.rev.startsWith("1-")) MutationEvent.Inserted(f.doc!!)
                 else MutationEvent.Updated(f.doc!!)
             }
             // For now, this is a leaky abstraction that wraps Series inside a Twin dummy view.

--- a/src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
@@ -1,0 +1,239 @@
+package borg.trikeshed.couch
+
+import borg.trikeshed.cursor.Cursor
+import borg.trikeshed.lib.Twin
+import borg.trikeshed.lib.Series
+import kotlin.test.*
+
+class CouchStoreCoverageTest {
+
+
+    @Test
+    fun testCreateUpdateDeleteRoundTrip() {
+        val store = CouchStoreFactory.inMemory()
+
+        val doc1 = Document("doc1", listOf(Field("name", "Alice")))
+        assertTrue(store.put(doc1), "Initial put should return true")
+
+        val retrieved1 = store.get("doc1")
+        assertNotNull(retrieved1)
+        assertEquals("Alice", retrieved1.fields.first { it.name == "name" }.value)
+
+        val rev1 = store.head.getRev("doc1")
+        assertNotNull(rev1)
+
+        val doc1Update = Document("doc1", listOf(Field("name", "Bob")))
+        val updateResult = store.put(doc1Update, rev1)
+        assertTrue(updateResult, "Update put should return true")
+
+        val retrieved2 = store.get("doc1")
+        assertNotNull(retrieved2)
+        assertEquals("Bob", retrieved2.fields.first { it.name == "name" }.value)
+
+        val rev2 = store.head.getRev("doc1")
+        assertNotNull(rev2)
+
+        assertTrue(store.delete("doc1", rev2), "Delete should return true")
+        assertNull(store.get("doc1"), "Document should be null after delete")
+        assertFalse(store.contains("doc1"), "Store should not contain deleted doc")
+    }
+
+
+    @Test
+    fun testStaleRevisionRejection() {
+        val store = CouchStoreFactory.inMemory()
+
+        val doc1 = Document("doc1", listOf(Field("name", "Alice")))
+        assertTrue(store.put(doc1), "Initial put should succeed")
+
+        val rev = store.head.getRev("doc1")
+        assertNotNull(rev)
+
+        val doc1Update = Document("doc1", listOf(Field("name", "Bob")))
+        assertFalse(store.put(doc1Update, "bad-rev"), "Update with bad rev should fail")
+        assertFalse(store.put(doc1Update), "Update with null rev on existing doc should fail")
+        assertTrue(store.put(doc1Update, rev), "Update with correct rev should succeed")
+    }
+
+
+    @Test
+    fun testTombstoneHistory() {
+        val store = CouchStoreFactory.inMemory()
+
+        val doc1 = Document("doc1", listOf(Field("name", "Alice")))
+        store.put(doc1)
+
+        val rev1 = store.head.getRev("doc1")
+        assertNotNull(rev1)
+
+        store.delete("doc1", rev1)
+
+        assertNull(store.get("doc1"))
+        assertFalse(store.contains("doc1"))
+        assertTrue(store.head.isDeleted("doc1"))
+
+        val revAfterDelete = store.head.getRev("doc1")
+        assertNotNull(revAfterDelete)
+        assertNotEquals(rev1, revAfterDelete)
+        assertTrue(revAfterDelete.endsWith("-deleted"))
+    }
+
+
+    @Test
+    fun testNoPreCommitVisibility() {
+        // Asserting that changes only reflect successfully committed intents
+        val head = CouchHeadProjection()
+        val changes = CouchChangesProjection()
+
+        var commitCount = 0
+        val ingress = ProductionCouchIngress(
+            head = head,
+            commitBoundary = { frame ->
+                head.applyCommit(frame)
+                changes.applyCommit(frame)
+                commitCount++
+            },
+            contentIdFn = { doc -> borg.trikeshed.job.ContentId.of(doc.id.encodeToByteArray()) }
+        )
+
+        val doc1 = Document("doc1", listOf())
+        ingress.putIntent(doc1, null)
+        assertEquals(1, commitCount)
+
+        // Stale update intent should fail and NOT trigger commitBoundary
+        val intentResult = ingress.putIntent(doc1, "wrong-rev")
+        assertFalse(intentResult)
+        assertEquals(1, commitCount)
+    }
+
+
+    @Test
+    fun testContainsCheck() {
+        val store = CouchStoreFactory.inMemory()
+        assertFalse(store.contains("doc1"))
+        store.put(Document("doc1", listOf()))
+        assertTrue(store.contains("doc1"))
+    }
+
+
+    @Test
+    fun testSubscriptionReceivesMutations() {
+        val store = CouchStoreFactory.inMemory()
+
+        val events = mutableListOf<CouchStore.MutationEvent>()
+        val cancel = store.subscribeMutations { events.add(it) }
+
+        store.put(Document("doc1", listOf(Field("name", "Alice"))))
+
+        val rev1 = store.head.getRev("doc1")!!
+        store.put(Document("doc1", listOf(Field("name", "Bob"))), rev1)
+
+        val rev2 = store.head.getRev("doc1")!!
+        store.delete("doc1", rev2)
+
+        assertEquals(3, events.size)
+        assertTrue(events[0] is CouchStore.MutationEvent.Inserted)
+        assertTrue(events[1] is CouchStore.MutationEvent.Updated)
+        assertTrue(events[2] is CouchStore.MutationEvent.Deleted)
+
+        cancel()
+    }
+
+
+    @Test
+    fun testChangesResumeAndReplayEquivalence() {
+        val store = CouchStoreFactory.inMemory()
+
+        store.put(Document("doc1", listOf(Field("name", "Alice"))))
+        store.put(Document("doc2", listOf(Field("name", "Bob"))))
+        val rev2 = store.head.getRev("doc2")!!
+        store.delete("doc2", rev2)
+
+        val frames = store.changes.series()
+        assertEquals(3, frames.a)
+
+        val afterSeq0 = store.changes.afterSequence(frames.b(0).sequence)
+        assertEquals(2, afterSeq0.a)
+        assertEquals("doc2", afterSeq0.b(0).docId)
+        assertFalse(afterSeq0.b(0).deleted)
+        assertEquals("doc2", afterSeq0.b(1).docId)
+        assertTrue(afterSeq0.b(1).deleted)
+    }
+
+
+    @Test
+    fun testQueryAllReturnsCursor() {
+        val store = CouchStoreFactory.inMemory()
+
+        store.put(Document("doc1", listOf(Field("name", "Alice"))))
+        store.put(Document("doc2", listOf(Field("name", "Bob"))))
+
+        val result = store.query()
+        assertEquals(2L, result.totalCount)
+        assertEquals(2, result.cursor.a)
+
+        val row0 = result.cursor.b(0)
+        assertEquals("doc1", row0.b(0).a) // _id
+        assertEquals("Alice", row0.b(1).a) // name
+    }
+
+
+    @Test
+    fun testIdsReturnsAllDocumentIds() {
+        val store = CouchStoreFactory.inMemory()
+        store.put(Document("doc1", listOf()))
+        store.put(Document("doc2", listOf()))
+
+        val ids = store.ids()
+        assertEquals(2, ids.a)
+        val idList = mutableListOf<String>()
+        for (i in 0 until ids.a) {
+            idList.add(ids.b(i))
+        }
+        assertTrue(idList.contains("doc1"))
+        assertTrue(idList.contains("doc2"))
+    }
+
+
+
+
+    @Test
+    fun testFlushAndDrainAreNoOpForInMemory() {
+        val store = CouchStoreFactory.inMemory()
+        store.flush()
+        store.drain()
+        store.close()
+    }
+
+
+
+    @Test
+    fun testViewServerExecuteStoreUsesQueryCursorPath() {
+        val store = CouchStoreFactory.inMemory()
+        store.put(Document("doc1", listOf(Field("name", "Alice"), Field("age", 30))))
+        store.put(Document("doc2", listOf(Field("name", "Bob"), Field("age", 40))))
+
+        val viewDef = ViewDefinition(ddoc = "test", viewName = "testView", mapFn = MapFunction.Emit(KeyExpr.DocField("name"), ValueExpr.DocField("age")))
+
+        val viewServer = ViewServer()
+        val result = viewServer.execute(viewDef, store)
+
+        assertEquals(2, result.rows.a)
+
+        var foundAlice = false
+        var foundBob = false
+        for (i in 0 until result.rows.a) {
+            val row = result.rows.b(i)
+            if (row.key == "Alice") {
+                assertEquals(30, row.value)
+                foundAlice = true
+            }
+            if (row.key == "Bob") {
+                assertEquals(40, row.value)
+                foundBob = true
+            }
+        }
+        assertTrue(foundAlice)
+        assertTrue(foundBob)
+    }
+}

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,9 @@
+sed -i 's/^    fun testCreateUpdateDeleteRoundTrip() {/    @Test\n    fun testCreateUpdateDeleteRoundTrip() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testStaleRevisionRejection() {/    @Test\n    fun testStaleRevisionRejection() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testTombstoneHistory() {/    @Test\n    fun testTombstoneHistory() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testNoPreCommitVisibility() {/    @Test\n    fun testNoPreCommitVisibility() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testContainsCheck() {/    @Test\n    fun testContainsCheck() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testSubscriptionReceivesMutations() {/    @Test\n    fun testSubscriptionReceivesMutations() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testChangesResumeAndReplayEquivalence() {/    @Test\n    fun testChangesResumeAndReplayEquivalence() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testQueryAllReturnsCursor() {/    @Test\n    fun testQueryAllReturnsCursor() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt
+sed -i 's/^    fun testIdsReturnsAllDocumentIds() {/    @Test\n    fun testIdsReturnsAllDocumentIds() {/' src/commonTest/kotlin/borg/trikeshed/couch/CouchStoreCoverageTest.kt


### PR DESCRIPTION
Restore CouchStore tests and fix logic around rev.

---
*PR created automatically by Jules for task [14335375926106556249](https://jules.google.com/task/14335375926106556249) started by @jnorthrup*