### PR TITLE
⚡ Wrap PosixProcessOperations exec in withContext to avoid blocking event loop

### DIFF
--- a/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
@@ -3,6 +3,7 @@
 package borg.trikeshed.userspace.nio.channels.spi
 import borg.trikeshed.userspace.nio.channels.spi.*
 import kotlinx.cinterop.*
+import kotlinx.coroutines.*
 import platform.posix.*
 
 class PosixProcessOperations : ProcessOperations {
@@ -12,14 +13,14 @@ class PosixProcessOperations : ProcessOperations {
         args: List<String>,
         stdin: ByteArray?,
         env: Map<String, String>,
-    ): ProcessResult {
+    ): ProcessResult = withContext(Dispatchers.Default) {
         val stdinPath = stdin?.let { createTempFile(it) }
         val stdoutPath = createTempFile(byteArrayOf())
-            ?: return ProcessResult(-1, byteArrayOf(), "mkstemp(stdout) failed".encodeToByteArray()).also {
+            ?: return@withContext ProcessResult(-1, byteArrayOf(), "mkstemp(stdout) failed".encodeToByteArray()).also {
                 stdinPath?.let(::unlink)
             }
         val stderrPath = createTempFile(byteArrayOf())
-            ?: return ProcessResult(-1, byteArrayOf(), "mkstemp(stderr) failed".encodeToByteArray()).also {
+            ?: return@withContext ProcessResult(-1, byteArrayOf(), "mkstemp(stderr) failed".encodeToByteArray()).also {
                 stdinPath?.let(::unlink)
                 unlink(stdoutPath)
             }
@@ -88,7 +89,7 @@ class PosixProcessOperations : ProcessOperations {
         unlink(stdoutPath)
         unlink(stderrPath)
 
-        return ProcessResult(exitCode, stdout, stderr)
+        ProcessResult(exitCode, stdout, stderr)
     }
 
     private fun createTempFile(bytes: ByteArray): String? = memScoped {


### PR DESCRIPTION
💡 **What:** Wrapped the blocking I/O operations (`createTempFile`, `unlink`, etc.) in `PosixProcessOperations.exec` using `withContext(Dispatchers.Default)`. Also updated early returns to use `return@withContext`.
🎯 **Why:** `createTempFile` and `unlink` are blocking I/O calls. Executing them directly in the suspend function on the calling thread blocks the event loop thread, degrading concurrency and performance. Offloading to `Dispatchers.Default` (as `Dispatchers.IO` is standardly missing or unstable in older K/N versions without specific configuration) solves this issue.
📊 **Measured Improvement:** I did not capture a specific numerical benchmark because running K/N benchmarks natively is complex in this environment, and full builds time out. However, offloading blocking I/O from an event-loop thread is a proven and necessary pattern in asynchronous programming architectures to prevent reactor starvation.

---
*PR created automatically by Jules for task [6801875303412786722](https://jules.google.com/task/6801875303412786722) started by @jnorthrup*