### PR TITLE
Replace BlackboardFabrics.create TODO with InMemoryBlackboardFabric

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/dag/BlackboardDagFabric.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/dag/BlackboardDagFabric.kt
@@ -541,5 +541,5 @@ class InMemoryBlackboardFabric : BlackboardFabric {
  */
 object BlackboardFabrics {
     /** Create a new in-memory blackboard fabric. */
-    fun create(): BlackboardFabric = TODO()
+    fun create(): BlackboardFabric = InMemoryBlackboardFabric()
 }


### PR DESCRIPTION
Replaces `BlackboardFabrics.create` `TODO()` with a call to the already defined `InMemoryBlackboardFabric()`.

Verified by running `./gradlew :jvmMainClasses --no-daemon` and then running the consumer `BlackboardDagDemo`:
```
bash -c "java -cp \"$(find build/classes -type d | tr '\n' ':'):/home/jules/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.3.21/a2ee2c4e220fee522f0451b723bab2a43f3481a7/kotlin-stdlib-2.3.21.jar\" borg.trikeshed.dag.demo.BlackboardDagDemo"
```

Output:
```
fabric_ok create=1 publish=2 delivered=1 slice=1
```

---
*PR created automatically by Jules for task [13434914650488484998](https://jules.google.com/task/13434914650488484998) started by @jnorthrup*