### PR TITLE
⚡ Optimize ByteArray allocation in WasmIsamOperations inner loops

### DIFF
--- a/src/wasmJsMain/kotlin/borg/trikeshed/isam/WasmIsamOperations.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/isam/WasmIsamOperations.kt
@@ -89,17 +89,22 @@ class WasmIsamOperations : IsamOperations {
 
         val groupBuffers = mutableMapOf<String, ByteArray>()
         val groupOffsets = mutableMapOf<String, Int>()
+        val groupRowBufs = mutableMapOf<String, ByteArray>()
+        val groupRecordLengths = mutableMapOf<String, Int>()
 
         for ((gname, cols) in columnsByGroup) {
             val groupRecordLen = cols.sumOf { it.end - it.begin }
             groupBuffers[gname] = ByteArray(groupRecordLen * cursor.size)
             groupOffsets[gname] = 0
+            groupRowBufs[gname] = ByteArray(groupRecordLen)
+            groupRecordLengths[gname] = groupRecordLen
         }
 
         cursor.iterator().forEach { rowVec ->
             for ((gname, cols) in columnsByGroup) {
-                val groupRecordLen = cols.sumOf { it.end - it.begin }
-                val rowBuf = ByteArray(groupRecordLen)
+                val groupRecordLen = groupRecordLengths[gname]!!
+                val rowBuf = groupRowBufs[gname]!!
+                rowBuf.fill(0)
                 writeGroupToBuffer(rowVec, rowBuf, cols, meta0)
                 val out = groupBuffers[gname]!!
                 val offset = groupOffsets[gname]!!
@@ -141,6 +146,8 @@ class WasmIsamOperations : IsamOperations {
 
         val groupBuffers = mutableMapOf<String, ByteArray>()
         val groupOffsets = mutableMapOf<String, Int>()
+        val groupRowBufs = mutableMapOf<String, ByteArray>()
+        val groupRecordLengths = mutableMapOf<String, Int>()
 
         for (gname in columnsByGroup.keys) {
             val cols = columnsByGroup[gname]!!
@@ -154,13 +161,16 @@ class WasmIsamOperations : IsamOperations {
             
             groupBuffers[gname] = out
             groupOffsets[gname] = existing.size
+            groupRowBufs[gname] = ByteArray(groupRecordLen)
+            groupRecordLengths[gname] = groupRecordLen
         }
 
         msf.forEach { rowVec ->
             val rv = transform?.invoke(rowVec) ?: rowVec
             for ((gname, cols) in columnsByGroup) {
-                val groupRecordLen = cols.sumOf { it.end - it.begin }
-                val rowBuf = ByteArray(groupRecordLen)
+                val groupRecordLen = groupRecordLengths[gname]!!
+                val rowBuf = groupRowBufs[gname]!!
+                rowBuf.fill(0)
                 writeGroupToBuffer(rv, rowBuf, cols, meta0)
                 
                 val out = groupBuffers[gname]!!


### PR DESCRIPTION
💡 **What:** 
Moved the instantiation of `ByteArray` objects out of the inner loop in both `write` and `append` functions of `WasmIsamOperations`. Pre-calculated `groupRecordLen` values as well. Cached both the pre-allocated byte arrays and lengths in map structures, and reset the byte arrays with `.fill(0)` in every iteration before reusing.

🎯 **Why:**
The previous code instantiated a new `ByteArray` object for every record and group. This resulted in significant memory allocation overhead during batch operations on Wasm Js target, causing more frequent Garbage Collections and slower CPU throughput.

📊 **Measured Improvement:**
Since running targeted benchmarks in the WasmJS ecosystem inside Gradle proved challenging in the current sandbox environment, measurement results are based on allocation analysis. By pre-allocating the `ByteArray` per group, we reduce object instantiations from `O(N * G)` to `O(G)` where N is the number of records (cursor size) and G is the number of column groups. This eliminates hundreds of thousands of small, short-lived object allocations for large cursors, translating directly into reduced GC pressure and higher write throughput.

---
*PR created automatically by Jules for task [2395414082415991441](https://jules.google.com/task/2395414082415991441) started by @jnorthrup*