### PR TITLE
test: Add ConflictMarkerAuditTest to prevent regression of conflict markers

### DIFF
--- a/fix_all.sh
+++ b/fix_all.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Run tests to make sure there are no issues.
+./gradlew jvmTest --tests "borg.trikeshed.ConflictMarkerAuditTest"

--- a/src/jvmTest/kotlin/borg/trikeshed/ConflictMarkerAuditTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/ConflictMarkerAuditTest.kt
@@ -1,0 +1,28 @@
+package borg.trikeshed
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.fail
+
+class ConflictMarkerAuditTest {
+    @Test
+    fun positioningPaperFilesDoNotContainConflictMarkers() {
+        val filesToCheck = listOf(
+            "src/commonMain/kotlin/borg/trikeshed/forge/shell/HtmlShell.kt",
+            "src/commonMain/kotlin/borg/trikeshed/wireproto/ActionDecoder.kt"
+        )
+        for (filePath in filesToCheck) {
+            val file = File(filePath)
+            if (!file.exists()) {
+                val absolutePath = File(".").absolutePath
+                fail("File $filePath does not exist relative to $absolutePath")
+            }
+            val content = file.readText()
+            assertFalse(content.contains("<<<<<<< SEARCH"), "File $filePath contains <<<<<<< SEARCH")
+            assertFalse(content.contains("======="), "File $filePath contains =======")
+            assertFalse(content.contains(">>>>>>> REPLACE"), "File $filePath contains >>>>>>> REPLACE")
+            assertFalse(content.contains(">>>>>>>"), "File $filePath contains >>>>>>>")
+        }
+    }
+}


### PR DESCRIPTION
Added an automated test in the `jvmTest` source set to verify that no git conflict markers exist within specific target files (`HtmlShell.kt` and `ActionDecoder.kt`), preventing regressions.

---
*PR created automatically by Jules for task [10559702188945957626](https://jules.google.com/task/10559702188945957626) started by @jnorthrup*