### PR TITLE
feat: Wire DoubleSeries into query engine

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/graph/query/QueryEngine.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/graph/query/QueryEngine.kt
@@ -1,8 +1,6 @@
 package borg.trikeshed.graph.query
 
 import borg.trikeshed.cursor.Cursor
-import borg.trikeshed.cursor.cells
-import borg.trikeshed.cursor.keys
 import borg.trikeshed.lib.DoubleSeries
 import borg.trikeshed.cursor.RowVec
 
@@ -21,8 +19,8 @@ class QueryEngine(private val data: Cursor) {
         // Find column index
         val firstRow: RowVec = data.b(0)
         var colIdx = -1
-        for (i in 0 until firstRow.keys.a) {
-            if (firstRow.keys.b(i) == columnName) {
+        for (i in 0 until firstRow.a) {
+            if (firstRow.b(i).b().name == columnName) {
                 colIdx = i
                 break
             }
@@ -31,7 +29,7 @@ class QueryEngine(private val data: Cursor) {
         require(colIdx != -1) { "Column '$columnName' not found" }
         
         for (i in 0 until data.a) {
-            val cell = data.b(i).cells.b(colIdx)
+            val cell = data.b(i).b(colIdx).a
             val value = when (cell) {
                 is Double -> cell
                 is Number -> cell.toDouble()

--- a/src/commonTest/kotlin/borg/trikeshed/graph/query/QueryEngineTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/graph/query/QueryEngineTest.kt
@@ -50,4 +50,12 @@ class QueryEngineTest {
             engine.extractDoubleColumn("missing")
         }
     }
+
+    @Test
+    fun extractDoubleColumn_returns_empty_series_for_empty_cursor() {
+        val cursor: Cursor = borg.trikeshed.lib.emptySeries()
+        val engine = QueryEngine(cursor)
+        val series = engine.extractDoubleColumn("score")
+        assertEquals(0, series.size)
+    }
 }


### PR DESCRIPTION
Refactored QueryEngine.kt to use the unboxed tuple access methods `firstRow.a`, `firstRow.b(i).b().name`, and `data.b(i).b(colIdx).a`, avoiding the overhead of the `.keys` and `.cells` wrappers which were removed.

Added test coverage in QueryEngineTest.kt.

Fixes failing apply issue in prior Jules session 8993771901974843282.

---
*PR created automatically by Jules for task [10635169297110193527](https://jules.google.com/task/10635169297110193527) started by @jnorthrup*