### PR TITLE
CBOR Definite Length Maps and Arrays Encoding

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
@@ -79,37 +79,45 @@ internal object ConfixCborEmitter {
                 }
             }
             is ConfixArray -> {
-                writeHead(out, 4, e.size.toULong())
-                e.forEach { write(out, it) }
+                writeDefiniteLengthArray(out, e)
             }
             is ConfixObject -> {
-                writeHead(out, 5, e.size.toULong())
-                val sortedEntries = e.entries.map {
-                    val keyBytes = it.key.encodeToByteArray()
-                    val outKey = ByteArrayBuilder()
-                    writeHead(outKey, 3, keyBytes.size.toULong())
-                    outKey.write(keyBytes)
-                    val keyEncoded = outKey.toByteArray()
-                    Triple(it.key, keyEncoded, it.value)
-                }.sortedWith { a, b ->
-                    val lenCmp = a.second.size.compareTo(b.second.size)
-                    if (lenCmp != 0) lenCmp else {
-                        var res = 0
-                        for (i in a.second.indices) {
-                            val ba = a.second[i].toInt() and 0xFF
-                            val bb = b.second[i].toInt() and 0xFF
-                            res = ba.compareTo(bb)
-                            if (res != 0) break
-                        }
-                        res
-                    }
-                }
-                
-                for ((_, keyEncoded, value) in sortedEntries) {
-                    out.write(keyEncoded)
-                    write(out, value)
-                }
+                writeDefiniteLengthMap(out, e)
             }
+        }
+    }
+
+    private fun writeDefiniteLengthArray(out: ByteArrayBuilder, e: ConfixArray) {
+        writeHead(out, 4, e.size.toULong())
+        e.forEach { write(out, it) }
+    }
+
+    private fun writeDefiniteLengthMap(out: ByteArrayBuilder, e: ConfixObject) {
+        writeHead(out, 5, e.size.toULong())
+        val sortedEntries = e.entries.map {
+            val keyBytes = it.key.encodeToByteArray()
+            val outKey = ByteArrayBuilder()
+            writeHead(outKey, 3, keyBytes.size.toULong())
+            outKey.write(keyBytes)
+            val keyEncoded = outKey.toByteArray()
+            Triple(it.key, keyEncoded, it.value)
+        }.sortedWith { a, b ->
+            val lenCmp = a.second.size.compareTo(b.second.size)
+            if (lenCmp != 0) lenCmp else {
+                var res = 0
+                for (i in a.second.indices) {
+                    val ba = a.second[i].toInt() and 0xFF
+                    val bb = b.second[i].toInt() and 0xFF
+                    res = ba.compareTo(bb)
+                    if (res != 0) break
+                }
+                res
+            }
+        }
+
+        for ((_, keyEncoded, value) in sortedEntries) {
+            out.write(keyEncoded)
+            write(out, value)
         }
     }
 

--- a/src/commonTest/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoderTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoderTest.kt
@@ -30,6 +30,49 @@ class ConfixCborEncoderTest {
         assertContentEquals(bytes(0x3b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff), emit(ConfixPrimitive(Long.MIN_VALUE.toString(), false)))
     }
 
+    @Test
+    fun testDefiniteLengthArrays() {
+        // []
+        assertContentEquals(bytes(0x80), emit(ConfixArray(emptyList())))
+
+        // [1, 2, 3]
+        assertContentEquals(bytes(0x83, 0x01, 0x02, 0x03), emit(ConfixArray(listOf(
+            ConfixPrimitive(1.toString(), false),
+            ConfixPrimitive(2.toString(), false),
+            ConfixPrimitive(3.toString(), false)
+        ))))
+
+        // Array of 24 elements (major type 4, length 24 => 0x98 0x18)
+        val arr24 = ConfixArray(List(24) { ConfixPrimitive(0.toString(), false) })
+        val expected24 = ByteArray(26)
+        expected24[0] = 0x98.toByte()
+        expected24[1] = 0x18.toByte()
+        assertContentEquals(expected24, emit(arr24))
+    }
+
+    @Test
+    fun testDefiniteLengthMaps() {
+        // {}
+        assertContentEquals(bytes(0xa0), emit(ConfixObject(emptyMap())))
+
+        // {"a": 1, "b": 2}
+        assertContentEquals(
+            bytes(0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x02),
+            emit(ConfixObject(mapOf(
+                "a" to ConfixPrimitive(1.toString(), false),
+                "b" to ConfixPrimitive(2.toString(), false)
+            )))
+        )
+
+        // Map of 24 pairs (major type 5, length 24 => 0xb8 0x18)
+        val map24 = ConfixObject((0 until 24).associate {
+            ('a' + it).toString() to ConfixPrimitive(0.toString(), false)
+        })
+        val emitted = emit(map24)
+        kotlin.test.assertEquals(0xb8.toByte(), emitted[0])
+        kotlin.test.assertEquals(0x18.toByte(), emitted[1])
+    }
+
     private fun emit(element: ConfixElement): ByteArray = ConfixCborEmitter.emit(element)
     private fun bytes(vararg values: Int): ByteArray = ByteArray(values.size) { values[it].toByte() }
 }


### PR DESCRIPTION
Extracted explicit methods for definite length encoding of CBOR arrays and maps, and added passing tests based on RFC 8949 specifications.

---
*PR created automatically by Jules for task [1896297694601663005](https://jules.google.com/task/1896297694601663005) started by @jnorthrup*