### PR TITLE
🔒 Fix predictable random numbers for LlmSession sessionId

### DIFF
--- a/src/commonMain/kotlin/modelmux/ModelMux.kt
+++ b/src/commonMain/kotlin/modelmux/ModelMux.kt
@@ -9,6 +9,8 @@ import borg.trikeshed.userspace.reactor.CacheLookup
 import borg.trikeshed.modelmux.ModelResponseReceipt
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 // ═══════════════════════════════════════════
 // Type algebra
@@ -58,12 +60,13 @@ object CapabilityRouter : ModelRouter {
 
 enum class SessionState { CREATED, OPEN, ACTIVE, DRAINING, CLOSED }
 
+@OptIn(ExperimentalUuidApi::class)
 class LlmSession(
     val model: ModelEntry,
     private val authKey: String,
     val baseUrl: String,
     /** Session id — stamped on every [ModelResponseReceipt] minted from this session. */
-    val sessionId: String = "sess-${kotlin.random.Random.nextLong().toString(16)}",
+    val sessionId: String = "sess-${Uuid.random()}",
 ) {
     private var _state = SessionState.CREATED
     val state: SessionState get() = _state


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of a predictable random number generator (`kotlin.random.Random`) to generate `sessionId`s in `LlmSession` within `ModelMux.kt`.
⚠️ **Risk:** The potential impact if left unfixed is that an attacker could predict session IDs by observing a few generated values or knowing the internal state of the RNG. This could lead to session hijacking, unauthorized access to session receipts (`ModelResponseReceipt`), or cross-session data leakage if the ID is used for routing or authorization.
🛡️ **Solution:** The fix replaces the predictable `Random.nextLong()` with `kotlin.uuid.Uuid.random()`. In Kotlin Multiplatform 2.0.20+, `Uuid.random()` leverages cryptographically secure pseudorandom number generators (CSPRNG) across all platforms (e.g., `SecureRandom` on JVM, `Crypto.getRandomValues()` on JS/Wasm, and OS-level secure APIs on Native). This guarantees that session IDs are unpredictable and secure. The change includes adding the `@OptIn(kotlin.uuid.ExperimentalUuidApi::class)` annotation.

---
*PR created automatically by Jules for task [15853354208087604788](https://jules.google.com/task/15853354208087604788) started by @jnorthrup*