### PR TITLE
Fix uncompleted coroutine error in JobSupervisorReteIntegrationTest

### DIFF
--- a/src/commonTest/kotlin/borg/trikeshed/job/JobSupervisorReteIntegrationTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/job/JobSupervisorReteIntegrationTest.kt
@@ -136,6 +136,7 @@ class JobSupervisorReteIntegrationTest {
         assertEquals(0, rete.agenda.size, "Agenda should be empty because facts are in different partitions")
 
         nexus.drain() // Fix the uncompleted coroutine error
+        nexus.cancel()
     }
 
     @Test


### PR DESCRIPTION
Resolves an uncompleted coroutine error in `JobSupervisorReteIntegrationTest.kt` by correctly shutting down the JobSupervisorElement's internal scopes.

---
*PR created automatically by Jules for task [592869253876894556](https://jules.google.com/task/592869253876894556) started by @jnorthrup*