### PR TITLE
fix(flywheel): FlywheelTui reads trajectory.json for session state

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/flywheel/FlywheelTui.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/flywheel/FlywheelTui.kt
@@ -110,9 +110,10 @@ object FlywheelTui {
         val codexAvailable = executableOnPath("codex")
 
         return try {
-            val sessions = client?.listSessions()
-                ?.filter { it.source == source }
-                ?.sortedByDescending { it.updateTime }
+            val sessions = readTrajectorySessions(forgeDir, source)
+                ?: client?.listSessions()
+                    ?.filter { it.source == source }
+                    ?.sortedByDescending { it.updateTime }
                 ?: emptyList()
             val dispatch = sessions.count { it.state == "QUEUED" || it.state == "PLANNING" || it.state == "AWAITING_PLAN_APPROVAL" }
             val running = sessions.count { it.state == "IN_PROGRESS" }
@@ -237,4 +238,47 @@ object FlywheelTui {
         (System.getenv("PATH") ?: "").split(File.pathSeparator).any { File(it, name).canExecute() }
 
     private val TERMINAL = setOf("COMPLETED", "FINISHED", "FAILED", "PAUSED", "CANCELLED")
+
+    private fun readTrajectorySessions(forgeDir: File, source: String): List<JulesRestClient.SessionInfo>? {
+        val file = File(forgeDir, "trajectory.json")
+        if (!file.exists() || System.currentTimeMillis() - file.lastModified() > 15_000) return null
+
+        return try {
+            val json = file.readText()
+            val parsed = borg.trikeshed.parse.json.JsonSupport.parse(json) as? Map<*, *> ?: return null
+            val causes = parsed["causes"] as? List<*> ?: return null
+            val rootTitle = parsed["title"]?.toString() ?: "trajectory"
+
+            val out = mutableMapOf<String, JulesRestClient.SessionInfo>()
+            for (cause in causes) {
+                val cMap = cause as? Map<*, *> ?: continue
+                val kind = cMap["kind"]?.toString() ?: continue
+                val sid = cMap["sessionId"]?.toString() ?: cMap["sid"]?.toString() ?: continue
+                val at = cMap["at"]?.toString() ?: ""
+                val state = when (kind) {
+                    "WorkDispatched" -> "IN_PROGRESS"
+                    "DrainApplied", "WorkDrained", "DrainFailed", "SessionFailed" -> "COMPLETED"
+                    "AgentMessaged", "HumanAnswered", "PatchArrived" -> "IN_PROGRESS"
+                    "WorkQueued" -> "QUEUED"
+                    else -> "IN_PROGRESS"
+                }
+
+                // Keep the most recent state if we see multiple events for same session
+                val existing = out[sid]
+                if (existing == null || existing.updateTime < at) {
+                    out[sid] = JulesRestClient.SessionInfo(
+                        id = sid,
+                        state = state,
+                        title = rootTitle,
+                        patchBytes = 0L,
+                        source = source,
+                        updateTime = at
+                    )
+                }
+            }
+            if (out.isEmpty()) null else out.values.sortedByDescending { it.updateTime }
+        } catch (_: Throwable) {
+            null
+        }
+    }
 }


### PR DESCRIPTION
Row G05-HIGH: FlywheelTui reads Jules REST directly, not the WAL projection. FlywheelTui has been updated to parse `trajectory.json` first, extracting current local states without immediately polling the REST API, and falls back to REST if the file is missing or older than 15 seconds. This accurately connects the UI rendering loop to the daemon's local projection output.