### PR TITLE
🔒 Explain hardcoded KeyStore password in JvmTlsCodecBackend

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
@@ -304,6 +304,7 @@ class JvmTlsCodecBackend : TlsCodecBackend, KeyedService {
 
         val certs = loadCertificates(Path.of(config.certificateFile))
         val privateKey = loadPrivateKey(Path.of(config.privateKeyFile), certs.first().publicKey.algorithm)
+        // In-memory KeyStore; password never persisted or exposed — safe to hardcode
         val password = (config.privateKeyPassword ?: "changeit").toCharArray()
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
         keyStore.load(null, null)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the reported hardcoded Keystore password.
⚠️ **Risk:** The potential impact if left unfixed could be mistakenly identified as a vulnerability by security scanners or reviewers who lack the context that the password is only used in-memory.
🛡️ **Solution:** The user confirmed that the in-memory `KeyStore` password is safe because it is never persisted or exposed. The solution documents this fact with a one-line comment explaining the rationale, satisfying the requirement to handle the issue securely without changing the code logic.

---
*PR created automatically by Jules for task [8692951936813070942](https://jules.google.com/task/8692951936813070942) started by @jnorthrup*