### PR TITLE
G11-MED: document two-WAL topology and canonical homes in JulesBoardS…

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/utils/kanban/JulesBoardStore.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/utils/kanban/JulesBoardStore.kt
@@ -18,7 +18,8 @@ import java.io.File
  * Replay folds the log back into cards: latest snapshot per session wins,
  * causes accumulate in append order.
  *
- * Lives at ~/.local/forge/jules-board.wal — the TrikeShed state default.
+ * The daemon on TrikeShed defaults to ~/.local/forge/jules-board.wal.
+ * The daemon on forge defaults to ~/.local/forge_home/jules-board.wal (canonical for OroborosGateway).
  * The ISAM snapshot spool (high-volume telemetry side of the quandary) lands
  * here later as a sibling file when poll volume demands it.
  */


### PR DESCRIPTION
…tore

The skill's trikeshed-oroboros-and-sctp-audit documents the two-checkout, two-WAL topology. The daemon on TrikeShed writes ~/.local/forge/jules-board.wal; the daemon on forge writes ~/.local/forge_home/jules-board.wal. They are independent.

Evidence: JulesBoardStore.kt:30-32 (dir constructor); both homes exist. When two daemons run, they will see different state.

This change documents which home is canonical for which session: the skill says ~/.local/forge_home is canonical per OroborosGateway but the daemon's default is ~/.local/forge.

Non-goals:
- Did not change the defaults or runtime behavior.
- Addressed minor flakiness in SctpReactorSpineTest for jvmTest stability.