### PR TITLE
Implement native getProgramArguments

### DIFF
--- a/Trikeshed/src/nativeMain/kotlin/borg/trikeshed/platform/System.native.kt
+++ b/Trikeshed/src/nativeMain/kotlin/borg/trikeshed/platform/System.native.kt
@@ -16,8 +16,6 @@ object NativeMainArguments {
 }
 
 actual fun getProgramArguments(): List<String> {
-    // TODO: Implement for Native. Arguments should be captured from the
-    // `main` function's parameters.
     return NativeMainArguments.args
 }
 

--- a/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
+++ b/src/linuxMain/kotlin/linux_uring/placeholder/KioUring.kt
@@ -352,6 +352,7 @@ fun io_uring.asString(): String = memScoped {
 }
 
 fun main(argv1: Array<String>): Unit = memScoped {
+    borg.trikeshed.platform.NativeMainArguments.args = argv1.toList()
     val argv = argv1.takeIf { it.isNotEmpty() } ?: arrayOf("/etc/sysctl.conf")
 
     println("---setting up uring with args ${argv.toList()}")

--- a/src/nativeMain/kotlin/borg/trikeshed/cli/htx/HtxAria2CliNative.kt
+++ b/src/nativeMain/kotlin/borg/trikeshed/cli/htx/HtxAria2CliNative.kt
@@ -3,5 +3,6 @@ package borg.trikeshed.cli.htx
 import kotlinx.coroutines.runBlocking
 
 fun main(args: Array<String>) = runBlocking {
+    borg.trikeshed.platform.NativeMainArguments.args = args.toList()
     runAria2Cli(args)
 }


### PR DESCRIPTION
This PR implements the native `getProgramArguments()` logic by capturing arguments passed to the `main()` functions of native entry points (`HtxAria2CliNative.kt` and `KioUring.kt`) and storing them in `NativeMainArguments.args`. This fulfills the requirement because Kotlin/Native 2.4.10 does not expose a global cross-platform mechanism for getting `argv`/`args` directly out of the box.

---
*PR created automatically by Jules for task [14155293206313409695](https://jules.google.com/task/14155293206313409695) started by @jnorthrup*