### PR TITLE
feat: inject platform-specific monotonic clock

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/MonotonicClock.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/MonotonicClock.kt
@@ -1,0 +1,3 @@
+package borg.trikeshed.lib
+
+expect fun monotonicNowMillis(): Long

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/CrmsReducers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/CrmsReducers.kt
@@ -192,9 +192,7 @@ object CrmsReducers {
             windows.getOrPut(windowKey) { mutableListOf() }.add(event)
 
             // Emit completed windows
-            // CommonMain-safe approximation: use event time as the clock edge.
-            // TODO(lcnc): platform-specific monotonic clock can be injected by a JVM/native adapter.
-            val now = event.timestampNanos
+            val now = borg.trikeshed.lib.monotonicNowMillis() * 1_000_000 // scale ms to nanos for window matching
             val completed = windows.keys.filter { it + windowDurationNanos <= now }.sorted()
             return completed.map { key ->
                 val events = windows.remove(key)!!

--- a/src/jsMain/kotlin/borg/trikeshed/lib/MonotonicClock.js.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/lib/MonotonicClock.js.kt
@@ -1,0 +1,3 @@
+package borg.trikeshed.lib
+
+actual fun monotonicNowMillis(): Long = js("Date.now()").unsafeCast<Number>().toLong()

--- a/src/jvmMain/kotlin/borg/trikeshed/lib/MonotonicClock.jvm.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/lib/MonotonicClock.jvm.kt
@@ -1,0 +1,3 @@
+package borg.trikeshed.lib
+
+actual fun monotonicNowMillis(): Long = java.lang.System.nanoTime() / 1_000_000

--- a/src/nativeMain/kotlin/borg/trikeshed/lib/MonotonicClock.native.kt
+++ b/src/nativeMain/kotlin/borg/trikeshed/lib/MonotonicClock.native.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.lib
+
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import platform.posix.CLOCK_MONOTONIC
+import platform.posix.clock_gettime
+import platform.posix.timespec
+
+actual fun monotonicNowMillis(): Long = memScoped {
+    val ts = alloc<timespec>()
+    clock_gettime(CLOCK_MONOTONIC, ts.ptr)
+    (ts.tv_sec.toLong() * 1000L) + (ts.tv_nsec.toLong() / 1_000_000L)
+}

--- a/src/wasmJsMain/kotlin/borg/trikeshed/lib/MonotonicClock.wasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/lib/MonotonicClock.wasm.kt
@@ -1,0 +1,5 @@
+package borg.trikeshed.lib
+
+import kotlin.js.Date
+
+actual fun monotonicNowMillis(): Long = Date.now().toLong()


### PR DESCRIPTION
Injects a cross-platform monotonic clock to be used for the CRMS reducer window emitting logic, replacing the event timestamp fallback. Includes expect/actual implementations in `commonMain`, `jvmMain`, `jsMain`, `wasmJsMain`, and `nativeMain`. Fixes native implementation overflow issues.

---
*PR created automatically by Jules for task [18361965708708568010](https://jules.google.com/task/18361965708708568010) started by @jnorthrup*