### PR TITLE
Fix JobFrame hashing to use CanonicalCbor

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/job/JobReducer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/job/JobReducer.kt
@@ -169,5 +169,5 @@ class JobReducer {
     fun facts(jobId: JobId): List<JobFact> = jobFacts[jobId]?.toList() ?: emptyList()
 
     private fun canonicalFrameBytes(frame: JobFrame): ByteArray =
-        frame.toString().encodeToByteArray()
+        CanonicalCbor.encode(frame.doc)
 }


### PR DESCRIPTION
Replaced the non-deterministic `toString()` byte hashing of `JobFrame` in `JobReducer.kt` with the canonical Confix/CBOR representation already utilized by the job pipeline (`CanonicalCbor.encode(frame.doc)`). This ensures the same logical frame yields the identical `JobFact` `ContentId` across executions.

Compiled and verified successfully via `./gradlew :jvmMainClasses --no-daemon`.

---
*PR created automatically by Jules for task [4465036716017209747](https://jules.google.com/task/4465036716017209747) started by @jnorthrup*