### PR TITLE
Refactor MmapCasStore to return mapped slices directly

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/job/MmapCasStore.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/job/MmapCasStore.kt
@@ -14,7 +14,7 @@ import java.lang.foreign.Arena
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.ValueLayout
 
-class MmapCasStore(val file: Path) : CasStore() {
+class MmapCasStore(val file: Path) {
     private val randomAccessFile = RandomAccessFile(file.toFile(), "rw")
     private val channel = randomAccessFile.channel
 
@@ -83,7 +83,7 @@ class MmapCasStore(val file: Path) : CasStore() {
         }
     }
 
-    override fun put(bytes: ByteArray): ContentId {
+    fun put(bytes: ByteArray): ContentId {
         val cid = ContentId.of(bytes)
         synchronized(this) {
             if (cid in offsetMap) return cid
@@ -103,16 +103,7 @@ class MmapCasStore(val file: Path) : CasStore() {
         return cid
     }
 
-    override fun get(cid: ContentId): ByteArray? {
-        val loc = synchronized(this) { offsetMap[cid] } ?: return null
-        val offset = loc.first
-        val length = loc.second
-        val buffer = ByteBuffer.allocate(length)
-        channel.read(buffer, offset)
-        return buffer.array()
-    }
-
-    fun getMapped(cid: ContentId): Series<Byte>? {
+    fun get(cid: ContentId): Series<Byte>? {
         val loc = synchronized(this) { offsetMap[cid] } ?: return null
         val offset = loc.first
         val length = loc.second

--- a/src/jvmTest/kotlin/borg/trikeshed/job/MmapCasStoreTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/job/MmapCasStoreTest.kt
@@ -1,5 +1,8 @@
 package borg.trikeshed.job
 
+import borg.trikeshed.parse.confix.Syntax
+import borg.trikeshed.parse.confix.ConfixIndexK
+import borg.trikeshed.parse.confix.facet
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -20,8 +23,8 @@ class MmapCasStoreTest {
         val bytes = ByteArray(size) { (it % 256).toByte() }
         val cid = store.put(bytes)
 
-        // Read via getMapped
-        val mappedSeries = store.getMapped(cid)
+        // Read via get
+        val mappedSeries = store.get(cid)
         assertNotNull(mappedSeries)
         assertEquals(size, mappedSeries.a) // size
 
@@ -47,14 +50,42 @@ class MmapCasStoreTest {
         store.close()
 
         val store2 = MmapCasStore(tempFile)
+
         val retrieved1 = store2.get(cid1)
         assertNotNull(retrieved1)
-        assertTrue(data1.contentEquals(retrieved1))
+        assertEquals(data1.size, retrieved1.a)
+        for (i in data1.indices) {
+            assertEquals(data1[i], retrieved1[i])
+        }
 
         val retrieved2 = store2.get(cid2)
         assertNotNull(retrieved2)
-        assertTrue(data2.contentEquals(retrieved2))
+        assertEquals(data2.size, retrieved2.a)
+        for (i in data2.indices) {
+            assertEquals(data2[i], retrieved2[i])
+        }
 
         store2.close()
+    }
+
+    @Test
+    fun testMmapConfixIndexOverMappedBytes() {
+        val tempFile = Files.createTempFile("mmap-cas-store-confix", ".dat")
+        tempFile.toFile().deleteOnExit()
+        val store = MmapCasStore(tempFile)
+
+        val jsonStr = """{"hello": "world", "data": [1, 2, 3]}"""
+        val cid = store.put(jsonStr.encodeToByteArray())
+
+        val mappedSeries = store.get(cid)
+        assertNotNull(mappedSeries)
+
+        // Composes: mmap file -> Series<Byte> -> Confix index over mapped bytes without copy
+        val confixIndex = Syntax.JSON.scanIndex(mappedSeries)
+        val tags = confixIndex.facet(ConfixIndexK.Tags)
+
+        assertTrue(tags.a > 0)
+
+        store.close()
     }
 }


### PR DESCRIPTION
- Break `CasStore` inheritance on `MmapCasStore`
- Change `get(cid)` signature to return `Series<Byte>?` directly from the mapped buffer
- Add tests to ensure Confix parses index over mapped bytes cleanly

---
*PR created automatically by Jules for task [5593493304427977067](https://jules.google.com/task/5593493304427977067) started by @jnorthrup*