### PR TITLE
Fix Cbor boundary leak

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
@@ -1,6 +1,6 @@
 package borg.trikeshed.parse.confix
 
-class ByteArrayBuilder(initialCapacity: Int = 32) {
+internal class ByteArrayBuilder(initialCapacity: Int = 32) {
     private var buffer = ByteArray(initialCapacity)
     var size = 0
         private set

--- a/src/jvmTest/kotlin/borg/trikeshed/parse/confix/ConfixCborBoundaryTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/parse/confix/ConfixCborBoundaryTest.kt
@@ -1,0 +1,17 @@
+package borg.trikeshed.parse.confix
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import java.io.File
+
+class ConfixCborBoundaryTest {
+    @Test
+    fun testByteArrayBuilderIsInternal() {
+        val rootDir = File(System.getProperty("user.dir"))
+        val encoderFile = File(rootDir, "src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt")
+        assertTrue(encoderFile.exists(), "Encoder file must exist")
+
+        val content = encoderFile.readText()
+        assertTrue(content.contains("internal class ByteArrayBuilder") || content.contains("private class ByteArrayBuilder"), "ByteArrayBuilder must be internal or private to avoid leaking implementation details")
+    }
+}


### PR DESCRIPTION
Enforce classpath boundary for Confix Cbor by making `ByteArrayBuilder` internal and adding a test.

---
*PR created automatically by Jules for task [1419339581744084421](https://jules.google.com/task/1419339581744084421) started by @jnorthrup*