### PR TITLE
chore: drain stale JobFrame CID task

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,21 @@
-1. Modify `src/commonMain/kotlin/forge/doc/WorkDrain.kt` using `replace_with_git_merge_diff`
-   - Add a new function `drainSession17389565571177971407` that appends a `WorkDrained` event with dummy signature to supersede the necromanced task.
-   - Register this function inside `drainWork` to ensure it is invoked.
-2. Read the modified file to verify changes using `cat src/commonMain/kotlin/forge/doc/WorkDrain.kt`.
-3. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-4. Invoke the `request_code_review` tool.
+1. **Analyze existing code in `JobReducer.kt`**
+   - The file uses `CanonicalCbor.encode(frame.doc)` when processing `JobFrame`.
+   - The current code already implements deterministic CIDs for `JobFrame` using `CanonicalCbor`.
+   - The user asked to re-read the code and if already covered by a landed session, supersede with a receipt-bearing `WorkDrained`.
+
+2. **Verify test passing**
+   - Run tests to see if tests pass.
+
+3. **Supersede necromanced work**
+   - Append to `WorkDrain.kt` a `WorkDrained` entry for `session:4465036716017209747`.
+   - The method to use is `appendWork`.
+   - Create a drain function named `drainSession4465036716017209747`.
+
+4. **Verify changes**
+   - Use `tail` on `WorkDrain.kt` to ensure changes are applied.
+
+5. **Run Pre-Commit Checks**
+   - Invoke `pre_commit_instructions` and follow the provided steps.
+
+6. **Submit Code Review**
+   - Request a code review.

--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -591,6 +591,7 @@ drainSession15466567759278489251(store)
     drainSession15956094472626662213(store)
     drainSession14162871126292114727(store)
     drainSession17099126540887000248(store)
+    drainSession4465036716017209747(store)
 }
 
 suspend fun drainSession13434914650488484998(store: JulesBoardStore) {
@@ -1297,6 +1298,31 @@ suspend fun drainSession15956094472626662213(store: JulesBoardStore) {
             ),
             claimedAt = 0L,
             prUrl = null
+        ),
+        at = 0L
+    ))
+}
+
+suspend fun drainSession4465036716017209747(store: JulesBoardStore) {
+    val workId = "session:4465036716017209747"
+    store.appendWork(workId, JulesCause.WorkDrained(
+        workId = workId,
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = workId,
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                "Superseded necromanced work",
+                "Make JobFrame fact CIDs deterministic",
+                "Superseded via drain script. Deterministic JobFrame fact CIDs are already implemented via CanonicalCbor.encode in JobReducer.kt."
+            ),
+            claimedAt = 0L
         ),
         at = 0L
     ))


### PR DESCRIPTION
Supersede the necromanced task session:4465036716017209747 (Make JobFrame fact CIDs deterministic) because JobFrame fact CIDs are already deterministic via CanonicalCbor.encode in JobReducer.kt.

---
*PR created automatically by Jules for task [9226920960613696175](https://jules.google.com/task/9226920960613696175) started by @jnorthrup*