### PR TITLE
fix(daemon): correct backoff calculation and logging in OroborosDaemon

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -250,8 +250,8 @@ object OroborosDaemon {
             if (watch) {
                 while (true) {
                     val errors = consecutivePollErrors.get()
-                    val backoffMs = kotlin.math.min(intervalMs * (1L shl kotlin.math.min(errors, 30)), intervalMs * 5)
-                    if (errors > 0) System.err.println("[OROBOROS] backoff=${backoffMs}ms consecutiveErrors=$errors")
+                    val backoffMs = kotlin.math.min(intervalMs * (1L shl kotlin.math.min(errors, 2)), intervalMs * 5)
+                    if (errors > 0) System.err.println("[OROBOROS] backoff=${backoffMs}ms")
                     delay(backoffMs)
                     if (!preflight(repoDir, driver)) {
                         System.err.println("[OROBOROS] preflight failed; skipping cycle")


### PR DESCRIPTION
This commit modifies `OroborosDaemon.kt` to:
1. Limit the maximum exponential backoff multiplier shift to 2 instead of 30, meaning backoff stops doubling much earlier on repeated failures.
2. Update the backoff logging string to precisely state `[OROBOROS] backoff=${backoffMs}ms`, stripping the `consecutiveErrors` text to conform to required formatting.

---
*PR created automatically by Jules for task [5720866949968247233](https://jules.google.com/task/5720866949968247233) started by @jnorthrup*