### PR TITLE
chore(treedoc): remove resolved fix comment in TreeDocPipeline

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/treedoc/TreeDocPipeline.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/treedoc/TreeDocPipeline.kt
@@ -85,7 +85,7 @@ class TreeDocPipeline(
 
         // Build canonical manifest for CID
         val manifestJson = buildManifestJson(documents, framesList)
-        val manifestDoc = confixDoc(manifestJson) // Fix: just pass string for JSON
+        val manifestDoc = confixDoc(manifestJson)
         val manifestCid = ContentId.of(manifestDoc) // This canonicalizes internally
         cas.put(manifestDoc) // Puts canonical CBOR
 


### PR DESCRIPTION
This removes a resolved TODO/Fix comment in `TreeDocPipeline.kt` regarding passing a JSON string to `confixDoc`. The code on line 88 already does exactly what the comment suggests. No other changes are necessary as confirmed.

---
*PR created automatically by Jules for task [12582820163300631149](https://jules.google.com/task/12582820163300631149) started by @jnorthrup*