### PR TITLE
Fix payloadOffset calculation in BtrfsDeviceTree.kt

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/btrfs/BtrfsDeviceTree.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/btrfs/BtrfsDeviceTree.kt
@@ -44,7 +44,7 @@ object BtrfsDeviceTree {
             val itemSize = readUIntLE(bytes, itemPtrOffset + 21).toInt()
             
             // fix: data offset is relative to the start of the node (offset)
-            val payloadOffset = offset + 101 + dataOffsetInNode
+            val payloadOffset = offset + dataOffsetInNode
             
             val devid = readULongLE(bytes, payloadOffset)
             // read only the first 8 bytes of uuid for simplicity here as required by the spec


### PR DESCRIPTION
This change fixes the payloadOffset calculation in BtrfsDeviceTree.kt to be strictly relative to the start of the BTRFS node, removing an erroneous 101 byte offset addition which was causing misaligned data reads.

---
*PR created automatically by Jules for task [16757013276649460335](https://jules.google.com/task/16757013276649460335) started by @jnorthrup*