### PR TITLE
SCTP-3. Association-owned structured concurrency scope TDD RED phase

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/sctp/AssociationScope.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/sctp/AssociationScope.kt
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2024-2026. The TrikeShed Authors.
+ * Licensed under the AGPLv3.
+ */
+package borg.trikeshed.sctp

--- a/src/commonTest/kotlin/borg/trikeshed/sctp/AssociationScopeTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/sctp/AssociationScopeTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024-2026. The TrikeShed Authors.
+ * Licensed under the AGPLv3.
+ */
+package borg.trikeshed.sctp
+
+import kotlin.test.Test
+
+class AssociationScopeTest {
+
+    @Test
+    fun testAssociationCreatesAndOwnsScope() {
+        kotlin.test.fail("not implemented")
+    }
+
+    @Test
+    fun testClosingAssociationCancelsChildJobs() {
+        kotlin.test.fail("not implemented")
+    }
+}


### PR DESCRIPTION
Adds failing tests and stub for SCTP-3: Association-owned structured concurrency scope according to the TDD requirements.

---
*PR created automatically by Jules for task [10512421110337504013](https://jules.google.com/task/10512421110337504013) started by @jnorthrup*