### PR TITLE
feat(lcnc): implement TrajectoryReduction for JulesCause

### DIFF
--- a/patch_trajectory9.patch
+++ b/patch_trajectory9.patch
@@ -1,0 +1,43 @@
+--- src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReduction.kt
++++ src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReduction.kt
+@@ -8,6 +8,8 @@
+ import borg.trikeshed.ws.Sha1Common
+ import borg.trikeshed.lib.j
+ import borg.trikeshed.lib.α
++import borg.trikeshed.lib.size
++import borg.trikeshed.lib.get
+
+ data class TrajectoryPayload(
+@@ -28,8 +30,8 @@
+         for (id in depJobIds) {
+             var foundComplete = false
+-            for (i in 0 until deps.a) {
+-                val item = deps.b(i)
++            for (i in 0 until deps.size) {
++                val item = deps[i]
+                 if (item.jobId.value == id && item.lifecycle == "complete") {
+                     foundComplete = true
+                     break
+                 }
+@@ -63,3 +65,3 @@
+         override val merger = Merger<TrajectoryOutcome> { partials ->
+-            if (partials.a == 0) initial else partials.b(partials.a - 1)
++            if (partials.size == 0) initial else partials[partials.size - 1]
+         }
+@@ -109,11 +111,11 @@
+         val attemptCauses = ArrayList<JulesCause>()
+-        for (i in 0 until payload.causes.a) {
+-            val cause = payload.causes.b(i)
+-            if (cause is JulesCause.DrainFailed || cause is JulesCause.DrainApplied ||
+-                cause is JulesCause.SessionFailed || cause is JulesCause.PatchArrived) {
+-                attemptCauses.add(cause)
+-            }
+-        }
++        val filteredSeries = payload.causes α { cause ->
++            if (cause is JulesCause.DrainFailed || cause is JulesCause.DrainApplied || cause is JulesCause.SessionFailed || cause is JulesCause.PatchArrived) cause else null
++        }
++        for (i in 0 until filteredSeries.size) {
++            val cause = filteredSeries[i]
++            if (cause != null) attemptCauses.add(cause)
++        }
+         val attemptCount = attemptCauses.size

--- a/src/commonMain/kotlin/borg/trikeshed/context/nuid/Nuid.kt.orig
+++ b/src/commonMain/kotlin/borg/trikeshed/context/nuid/Nuid.kt.orig
@@ -92,9 +92,6 @@ sealed class Capability(val category: String) {
     data object ModelAll : Capability("modelmux*")
     data object BlackBoardAll : Capability("blackboard*")
     data object CustomAll : Capability("custom*")
-
-    data object Trajectory : Capability("trajectory") { override fun familyRoot() = TrajectoryAll }
-    data object TrajectoryAll : Capability("trajectory*")
 }
 
 /** Internal capability equality + family matching. */

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/ReducerRegistry.kt
@@ -10,6 +10,7 @@ val Capability.category: String
         is Capability.Sctp -> "sctp"
         is Capability.Model -> "modelmux"
         is Capability.BlackBoard -> "blackboard"
+        is Capability.Trajectory -> "trajectory"
         else -> "custom"
     }
 
@@ -17,7 +18,8 @@ object ReducerRegistry {
     var registry: Map<String, LcncReduction<*, *, *, *>> = mapOf(
         "process" to LcncReductions.forgeCascade(emptyList(), emptyList()),
         "cas" to LcncReductions.confixParse(),
-        "wireproto" to LcncReductions.crmsFold()
+        "wireproto" to LcncReductions.crmsFold(),
+        "trajectory" to TrajectoryReduction()
     )
 
     fun runFor(winningCapability: Capability, payload: Any?): Any? {

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryOutcome.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryOutcome.kt
@@ -1,0 +1,17 @@
+package borg.trikeshed.lcnc.reduction
+
+sealed class TrajectoryOutcome {
+    data object NoPatch : TrajectoryOutcome()
+    data class DeletionDominant(val path: String) : TrajectoryOutcome()
+    data class Stub(val reason: String) : TrajectoryOutcome()
+    data class GateRed(val failures: List<String>) : TrajectoryOutcome()
+    data object Landed : TrajectoryOutcome()
+}
+
+data class TrajectoryVerdict(
+    val taskFingerprint: String,
+    val attemptCount: Int,
+    val outcome: TrajectoryOutcome,
+    val frozen: Boolean,
+    val depsSatisfied: Boolean
+)

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReduction.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReduction.kt
@@ -1,0 +1,145 @@
+package borg.trikeshed.lcnc.reduction
+
+import borg.trikeshed.job.JobSnapshot
+import borg.trikeshed.jules.JulesCause
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.emptySeriesOf
+import borg.trikeshed.ws.Sha1Common
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.α
+import borg.trikeshed.lib.size
+import borg.trikeshed.lib.get
+
+data class TrajectoryPayload(
+    val title: String,
+    val headSha: String,
+    val causes: Series<JulesCause>,
+    val depJobIds: List<String> = emptyList(),
+    val deps: Series<JobSnapshot> = emptySeriesOf()
+)
+
+class TrajectoryCarrier(val payload: TrajectoryPayload) : ReductionCarrier<JulesCause> by SeriesCarrier(payload.causes)
+
+object TrajectoryPhaseAlg : PhaseAlg {
+    override val transitions: PhaseTransition = LcncPhaseAlg.forgeTransitions
+    override fun validateSequence(phases: List<ReductionPhase>): Boolean = true
+    override fun nextValidPhases(current: ReductionPhase): Set<ReductionPhase> = emptySet()
+
+    fun checkDeps(depJobIds: List<String>, deps: Series<JobSnapshot>): Boolean {
+        if (depJobIds.isEmpty()) return true
+        for (id in depJobIds) {
+            var foundComplete = false
+            for (i in 0 until deps.size) {
+                val item = deps[i]
+                if (item.jobId.value == id && item.lifecycle == "complete") {
+                    foundComplete = true
+                    break
+                }
+            }
+            if (!foundComplete) return false
+        }
+        return true
+    }
+}
+
+class TrajectoryReduction : LcncReduction<String, JulesCause, TrajectoryOutcome, TrajectoryVerdict> {
+    override val keyAlg: KeyAlg<String> = object : KeyAlg<String> {
+        override val extractor = KeyExtractor<Any, String> { input ->
+            val payload = (input as TrajectoryCarrier).payload
+            val text = payload.title + payload.headSha
+            val hashBytes = Sha1Common.hash(text.encodeToByteArray())
+            hashBytes.joinToString("") { it.toUByte().toString(16).padStart(2, '0') }.take(12)
+        }
+        override val hierarchy = object : KeyHierarchy<String> {
+            override val levels = emptyList<KeyExtractor<Any, String>>()
+            override fun compositeKey(input: Any) = listOf(extractor.extract(input))
+            override fun prefix(key: List<String>, depth: Int) = key
+        }
+        override val order = LcncKeyAlg.naturalKeyOrder<String>()
+    }
+
+    override val valueAlg: ValueAlg<JulesCause, TrajectoryOutcome> = object : ValueAlg<JulesCause, TrajectoryOutcome> {
+        override val initial = TrajectoryOutcome.NoPatch
+        override val folder = Folder<JulesCause, TrajectoryOutcome> { acc, cause ->
+            parseCause(cause, acc)
+        }
+        override val merger = Merger<TrajectoryOutcome> { partials ->
+            if (partials.size == 0) initial else partials[partials.size - 1]
+        }
+    }
+
+    override val phaseAlg: PhaseAlg = TrajectoryPhaseAlg
+
+    override val carrierAlg: CarrierAlg<JulesCause> = object : CarrierAlg<JulesCause> {
+        override val carrier: (Any) -> ReductionCarrier<JulesCause> = { input ->
+            if (input is TrajectoryPayload) TrajectoryCarrier(input)
+            else SeriesCarrier(emptySeriesOf())
+        }
+    }
+
+    private fun parseReason(reason: String): TrajectoryOutcome {
+        return when {
+            "no patch" in reason || "without a client" in reason -> TrajectoryOutcome.NoPatch
+            "deletion-dominant" in reason -> {
+                val path = reason.substringAfter("deletion-dominant").trim(':', ' ')
+                TrajectoryOutcome.DeletionDominant(path)
+            }
+            "NotImplementedError" in reason || "no-op" in reason -> TrajectoryOutcome.Stub(reason)
+            "red" in reason || "FAILED" in reason -> TrajectoryOutcome.GateRed(listOf(reason))
+            else -> TrajectoryOutcome.GateRed(listOf(reason))
+        }
+    }
+
+    private fun parseCause(cause: JulesCause, current: TrajectoryOutcome): TrajectoryOutcome = when (cause) {
+        is JulesCause.DrainApplied -> TrajectoryOutcome.Landed
+        is JulesCause.DrainFailed -> parseReason(cause.reason)
+        is JulesCause.SessionFailed -> parseReason(cause.reason)
+        is JulesCause.PatchArrived -> current
+        else -> current
+    }
+
+    override fun execute(input: ReductionCarrier<*>): TrajectoryVerdict {
+        return executeWithCheckpoints(input).output
+    }
+
+    override fun executeWithCheckpoints(input: ReductionCarrier<*>): ReductionResult<TrajectoryVerdict> {
+        val carrier = input as TrajectoryCarrier
+        val payload = carrier.payload
+
+        val fingerprint = keyAlg.extractor.extract(carrier)
+        val depsSatisfied = TrajectoryPhaseAlg.checkDeps(payload.depJobIds, payload.deps)
+
+        val attemptCauses = ArrayList<JulesCause>()
+        val mappedSeries = payload.causes α { cause ->
+            if (cause is JulesCause.DrainFailed || cause is JulesCause.DrainApplied ||
+                cause is JulesCause.SessionFailed || cause is JulesCause.PatchArrived) cause else null
+        }
+        for (i in 0 until mappedSeries.size) {
+            val cause = mappedSeries[i]
+            if (cause != null) attemptCauses.add(cause)
+        }
+        val attemptCount = attemptCauses.size
+
+        val finalOutcome = attemptCauses.fold(valueAlg.initial as TrajectoryOutcome) { acc, cause ->
+            parseCause(cause, acc)
+        }
+
+        var frozen = false
+        if (attemptCount >= 3) {
+            val last3 = attemptCauses.takeLast(3).map { parseCause(it, TrajectoryOutcome.NoPatch) }
+            if (last3[0]::class == last3[1]::class && last3[1]::class == last3[2]::class) {
+                frozen = true
+            }
+        }
+
+        val verdict = TrajectoryVerdict(
+            taskFingerprint = fingerprint,
+            attemptCount = attemptCount,
+            outcome = finalOutcome,
+            frozen = frozen,
+            depsSatisfied = depsSatisfied
+        )
+
+        return ReductionResult(verdict, emptyMap())
+    }
+}

--- a/src/jvmTest/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReductionTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/lcnc/reduction/TrajectoryReductionTest.kt
@@ -1,0 +1,75 @@
+package borg.trikeshed.lcnc.reduction
+
+import borg.trikeshed.job.JobSnapshot
+import borg.trikeshed.jules.JulesCause
+import borg.trikeshed.lib.j
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class TrajectoryReductionTest {
+    @Test
+    fun testTrajectory() {
+        try {
+            val reduction = TrajectoryReduction()
+
+            // (a) single DrainApplied -> Landed, frozen=false
+            val payloadA = TrajectoryPayload(
+                title = "Title A",
+                headSha = "shaA",
+                causes = 1 j { JulesCause.DrainApplied("commit", 0, 1L) },
+                depJobIds = listOf("job1"),
+                deps = 1 j { JobSnapshot("job1", 1, "k", "complete") }
+            )
+            val verdictA = reduction.execute(TrajectoryCarrier(payloadA))
+            assertEquals(TrajectoryOutcome.Landed, verdictA.outcome)
+            assertFalse(verdictA.frozen)
+            assertEquals(1, verdictA.attemptCount)
+            assertTrue(verdictA.depsSatisfied)
+
+            // (b) three DrainFailed("no patch") -> NoPatch, frozen=true
+            val payloadB = TrajectoryPayload(
+                title = "Title B",
+                headSha = "shaB",
+                causes = 3 j { JulesCause.DrainFailed("no patch", 1L) },
+                depJobIds = listOf("job1"),
+                deps = 1 j { JobSnapshot("job1", 1, "k", "complete") }
+            )
+            val verdictB = reduction.execute(TrajectoryCarrier(payloadB))
+            assertEquals(TrajectoryOutcome.NoPatch, verdictB.outcome)
+            assertTrue(verdictB.frozen)
+            assertEquals(3, verdictB.attemptCount)
+
+            // (c) two DrainFailed then DrainApplied -> Landed, frozen=false
+            val payloadC = TrajectoryPayload(
+                title = "Title C",
+                headSha = "shaC",
+                causes = 3 j { i ->
+                    if (i < 2) JulesCause.DrainFailed("failed", 1L)
+                    else JulesCause.DrainApplied("commit", 0, 1L)
+                },
+                depJobIds = listOf("job1"),
+                deps = 1 j { JobSnapshot("job1", 1, "k", "complete") }
+            )
+            val verdictC = reduction.execute(TrajectoryCarrier(payloadC))
+            assertEquals(TrajectoryOutcome.Landed, verdictC.outcome)
+            assertFalse(verdictC.frozen)
+            assertEquals(3, verdictC.attemptCount)
+
+            // (d) deps unsatisfied when a dep jobId has no completed snapshot
+            val payloadD = TrajectoryPayload(
+                title = "Title D",
+                headSha = "shaD",
+                causes = 1 j { JulesCause.DrainApplied("commit", 0, 1L) },
+                depJobIds = listOf("job1", "job2"),
+                deps = 1 j { JobSnapshot("job1", 1, "k", "complete") } // job2 missing!
+            )
+            val verdictD = reduction.execute(TrajectoryCarrier(payloadD))
+            assertFalse(verdictD.depsSatisfied)
+        } catch (e: NotImplementedError) {
+            fail("Not implemented: \${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
Implemented the `TrajectoryReduction` pipeline to fold `Series<JulesCause>` into a structured `TrajectoryOutcome`. Evaluates final disposition (e.g., `Landed`, `GateRed`, `NoPatch`, `DeletionDominant`, `Stub`), computes the `frozen` consensus condition over attempt bounds, and validates job dependencies as an execution gate. Wires the capability to the registry and uses strict `Series` operators per project constraints.

---
*PR created automatically by Jules for task [16011465174516649021](https://jules.google.com/task/16011465174516649021) started by @jnorthrup*