### PR TITLE
Extract TlvChunkParser and test unknown-skip behavior

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/reactor/ngsctp/SctpReactorSpine.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/ngsctp/SctpReactorSpine.kt
@@ -20,6 +20,7 @@ import borg.trikeshed.context.nuid.Subnet
 import borg.trikeshed.context.nuid.NuidFanoutElement
 import borg.trikeshed.context.StreamHandle
 import borg.trikeshed.sctp.SctpElement
+import borg.trikeshed.sctp.TlvChunkParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -27,37 +28,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 
 // 1. TLV Chunk Parser
-class TlvChunkParser {
-    class Chunk(val type: Int, val data: ByteArray)
-
-    fun parse(data: ByteArray): Series<Chunk> {
-        val resultList = mutableListOf<Chunk>()
-        var offset = 0
-        while (offset < data.size) {
-            if (offset + 4 > data.size) break
-            val type = data[offset].toInt() and 0xFF
-            val length = ((data[offset + 2].toInt() and 0xFF) shl 8) or (data[offset + 3].toInt() and 0xFF)
-            if (offset + length > data.size) break
-
-            val chunkData = data.copyOfRange(offset + 4, offset + length)
-
-            if (type == 0x00) {
-                resultList.add(Chunk(type, chunkData))
-            } else {
-                val action = type shr 6
-                if (action == 0 || action == 1) {
-                    break // Stop processing
-                }
-                // skip others implicitly
-            }
-
-            val padding = (4 - (length % 4)) % 4
-            offset += length + padding
-        }
-
-        return resultList.size j { i -> resultList[i] }
-    }
-}
 
 // 2. Bounded Channel Stream
 class BoundedChannelStream(capacity: Int) {

--- a/src/commonMain/kotlin/borg/trikeshed/sctp/TlvChunkParser.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/sctp/TlvChunkParser.kt
@@ -1,0 +1,36 @@
+package borg.trikeshed.sctp
+
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+
+class TlvChunkParser {
+    class Chunk(val type: Int, val data: ByteArray)
+
+    fun parse(data: ByteArray): Series<Chunk> {
+        val resultList = mutableListOf<Chunk>()
+        var offset = 0
+        while (offset < data.size) {
+            if (offset + 4 > data.size) break
+            val type = data[offset].toInt() and 0xFF
+            val length = ((data[offset + 2].toInt() and 0xFF) shl 8) or (data[offset + 3].toInt() and 0xFF)
+            if (offset + length > data.size) break
+
+            val chunkData = data.copyOfRange(offset + 4, offset + length)
+
+            if (type == 0x00) {
+                resultList.add(Chunk(type, chunkData))
+            } else {
+                val action = type shr 6
+                if (action == 0 || action == 1) {
+                    break // Stop processing
+                }
+                // skip others implicitly
+            }
+
+            val padding = (4 - (length % 4)) % 4
+            offset += length + padding
+        }
+
+        return resultList.size j { i -> resultList[i] }
+    }
+}

--- a/src/commonTest/kotlin/borg/trikeshed/sctp/TlvChunkParseTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/sctp/TlvChunkParseTest.kt
@@ -1,0 +1,32 @@
+package borg.trikeshed.sctp
+
+import borg.trikeshed.lib.get
+import borg.trikeshed.lib.size
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TlvChunkParseTest {
+    @Test
+    fun testUnknownSkipBehavior() {
+        val parser = TlvChunkParser()
+
+        // Chunk 1: Type 0x00 (DATA), Length 8, data = 0xAA 0xBB 0xCC 0xDD
+        val chunk1 = byteArrayOf(0x00, 0x00, 0x00, 0x08, 0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte())
+
+        // Chunk 2: Unknown type with action 10 (skip) -> type = 0x80 (top two bits '10'). Length 8
+        val chunk2 = byteArrayOf(0x80.toByte(), 0x00, 0x00, 0x08, 0x11, 0x22, 0x33, 0x44)
+
+        // Chunk 3: Type 0x00 (DATA), Length 8. Should BE PARSED since we skipped chunk 2.
+        val chunk3 = byteArrayOf(0x00, 0x00, 0x00, 0x08, 0xEE.toByte(), 0xFF.toByte(), 0x00, 0x11)
+
+        val data = chunk1 + chunk2 + chunk3
+        val result = parser.parse(data)
+
+        // It must parse chunk 1 and chunk 3.
+        assertEquals(2, result.size)
+        assertEquals(0x00, result[0].type)
+        assertEquals(0xAA.toByte(), result[0].data[0])
+        assertEquals(0x00, result[1].type)
+        assertEquals(0xEE.toByte(), result[1].data[0])
+    }
+}


### PR DESCRIPTION
Extracts TlvChunkParser to its own file and adds tests for unknown-skip behavior, satisfying SCTP-1 TDD requirement.

---
*PR created automatically by Jules for task [9412451432039160301](https://jules.google.com/task/9412451432039160301) started by @jnorthrup*