### PR TITLE
flywheel: drain necromanced task synth:11191049401439195892

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -182,7 +182,32 @@ suspend fun drainSupersededTask(store: JulesBoardStore) {
     )
 }
 
+suspend fun drainSynth11191049401439195892(store: JulesBoardStore) {
+    store.appendWork("synth:11191049401439195892", JulesCause.WorkDrained(
+        workId = "synth:11191049401439195892",
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = "synth:11191049401439195892",
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                "Superseded necromanced work",
+                "Replace Iterator-returning filter with Series-returning filter",
+                "Superseded via drain script."
+            ),
+            claimedAt = 0L
+        ),
+        at = 0L
+    ))
+}
+
 suspend fun drainWork(store: JulesBoardStore) {
+    drainSynth11191049401439195892(store)
     val workId = "synth:12224356407860756599#2"
 
     val receipt = MergeReceipt(


### PR DESCRIPTION
Supersedes task synth:11191049401439195892 with a receipt-bearing WorkDrained event because the requested refactoring (Replace Iterator-returning filter with Series-returning filter) was already completed in commit be281e48.

---
*PR created automatically by Jules for task [12937871092903792940](https://jules.google.com/task/12937871092903792940) started by @jnorthrup*