### PR TITLE
Move LcncReduction components to root reduction package

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElement.kt
@@ -6,10 +6,10 @@ import borg.trikeshed.context.ElementState
 import borg.trikeshed.context.nuid.Capability
 import borg.trikeshed.context.nuid.Nuid
 import borg.trikeshed.context.nuid.NuidFanoutElement
-import borg.trikeshed.lcnc.reduction.LcncCarrierAlg
-import borg.trikeshed.lcnc.reduction.LcncReduction
-import borg.trikeshed.lcnc.reduction.LcncReductions
-import borg.trikeshed.lcnc.reduction.category
+import borg.trikeshed.reduction.LcncCarrierAlg
+import borg.trikeshed.reduction.LcncReduction
+import borg.trikeshed.reduction.LcncReductions
+import borg.trikeshed.reduction.category
 import kotlinx.coroutines.Job
 
 class LcncFanoutElement(
@@ -37,7 +37,7 @@ class LcncFanoutElement(
         val carrier = if (payload != null) {
             typedCarrierAlg.carrier(payload)
         } else {
-            borg.trikeshed.lcnc.reduction.emptySeriesCarrier()
+            borg.trikeshed.reduction.emptySeriesCarrier()
         }
 
         return typedReduction.execute(carrier)

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/IngestCodec.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reactor/IngestCodec.kt
@@ -7,7 +7,7 @@ package borg.trikeshed.lcnc.reactor
 import borg.trikeshed.lcnc.isam.LcncEntity
 import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.emptySeriesOf
-import borg.trikeshed.lcnc.reduction.j
+import borg.trikeshed.reduction.j
 
 /**
  * Reactor asynchronous gems for parsing and digesting various formats.

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/rollup/RollupReducer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/rollup/RollupReducer.kt
@@ -1,7 +1,7 @@
 package borg.trikeshed.lcnc.rollup
 
 import borg.trikeshed.lcnc.collections.associative.PropertyValue
-import borg.trikeshed.lcnc.reduction.*
+import borg.trikeshed.reduction.*
 import borg.trikeshed.lib.Series
 import kotlin.math.pow
 import kotlin.math.round

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/ConfixReducers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/ConfixReducers.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.cursor.*
 import borg.trikeshed.lib.*

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/CrmsReducers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/CrmsReducers.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.*
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/ForgeReducers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/ForgeReducers.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 /**
  * Forge-specific Folder/Merger implementations extracted from ForgeWorkspaceImpl.

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncCarrierAlg.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncCarrierAlg.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.cursor.*
 import borg.trikeshed.lib.*

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncKeyAlg.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncKeyAlg.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.*
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncPatchCables.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncPatchCables.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.j
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncPhaseAlg.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncPhaseAlg.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 /**
  * Universal phase marker — unifies Forge MAP/REDUCE/REREDUCE, Confix scan/buildTree, CRMS BEFORE/AFTER.

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncReduction.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncReduction.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.*
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncReductions.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncReductions.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.cursor.Cursor
 import borg.trikeshed.mutable.RingSeries

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncSupport.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncSupport.kt
@@ -1,6 +1,6 @@
 @file:Suppress("ObjectPropertyName", "FunctionName")
 
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.Join
 import borg.trikeshed.lib.Series

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/LcncValueAlg.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/LcncValueAlg.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.*
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/ReducerRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/ReducerRegistry.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.context.nuid.Capability
 

--- a/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/context/lcnc/LcncFanoutElementTest.kt
@@ -1,13 +1,13 @@
 package borg.trikeshed.context.lcnc
 
 import borg.trikeshed.context.nuid.*
-import borg.trikeshed.lcnc.reduction.LcncReduction
-import borg.trikeshed.lcnc.reduction.ReductionCarrier
-import borg.trikeshed.lcnc.reduction.ReductionResult
-import borg.trikeshed.lcnc.reduction.KeyAlg
-import borg.trikeshed.lcnc.reduction.ValueAlg
-import borg.trikeshed.lcnc.reduction.PhaseAlg
-import borg.trikeshed.lcnc.reduction.CarrierAlg
+import borg.trikeshed.reduction.LcncReduction
+import borg.trikeshed.reduction.ReductionCarrier
+import borg.trikeshed.reduction.ReductionResult
+import borg.trikeshed.reduction.KeyAlg
+import borg.trikeshed.reduction.ValueAlg
+import borg.trikeshed.reduction.PhaseAlg
+import borg.trikeshed.reduction.CarrierAlg
 import borg.trikeshed.lib.j
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -40,7 +40,7 @@ class LcncFanoutElementTest {
             override val phaseAlg: PhaseAlg get() = TODO("Not yet implemented")
             override val carrierAlg: CarrierAlg<Any>
                 get() = object : CarrierAlg<Any> {
-                    override val carrier: (Any) -> ReductionCarrier<Any> = { borg.trikeshed.lcnc.reduction.emptySeriesCarrier() }
+                    override val carrier: (Any) -> ReductionCarrier<Any> = { borg.trikeshed.reduction.emptySeriesCarrier() }
                 }
 
             override fun execute(input: ReductionCarrier<*>): Any {

--- a/src/commonTest/kotlin/borg/trikeshed/reduction/LcncPatchCablesTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/reduction/LcncPatchCablesTest.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/commonTest/kotlin/borg/trikeshed/reduction/LcncReductionCoreTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/reduction/LcncReductionCoreTest.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.lcnc.reduction
+package borg.trikeshed.reduction
 
 import borg.trikeshed.lib.*
 import kotlin.test.*


### PR DESCRIPTION
Moved the core LcncReduction engine components from `lcnc.reduction` to a top level `reduction` package in `commonMain` to follow structural separation. Tests and references have been updated.

---
*PR created automatically by Jules for task [13479216492645772956](https://jules.google.com/task/13479216492645772956) started by @jnorthrup*