### PR TITLE
Refactor immutable Pair sites to Join

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/Files.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/Files.kt
@@ -1,4 +1,6 @@
 package borg.trikeshed.lib
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 @Deprecated("Use FileOperations CCEK: coroutineContext[FileOperations.Key]")
 expect object Files {
@@ -18,6 +20,6 @@ expect object Files {
     fun mkdirs(path: String)
     fun deleteRecursively(path: String)
     fun resolvePath(vararg parts: String): String
-    fun readZip(path: String): List<Pair<String, ByteArray>>
+    fun readZip(path: String): List<Join<String, ByteArray>>
     fun createTempDir(prefix: String): String
 }

--- a/src/commonMain/kotlin/borg/trikeshed/platform/tensor/MlirJit.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/platform/tensor/MlirJit.kt
@@ -1,4 +1,6 @@
 package borg.trikeshed.platform.tensor
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 /**
  * ORC JIT compiler for tensor operations using LLVM ORC
@@ -63,8 +65,8 @@ sealed class TensorOp {
     object Relu : TensorOp()
     object Softmax : TensorOp()
     data class Conv2d(
-        val padding: Pair<Int, Int>,
-        val stride: Pair<Int, Int>
+        val padding: Join<Int, Int>,
+        val stride: Join<Int, Int>
     ) : TensorOp()
     data class Gemm(
         val transA: Boolean,

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/FileOperations.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/FileOperations.kt
@@ -33,7 +33,7 @@ interface FileOperations : CoroutineContext.Element {
     fun mkdirs(path: String)
     fun deleteRecursively(path: String)
     fun resolvePath(vararg parts: String): String
-    fun readZip(path: String): List<Pair<String, ByteArray>>
+    fun readZip(path: String): List<Join<String, ByteArray>>
     fun createTempDir(prefix: String): String
 
     /** Close a file descriptor. Returns 0 on success. */

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/InMemoryFileOperations.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/InMemoryFileOperations.kt
@@ -114,7 +114,7 @@ class InMemoryFileOperations(
     override fun iterateLines(fileName: String, bufsize: Int): Iterable<Join<Long, Series<Byte>>> =
         streamLines(fileName, bufsize).map { (off, arr) -> off j arr.toSeries() }.asIterable()
 
-    override fun readZip(path: String): List<Pair<String, ByteArray>> =
+    override fun readZip(path: String): List<Join<String, ByteArray>> =
         error("readZip unsupported in InMemoryFileOperations")
 
     override val key: CoroutineContext.Key<*> get() = FileOperations.Key

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/tensor/MlirJit.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/tensor/MlirJit.kt
@@ -1,4 +1,6 @@
 package borg.trikeshed.userspace.tensor
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 /**
  * ORC JIT compiler for tensor operations using LLVM ORC
@@ -63,8 +65,8 @@ sealed class TensorOp {
     object Relu : TensorOp()
     object Softmax : TensorOp()
     data class Conv2d(
-        val padding: Pair<Int, Int>,
-        val stride: Pair<Int, Int>
+        val padding: Join<Int, Int>,
+        val stride: Join<Int, Int>
     ) : TensorOp()
     data class Gemm(
         val transA: Boolean,

--- a/src/commonTest/kotlin/keymux/KeyMuxTest.kt
+++ b/src/commonTest/kotlin/keymux/KeyMuxTest.kt
@@ -1,4 +1,6 @@
 package keymux
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 import borg.trikeshed.lib.*
 import borg.trikeshed.htx.*
@@ -35,7 +37,7 @@ class KeyMuxTest {
         override fun mkdirs(path: String) {}
         override fun deleteRecursively(path: String) {}
         override fun resolvePath(vararg parts: String): String = parts.joinToString("/")
-        override fun readZip(path: String): List<Pair<String, ByteArray>> = emptyList()
+        override fun readZip(path: String): List<Join<String, ByteArray>> = emptyList()
         override fun createTempDir(prefix: String): String = ""
         override fun close(fd: Int): Int = 0
         override fun size(fd: Int): Long = 0L

--- a/src/jsMain/kotlin/borg/trikeshed/lib/JsCommonActuals.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/lib/JsCommonActuals.kt
@@ -70,7 +70,7 @@ actual object Files {
     actual fun resolvePath(vararg parts: String): String =
         path.join(jsCwd(), parts.joinToString("/")) as String
 
-    actual fun readZip(path: String): List<Pair<String, ByteArray>> = error("readZip JS not supported")
+    actual fun readZip(path: String): List<Join<String, ByteArray>> = error("readZip JS not supported")
 
     actual fun createTempDir(prefix: String): String {
         val dir = path.join(os.tmpdir(), "$prefix-${Random.nextInt(1_000_000)}") as String

--- a/src/jvmMain/kotlin/borg/trikeshed/lib/Files.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/lib/Files.kt
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalTime::class)
 
 package borg.trikeshed.lib
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 import borg.trikeshed.userspace.nio.file.spi.JvmFileOperations
 import kotlin.time.ExperimentalTime
@@ -25,7 +27,7 @@ actual object Files {
     actual fun mkdirs(path: String) = delegate.mkdirs(path)
     actual fun deleteRecursively(path: String) = delegate.deleteRecursively(path)
     actual fun resolvePath(vararg parts: String): String = delegate.resolvePath(*parts)
-    actual fun readZip(path: String): List<Pair<String, ByteArray>> = delegate.readZip(path)
+    actual fun readZip(path: String): List<Join<String, ByteArray>> = delegate.readZip(path)
     actual fun createTempDir(prefix: String): String = delegate.createTempDir(prefix)
 }
 

--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/file/spi/JvmFileOperations.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/file/spi/JvmFileOperations.kt
@@ -167,10 +167,10 @@ class JvmFileOperations : FileOperations {
         }
     }
 
-    override fun readZip(path: String): List<Pair<String, ByteArray>> =
+    override fun readZip(path: String): List<Join<String, ByteArray>> =
         ZipFile(path).use { zip ->
             zip.entries().asSequence().map { entry ->
-                entry.name to zip.getInputStream(entry).use { it.readBytes() }
+                entry.name j zip.getInputStream(entry).use { it.readBytes() }
             }.toList()
         }
 

--- a/src/linuxMain/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperations.kt
+++ b/src/linuxMain/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperations.kt
@@ -141,7 +141,7 @@ class LinuxFileOperations : FileOperations {
         }
     }
     override fun resolvePath(vararg parts: String): String = parts.joinToString("/")
-    override fun readZip(path: String): List<Pair<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
+    override fun readZip(path: String): List<Join<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
     override fun createTempDir(prefix: String): String = createTempDirectory(prefix)
 
     override fun open(path: String, readOnly: Boolean): Int {

--- a/src/posixMain/kotlin/borg/trikeshed/lib/Files.posix.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/lib/Files.posix.kt
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalForeignApi::class)
 
 package borg.trikeshed.lib
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 import borg.trikeshed.common.createTempDirectory
 import kotlinx.cinterop.*
@@ -164,7 +166,7 @@ actual object Files {
 
     actual fun resolvePath(vararg parts: String): String = parts.joinToString("/")
 
-    actual fun readZip(path: String): List<Pair<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
+    actual fun readZip(path: String): List<Join<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
 
     actual fun createTempDir(prefix: String): String = createTempDirectory(prefix)
 

--- a/src/posixMain/kotlin/borg/trikeshed/userspace/nio/file/spi/PosixFileOperations.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/userspace/nio/file/spi/PosixFileOperations.kt
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalForeignApi::class)
 
 package borg.trikeshed.userspace.nio.file.spi
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 import borg.trikeshed.common.createTempDirectory
 import borg.trikeshed.lib.*
@@ -112,7 +114,7 @@ class PosixFileOperations : FileOperations {
         }
     }
     override fun resolvePath(vararg parts: String): String = parts.joinToString("/")
-    override fun readZip(path: String): List<Pair<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
+    override fun readZip(path: String): List<Join<String, ByteArray>> = throw UnsupportedOperationException("readZip unsupported")
     override fun open(path: String, readOnly: Boolean): Int {
         val flags = if (readOnly) O_RDONLY else (O_RDWR or O_CREAT)
         return platform.posix.open(path, flags,  644.fromOctal())

--- a/src/wasmJsMain/kotlin/borg/trikeshed/lib/WasmCommonActuals.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/lib/WasmCommonActuals.kt
@@ -1,4 +1,6 @@
 package borg.trikeshed.lib
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
 
 import borg.trikeshed.userspace.ByteRegion
 import borg.trikeshed.lib.long.LongSeries
@@ -275,7 +277,7 @@ actual object Files {
     actual fun resolvePath(vararg parts: String): String =
         normalizePath(parts.joinToString("/"))
 
-    actual fun readZip(path: String): List<Pair<String, ByteArray>> = error("readZip WASM not supported")
+    actual fun readZip(path: String): List<Join<String, ByteArray>> = error("readZip WASM not supported")
 
     actual fun createTempDir(prefix: String): String =
         "/tmp/$prefix-${Random.nextLong().toString(16)}"


### PR DESCRIPTION
Triage the 52 Pair sites and apply the `Join<A,B>` kernel binary composition for immutable/rejoinable payloads. Replaced Pair and `to` with Join and `j` in platform tensors, FileOperations wrappers, and Test actuals, while ensuring main classes build passes perfectly.

---
*PR created automatically by Jules for task [11638874304456561089](https://jules.google.com/task/11638874304456561089) started by @jnorthrup*