### PR TITLE
⚡ Offload blocking file I/O to Dispatchers.IO in PosixProcessOperations

### DIFF
--- a/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
@@ -13,7 +13,7 @@ class PosixProcessOperations : ProcessOperations {
         args: List<String>,
         stdin: ByteArray?,
         env: Map<String, String>,
-    ): ProcessResult = withContext(Dispatchers.Default) {
+    ): ProcessResult = withContext(Dispatchers.IO) {
         val stdinPath = stdin?.let { createTempFile(it) }
         val stdoutPath = createTempFile(byteArrayOf())
             ?: return@withContext ProcessResult(-1, byteArrayOf(), "mkstemp(stdout) failed".encodeToByteArray()).also {


### PR DESCRIPTION
💡 **What:** Changed `withContext(Dispatchers.Default)` to `withContext(Dispatchers.IO)` in `PosixProcessOperations.exec`.
🎯 **Why:** `createTempFile` (which calls `mkstemp` and `write`) and `unlink` are synchronous, blocking POSIX operations. Running them on `Dispatchers.Default` blocks the core-sized thread pool meant for CPU-bound tasks.
📊 **Measured Improvement:** Replaced default thread pool (size of CPU cores) with `Dispatchers.IO` (which can scale up for blocking calls) for the specific blocking I/O calls, ensuring CPU tasks aren't starved during process spawned disk writing.

---
*PR created automatically by Jules for task [14034218290048672514](https://jules.google.com/task/14034218290048672514) started by @jnorthrup*