### PR TITLE
test: setup RED phase for CBOR-6 classpath boundary enforcement

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborClasspathBoundary.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/confix/ConfixCborClasspathBoundary.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024. TrikeShed Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package borg.trikeshed.parse.confix
+
+class ConfixCborClasspathBoundary

--- a/src/jvmTest/kotlin/borg/trikeshed/parse/confix/ConfixCborClasspathBoundaryTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/parse/confix/ConfixCborClasspathBoundaryTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024. TrikeShed Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package borg.trikeshed.parse.confix
+
+import kotlin.test.Test
+import kotlin.test.fail
+
+class ConfixCborClasspathBoundaryTest {
+
+    @Test
+    fun testBoundary() {
+        fail("not implemented")
+    }
+}


### PR DESCRIPTION
This submission adds the skeleton files to begin TDD for the CBOR-6 classpath boundary enforcement feature. It explicitly sets up a failing test by calling `kotlin.test.fail("not implemented")` and provides an empty class `ConfixCborClasspathBoundary` to satisfy the minimal implementation file requirement.

---
*PR created automatically by Jules for task [2252734096321142928](https://jules.google.com/task/2252734096321142928) started by @jnorthrup*