### PR TITLE
Hoist Static Regex in parseKanbanColumnObject

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/ForgeDoc.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/ForgeDoc.kt
@@ -375,7 +375,14 @@ private data class KanbanColumnRef(
     val name: String,
     val order: Int,
     val wipLimit: Int? = null,
-)
+) {
+    companion object {
+        val ID_REGEX = Regex("\"id\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
+        val NAME_REGEX = Regex("\"name\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
+        val ORDER_REGEX = Regex("\"order\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
+        val WIP_LIMIT_REGEX = Regex("\"wipLimit\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
+    }
+}
 
 /**
  * Lightweight parser for `kanban.columns` JSON arrays.
@@ -412,20 +419,15 @@ private fun parseKanbanColumnsProperty(raw: String?): List<KanbanColumnRef> {
     return out
 }
 
-private val ID_REGEX = Regex("\"id\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
-private val NAME_REGEX = Regex("\"name\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
-private val ORDER_REGEX = Regex("\"order\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
-private val WIP_LIMIT_REGEX = Regex("\"wipLimit\"\\s*:\\s*(\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([0-9]+))")
-
 private fun parseKanbanColumnObject(entry: String): KanbanColumnRef? {
     fun field(regex: Regex): String? {
         val m = regex.find(entry) ?: return null
         return m.groupValues[2].ifEmpty { m.groupValues[3] }
     }
-    val id = field(ID_REGEX) ?: return null
-    val name = field(NAME_REGEX) ?: id
-    val order = field(ORDER_REGEX)?.toIntOrNull() ?: 0
-    val wipLimit = field(WIP_LIMIT_REGEX)?.toIntOrNull()
+    val id = field(KanbanColumnRef.ID_REGEX) ?: return null
+    val name = field(KanbanColumnRef.NAME_REGEX) ?: id
+    val order = field(KanbanColumnRef.ORDER_REGEX)?.toIntOrNull() ?: 0
+    val wipLimit = field(KanbanColumnRef.WIP_LIMIT_REGEX)?.toIntOrNull()
     return KanbanColumnRef(id = id, name = name, order = order, wipLimit = wipLimit)
 }
 

--- a/src/commonTest/kotlin/borg/trikeshed/forge/KanbanColumnParserTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/forge/KanbanColumnParserTest.kt
@@ -1,0 +1,39 @@
+package borg.trikeshed.forge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KanbanColumnParserTest {
+    @Test
+    fun testKanbanColumnParsingRegexOptimizations() {
+        val rootPageId = ForgeBlockId("page-1")
+        val columnsJson = """[{"id":"col-1","name":"To Do","order":1,"wipLimit":5},{"id":"col-2","name":"Doing","order":2}]"""
+        val pageBlock = ForgeBlock(
+            id = rootPageId,
+            kind = ForgeBlockKind.PAGE,
+            text = "Test Page",
+            parentId = null,
+            properties = mapOf("kanban.columns" to columnsJson)
+        )
+        val doc = ForgeDocument(
+            rootPageId = rootPageId,
+            cursor = ForgeCursor(rootPageId, rootPageId),
+            blocks = mapOf(rootPageId.value to pageBlock)
+        )
+
+        val board = doc.toKanbanBoard()
+        assertEquals(2, board.columns.size)
+
+        val col1 = board.columns[0]
+        assertEquals("col-1", col1.id.value)
+        assertEquals("To Do", col1.name)
+        assertEquals(1, col1.order)
+        assertEquals(5, col1.wipLimit)
+
+        val col2 = board.columns[1]
+        assertEquals("col-2", col2.id.value)
+        assertEquals("Doing", col2.name)
+        assertEquals(2, col2.order)
+        assertEquals(null, col2.wipLimit)
+    }
+}


### PR DESCRIPTION
Prior attempt to hoist regex values failed to apply to current master branch cleanly. This patch re-applies the logic by placing the precompiled regex constants into a `companion object` of the `KanbanColumnRef` data class. Also adds the requested unit test.

---
*PR created automatically by Jules for task [5730596377896389899](https://jules.google.com/task/5730596377896389899) started by @jnorthrup*