### PR TITLE
fix(couch): reorder guard before require in CouchHeadProjection

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/couch/CouchHeadProjection.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/CouchHeadProjection.kt
@@ -31,13 +31,13 @@ class CouchHeadProjection {
     private val frames = mutableMapOf<String, CouchCommittedFrame>()
 
     fun applyCommit(frame: CouchCommittedFrame) {
-        require(frame.deleted || frame.doc?.id == frame.docId) {
-            "Insert/Update frame docId must match document id"
-        }
-
         val existingFrame = frames[frame.docId]
         if (existingFrame != null && (frame.sequence <= existingFrame.sequence || frame.rev == existingFrame.rev)) {
             return
+        }
+
+        require(frame.deleted || frame.doc?.id == frame.docId) {
+            "Insert/Update frame docId must match document id"
         }
 
         frames[frame.docId] = frame


### PR DESCRIPTION
Enforce committed-frame ordering before mutating head state. Reject stale/duplicate per-document sequence/revision transitions. Require non-delete document id to match frame.docId. Preserve tombstone semantics. Currently unused existing-frame lookup must become the guard.

---
*PR created automatically by Jules for task [9145925316375278666](https://jules.google.com/task/9145925316375278666) started by @jnorthrup*