### PR TITLE
G09-MED: add --once, --watch, and --interval-ms flags to oroboros-daemon

### DIFF
--- a/bin/oroboros-daemon
+++ b/bin/oroboros-daemon
@@ -8,4 +8,30 @@ if [[ ! -f "$JAR" ]]; then
     exit 1
 fi
 CP="$JAR:$(find "$HOME/.gradle/caches/modules-2" -name '*.jar' 2>/dev/null | tr '\n' ':')"
-exec java -cp "$CP" borg.trikeshed.daemon.OroborosDaemon "$@"
+
+WATCH="--watch"
+INTERVAL="20000"
+DAEMON_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once)
+      WATCH="--once"
+      shift
+      ;;
+    --watch)
+      WATCH="--watch"
+      shift
+      ;;
+    --interval-ms)
+      INTERVAL="$2"
+      shift 2
+      ;;
+    *)
+      DAEMON_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec java -cp "$CP" borg.trikeshed.daemon.OroborosDaemon $WATCH --interval-ms "$INTERVAL" "${DAEMON_ARGS[@]:-}"

--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -29,8 +29,34 @@ object OroborosDaemon {
 
     @JvmStatic
     fun main(args: Array<String>) = runBlocking {
-        val forgeHome = File(args.getOrNull(0) ?: System.getProperty("user.home") + "/.local/forge")
-        val repoDir = File(args.getOrNull(1) ?: System.getProperty("user.dir"))
+        var watch = true
+        var intervalMs = 20000L
+        val positionalArgs = mutableListOf<String>()
+
+        var i = 0
+        while (i < args.size) {
+            when (args[i]) {
+                "--once" -> {
+                    watch = false
+                    i++
+                }
+                "--watch" -> {
+                    watch = true
+                    i++
+                }
+                "--interval-ms" -> {
+                    intervalMs = args.getOrNull(i + 1)?.toLongOrNull() ?: 20000L
+                    i += 2
+                }
+                else -> {
+                    positionalArgs.add(args[i])
+                    i++
+                }
+            }
+        }
+
+        val forgeHome = File(positionalArgs.getOrNull(0) ?: System.getProperty("user.home") + "/.local/forge")
+        val repoDir = File(positionalArgs.getOrNull(1) ?: System.getProperty("user.dir"))
         val apiKey = System.getenv("JULES_API_KEY")
 
         if (apiKey.isNullOrBlank()) {
@@ -52,7 +78,7 @@ object OroborosDaemon {
         val flywheel = Flywheel(store, repoDir, element)
         val conductor = JulesConductor(julesClient, headShaProvider, store)
 
-        System.err.println("[OROBOROS] daemon up. forgeHome=$forgeHome repo=$repoDir maxLive=${element.defaults.maxLive} pollIntervalMs=${element.defaults.pollIntervalMs} simBudgetMs=${element.defaults.sessionSimulationMs}")
+        System.err.println("[OROBOROS] daemon up. forgeHome=$forgeHome repo=$repoDir maxLive=${element.defaults.maxLive} pollIntervalMs=$intervalMs simBudgetMs=${element.defaults.sessionSimulationMs}")
 
         var cycle = 0
         while (true) {
@@ -66,7 +92,8 @@ object OroborosDaemon {
             } catch (t: Throwable) {
                 System.err.println("[OROBOROS] cycle error: ${t::class.simpleName}: ${t.message}")
             }
-            delay(element.defaults.pollIntervalMs)
+            if (!watch) break
+            delay(intervalMs)
         }
     }
 


### PR DESCRIPTION
The wrapper is chmod 755 and works, but has no --once / --watch / --interval-ms flags. The skill's OroborosMain has them; this wrapper does not. Evidence: bin/oroboros-daemon:1-19 (no flag parsing). Add --once, --watch (default), --interval-ms 20000 flags that forward to OroborosDaemon.main as args.

---
*PR created automatically by Jules for task [10432190442147800360](https://jules.google.com/task/10432190442147800360) started by @jnorthrup*