### PR TITLE
Fix Litebike HTTP boundary to properly consume and route requests

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -208,12 +208,16 @@ object JvmKanbanServer {
         // stream is a request; we route on the request path.
         val httpScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-        // The HTTP handler logic is handled by the wireproto workgroup.
+        // The HTTP handler logic is handled by the Protocol.Http slot.
         httpScope.launch {
-            val slot = fanout.slotOf("wireproto") ?: return@launch
+            val httpSlot = listener.register(Protocol.Http)
             while (true) {
-                val claim = slot.consume()
-                val payload = claim.payload as? ByteArray ?: continue
+                val msg = httpSlot.consume()
+                val payload = msg.payload
+
+                val wireNuid = nuid(Capability.Wireproto("http"), Nonce.RandomBytes(), Subnet.lanLocalhost)
+                fanout.dispatch(wireNuid, payload)
+
                 val resp = routeHttp(payload)
                 val out = buildString {
                     append("HTTP/1.1 ${resp.status} ${statusReason(resp.status)}\r\n")
@@ -223,8 +227,8 @@ object JvmKanbanServer {
                     append(resp.body)
                 }
                 val outBytes = out.toByteArray(StandardCharsets.UTF_8)
-                // Surface the response on the Json protocol slot (downstream consumers)
-                listener.accept(Protocol.Json, out.toByteArray(StandardCharsets.UTF_8))
+                // Write back through the listener's response callback
+                msg.respond?.invoke(outBytes)
             }
         }
 


### PR DESCRIPTION
This commit repairs the HTTP boundary in `JvmKanbanServer`. Previously, it incorrectly looked for a "wireproto" workgroup slot and dropped responses onto a sink-only JSON path. 

It now properly registers and consumes the `Protocol.Http` slot, derives and dispatches a wire-protocol NUID through the registered workgroup for handling, routes the HTTP response correctly, and invokes the `ChannelMessage.respond` callback to complete the lifecycle and serve the request.

---
*PR created automatically by Jules for task [15306568476472788054](https://jules.google.com/task/15306568476472788054) started by @jnorthrup*