### PR TITLE
Fix flaky file watcher test by properly draining channel

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/util/oroboros/JvmFileWatchReactorElementTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/util/oroboros/JvmFileWatchReactorElementTest.kt
@@ -28,6 +28,10 @@ class JvmFileWatchReactorElementTest {
             root.toFile().deleteRecursively()
         }
         assertEquals(borg.trikeshed.context.ElementState.CLOSED, watcher.state)
-        assertTrue(watcher.events.receiveCatching().isClosed)
+
+        // Drain any remaining events (e.g. MODIFY after CREATE) that were queued before close
+        while (true) {
+            if (watcher.events.receiveCatching().isClosed) break
+        }
     }
 }


### PR DESCRIPTION
Fixes a flaky test `emitsCreateAndDrainsClosed` in `JvmFileWatchReactorElementTest` by properly draining trailing events from the channel before asserting closure.

---
*PR created automatically by Jules for task [5465222636555110765](https://jules.google.com/task/5465222636555110765) started by @jnorthrup*