### PR TITLE
🔒 Fix arbitrary module loading vulnerability in nodeRequire

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/lib/JsNode.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/lib/JsNode.kt
@@ -8,7 +8,10 @@ import kotlin.random.Random
 // which would crash the browser bundle with "Cannot find module 'fs'".
 // Browser code paths never call these — only Node paths do.
 
-private fun nodeRequire(name: String): dynamic = js("eval(\"require\")(name)")
+private fun nodeRequire(name: String): dynamic {
+    require(name == "fs" || name == "os" || name == "path") { "Unauthorized Node.js module: $name" }
+    return js("eval(\"require\")(name)")
+}
 
 val fs: dynamic get() = nodeRequire("fs")
 val os: dynamic get() = nodeRequire("os")


### PR DESCRIPTION
🎯 **What:** Fixed an arbitrary module loading vulnerability in `nodeRequire` by sanitizing inputs.
⚠️ **Risk:** The previous implementation used `eval("require")(name)` allowing arbitrary node modules to be loaded if untrusted input ever reached the `nodeRequire` function.
🛡️ **Solution:** Added a strict `require` allowlist check restricting `nodeRequire` to only `"fs"`, `"os"`, and `"path"`, throwing an `IllegalArgumentException` for any unauthorized modules.

---
*PR created automatically by Jules for task [14941237522288008339](https://jules.google.com/task/14941237522288008339) started by @jnorthrup*