### PR TITLE
fix: Close Litebike connection lifecycle properly without redundant IO dispatch

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
@@ -133,25 +133,23 @@ object JvmLitebikeBindAdapter {
         val buf = ByteBuffer.allocate(8 * 1024)
         val respondCallback: suspend (ByteArray) -> Unit = { responseBytes ->
             try {
-                withContext(Dispatchers.IO) {
-                    val writeBuf = ByteBuffer.wrap(responseBytes)
-                    while (writeBuf.hasRemaining()) {
-                        val written = kotlin.coroutines.suspendCoroutine { cont ->
-                            ch.write(writeBuf, null, object : CompletionHandler<Int, Any?> {
-                                override fun completed(result: Int, attachment: Any?) {
-                                    cont.resumeWith(Result.success(result))
-                                }
-                                override fun failed(exc: Throwable, attachment: Any?) {
-                                    cont.resumeWith(Result.failure(exc))
-                                }
-                            })
-                        }
-                        if (written < 0) break
+                val writeBuffer = ByteBuffer.wrap(responseBytes)
+                while (writeBuffer.hasRemaining()) {
+                    val bytesWritten = kotlin.coroutines.suspendCoroutine { cont ->
+                        ch.write(writeBuffer, null, object : CompletionHandler<Int, Any?> {
+                            override fun completed(result: Int, attachment: Any?) {
+                                cont.resumeWith(Result.success(result))
+                            }
+                            override fun failed(exc: Throwable, attachment: Any?) {
+                                cont.resumeWith(Result.failure(exc))
+                            }
+                        })
                     }
+                    if (bytesWritten < 0) break
                 }
             } finally {
                 connections.unregister(connId)
-                // Close the accepted-channel lifecycle around the existing respond callback
+                // Close accepted-channel lifecycle around existing respond callback
                 runCatching { ch.close() }
             }
         }


### PR DESCRIPTION
- Removed redundant coroutine context dispatch on IO pool when performing `ch.write`.
- Renamed variables (`writeBuf` -> `writeBuffer`, `written` -> `bytesWritten`) for better code clarity.
- Confirmed that this completes the intended loop behavior and closes the connection securely within the `finally` block to prevent socket leaks.

---
*PR created automatically by Jules for task [9875178922791658457](https://jules.google.com/task/9875178922791658457) started by @jnorthrup*