### PR TITLE
chore: Supersede BTRFS chunk tree offset task with WorkDrained event

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -183,6 +183,8 @@ suspend fun drainSupersededTask(store: JulesBoardStore) {
 }
 
 suspend fun drainWork(store: JulesBoardStore) {
+    drainSynth10874136384651488584(store)
+
     val workId = "synth:12224356407860756599#2"
 
     val receipt = MergeReceipt(
@@ -226,6 +228,31 @@ suspend fun drainReworkSynth3803389897151472172(store: JulesBoardStore) {
             ),
             claimedAt = 0L,
             prUrl = null
+        ),
+        at = 0L
+    ))
+}
+
+suspend fun drainSynth10874136384651488584(store: JulesBoardStore) {
+    val workId = "synth:10874136384651488584"
+    store.appendWork(workId, JulesCause.WorkDrained(
+        workId = workId,
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = workId,
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                "Superseded necromanced work",
+                "Fix BTRFS Chunk Tree Data Offset Logic",
+                "Superseded via drain script."
+            ),
+            claimedAt = 0L
         ),
         at = 0L
     ))


### PR DESCRIPTION
Superseded necromanced work `synth:10874136384651488584` via drain script. Code has been verified and already functions as intended.

---
*PR created automatically by Jules for task [7544761682517583967](https://jules.google.com/task/7544761682517583967) started by @jnorthrup*