### PR TITLE
Fix OroborosDaemon to cleanly shut down on --once

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -460,6 +460,9 @@ object OroborosDaemon {
                 // --once: run one reactive tick synchronously.
                 driver.startReactiveCycle(this)
                 delay(intervalMs * 2)
+                isRunning = false
+                mainJob?.cancel()
+                return
             }
         } finally {
             healthJob.cancel()


### PR DESCRIPTION
Fix OroborosDaemon to cleanly shut down on --once

Sets `isRunning = false`, calls `mainJob?.cancel()` to terminate child coroutines (like the reactive cycle driver), and explicitly breaks out of the execution loop when `--once` finishes, ensuring the finally block executes properly to flush out trace writers gracefully.

---
*PR created automatically by Jules for task [5712543944633264156](https://jules.google.com/task/5712543944633264156) started by @jnorthrup*