### PR TITLE
fix(cbor): correctly differentiate between text strings and byte strings in ConfixCborEncoder

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,4 @@
+1. **Add test for Text Strings and Byte Strings**: Write tests in `src/commonTest/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoderTest.kt` to verify that `ConfixPrimitive` with `isString == true` encodes as Major Type 3 (0x60), and `isString == false` with non-numeric/non-boolean values encodes as Major Type 2 (0x40).
+2. **Implement fix in ConfixCborEncoder**: Modify `src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt` to check the `e.isString` property and output the correct CBOR Major Type (3 for text string, 2 for byte string).
+3. **Run tests**: Execute `./gradlew jvmTest --no-daemon` to ensure the new tests pass and no other tests regress.
+4. **Pre-commit and Submit**: Complete pre-commit steps to make sure proper testing, verifications, reviews and reflections are done, then submit the code.

--- a/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoder.kt
@@ -39,42 +39,49 @@ internal object ConfixCborEmitter {
             ConfixNull -> out.write(0xF6)
             is ConfixPrimitive -> {
                 val v = e.content
-                val bool = e.booleanOrNull
 
-                // Try ULong first for positive integers including very large ones
-                val ulong = v.toULongOrNull()
-                // Try Long for negative integers
-                val long = v.toLongOrNull()
-                val dbl = v.toDoubleOrNull()
-                when {
-                    bool != null -> out.write(if (bool) 0xF5 else 0xF4)
-                    ulong != null -> {
-                        writeHead(out, 0, ulong)
-                    }
-                    long != null -> {
-                        if (long >= 0) {
-                            writeHead(out, 0, long.toULong())
-                        } else {
-                            val magnitude = (-1L - long).toULong()
-                            writeHead(out, 1, magnitude)
+                if (e.isString) {
+                    val b = v.encodeToByteArray()
+                    writeHead(out, 3, b.size.toULong())
+                    out.write(b)
+                } else {
+                    val bool = e.booleanOrNull
+                    // Try ULong first for positive integers including very large ones
+                    val ulong = v.toULongOrNull()
+                    // Try Long for negative integers
+                    val long = v.toLongOrNull()
+                    val dbl = v.toDoubleOrNull()
+
+                    when {
+                        bool != null -> out.write(if (bool) 0xF5 else 0xF4)
+                        ulong != null -> {
+                            writeHead(out, 0, ulong)
                         }
-                    }
-                    dbl != null -> {
-                        out.write(0xFB)
-                        val bits = dbl.toBits()
-                        out.write((bits ushr 56).toInt() and 0xFF)
-                        out.write((bits ushr 48).toInt() and 0xFF)
-                        out.write((bits ushr 40).toInt() and 0xFF)
-                        out.write((bits ushr 32).toInt() and 0xFF)
-                        out.write((bits ushr 24).toInt() and 0xFF)
-                        out.write((bits ushr 16).toInt() and 0xFF)
-                        out.write((bits ushr 8).toInt() and 0xFF)
-                        out.write((bits ushr 0).toInt() and 0xFF)
-                    }
-                    else -> {
-                        val b = v.encodeToByteArray()
-                        writeHead(out, 3, b.size.toULong())
-                        out.write(b)
+                        long != null -> {
+                            if (long >= 0) {
+                                writeHead(out, 0, long.toULong())
+                            } else {
+                                val magnitude = (-1L - long).toULong()
+                                writeHead(out, 1, magnitude)
+                            }
+                        }
+                        dbl != null -> {
+                            out.write(0xFB)
+                            val bits = dbl.toBits()
+                            out.write((bits ushr 56).toInt() and 0xFF)
+                            out.write((bits ushr 48).toInt() and 0xFF)
+                            out.write((bits ushr 40).toInt() and 0xFF)
+                            out.write((bits ushr 32).toInt() and 0xFF)
+                            out.write((bits ushr 24).toInt() and 0xFF)
+                            out.write((bits ushr 16).toInt() and 0xFF)
+                            out.write((bits ushr 8).toInt() and 0xFF)
+                            out.write((bits ushr 0).toInt() and 0xFF)
+                        }
+                        else -> {
+                            val b = v.encodeToByteArray()
+                            writeHead(out, 2, b.size.toULong())
+                            out.write(b)
+                        }
                     }
                 }
             }

--- a/src/commonTest/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoderTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/parse/confix/ConfixCborEncoderTest.kt
@@ -5,6 +5,32 @@ import kotlin.test.assertContentEquals
 
 class ConfixCborEncoderTest {
     @Test
+    fun testTextStringsAndByteStrings() {
+        // Text string: Major Type 3 (0x60 base)
+        assertContentEquals(bytes(0x60), emit(ConfixPrimitive("", true)))
+        assertContentEquals(bytes(0x61, 0x61), emit(ConfixPrimitive("a", true)))
+        assertContentEquals(bytes(0x64, 0x49, 0x45, 0x54, 0x46), emit(ConfixPrimitive("IETF", true)))
+        assertContentEquals(bytes(0x62, 0x22, 0x5c), emit(ConfixPrimitive("\"\\", true)))
+        assertContentEquals(bytes(0x62, 0xc3, 0xbc), emit(ConfixPrimitive("\u00fc", true)))
+        assertContentEquals(bytes(0x63, 0xe6, 0xb0, 0xb4), emit(ConfixPrimitive("\u6c34", true)))
+        assertContentEquals(bytes(0x64, 0xf0, 0x90, 0x85, 0x91), emit(ConfixPrimitive("\ud800\udd51", true))) // water
+
+        // Byte string: Major Type 2 (0x40 base), for non-numbers when isString = false
+        assertContentEquals(bytes(0x40), emit(ConfixPrimitive("", false)))
+        assertContentEquals(bytes(0x41, 0x61), emit(ConfixPrimitive("a", false)))
+        assertContentEquals(bytes(0x44, 0x49, 0x45, 0x54, 0x46), emit(ConfixPrimitive("IETF", false)))
+        assertContentEquals(bytes(0x42, 0x22, 0x5c), emit(ConfixPrimitive("\"\\", false)))
+        assertContentEquals(bytes(0x42, 0xc3, 0xbc), emit(ConfixPrimitive("\u00fc", false)))
+        assertContentEquals(bytes(0x43, 0xe6, 0xb0, 0xb4), emit(ConfixPrimitive("\u6c34", false)))
+        assertContentEquals(bytes(0x44, 0xf0, 0x90, 0x85, 0x91), emit(ConfixPrimitive("\ud800\udd51", false)))
+
+        // A string that looks like a number/boolean should still be a string (MT 3) if isString = true
+        assertContentEquals(bytes(0x61, 0x31), emit(ConfixPrimitive("1", true)))
+        assertContentEquals(bytes(0x62, 0x2d, 0x31), emit(ConfixPrimitive("-1", true)))
+        assertContentEquals(bytes(0x64, 0x74, 0x72, 0x75, 0x65), emit(ConfixPrimitive("true", true)))
+    }
+
+    @Test
     fun testUnsignedAndSignedIntegers() {
         assertContentEquals(bytes(0x00), emit(ConfixPrimitive(0.toString(), false)))
         assertContentEquals(bytes(0x17), emit(ConfixPrimitive(23.toString(), false)))


### PR DESCRIPTION
Fix CBOR encoding for ConfixPrimitive to correctly handle text strings vs byte strings using the `isString` property.

---
*PR created automatically by Jules for task [5958868227266654104](https://jules.google.com/task/5958868227266654104) started by @jnorthrup*