### PR TITLE
Supersede necromanced PosixIsamOperations.append task

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -273,6 +273,7 @@ suspend fun drainWork(store: JulesBoardStore) {
     drainSession11949152291930230780(store)
     drainSession15956094472626662213(store)
     drainSession14162871126292114727(store)
+    drainSession17099126540887000248(store)
 }
 
 suspend fun drainSession13434914650488484998(store: JulesBoardStore) {
@@ -296,6 +297,31 @@ suspend fun drainSession13434914650488484998(store: JulesBoardStore) {
             ),
             claimedAt = 0L,
             prUrl = null
+        ),
+        at = 0L
+    ))
+}
+
+suspend fun drainSession17099126540887000248(store: JulesBoardStore) {
+    val workId = "session:17099126540887000248"
+    store.appendWork(workId, JulesCause.WorkDrained(
+        workId = workId,
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = workId,
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                "Superseded necromanced work",
+                "Implement PosixIsamOperations.append",
+                "Superseded via drain script."
+            ),
+            claimedAt = 0L
         ),
         at = 0L
     ))


### PR DESCRIPTION
This clears the necromanced queue entry `session:17099126540887000248` (Implement PosixIsamOperations.append) which was already implemented previously.

---
*PR created automatically by Jules for task [9651175915398584138](https://jules.google.com/task/9651175915398584138) started by @jnorthrup*