### PR TITLE
fix(litebike): close accepted-channel lifecycle in bind adapter

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
@@ -132,21 +132,26 @@ object JvmLitebikeBindAdapter {
     ) {
         val buf = ByteBuffer.allocate(8 * 1024)
         val respondCallback: suspend (ByteArray) -> Unit = { responseBytes ->
-            withContext(Dispatchers.IO) {
-                val writeBuf = ByteBuffer.wrap(responseBytes)
-                while (writeBuf.hasRemaining()) {
-                    val written = kotlin.coroutines.suspendCoroutine { cont ->
-                        ch.write(writeBuf, null, object : CompletionHandler<Int, Any?> {
-                            override fun completed(result: Int, attachment: Any?) {
-                                cont.resumeWith(Result.success(result))
-                            }
-                            override fun failed(exc: Throwable, attachment: Any?) {
-                                cont.resumeWith(Result.failure(exc))
-                            }
-                        })
+            try {
+                withContext(Dispatchers.IO) {
+                    val writeBuf = ByteBuffer.wrap(responseBytes)
+                    while (writeBuf.hasRemaining()) {
+                        val written = kotlin.coroutines.suspendCoroutine { cont ->
+                            ch.write(writeBuf, null, object : CompletionHandler<Int, Any?> {
+                                override fun completed(result: Int, attachment: Any?) {
+                                    cont.resumeWith(Result.success(result))
+                                }
+                                override fun failed(exc: Throwable, attachment: Any?) {
+                                    cont.resumeWith(Result.failure(exc))
+                                }
+                            })
+                        }
+                        if (written < 0) break
                     }
-                    if (written < 0) break
                 }
+            } finally {
+                connections.unregister(connId)
+                runCatching { ch.close() }
             }
         }
         ch.read(
@@ -164,10 +169,10 @@ object JvmLitebikeBindAdapter {
                     // runBlocking is OK from a JDK CompletionHandler because
                     // those callbacks are pure Java threads, not coroutines.
                     val ok = runBlocking { element.accept(proto, bytes, respondCallback) }
-                    if (!ok) runCatching { ch.close() }
-                    // Continue draining while data remains.
-                    buf.clear()
-                    ch.read(buf, null, this)
+                    if (!ok) {
+                        connections.unregister(connId)
+                        runCatching { ch.close() }
+                    }
                 }
 
                 override fun failed(t: Throwable, attached: Any?) {


### PR DESCRIPTION
The JvmLitebikeBindAdapter was leaking connections by failing to gracefully unregister and close the channel after the `respondCallback` completes and by eagerly reading again, violating the one-response-per-connection pattern.

Wrapped the `respondCallback` write loop in a `try/finally` to guarantee `unregister(connId)` and `ch.close()` execute. Removed the recursive `ch.read(buf)` in `drainOne`'s completed block. The adapter now safely closes accepted-channels instead of leaking active connections.

---
*PR created automatically by Jules for task [3128281449317195096](https://jules.google.com/task/3128281449317195096) started by @jnorthrup*