### PR TITLE
Supersede necromanced session 10635169297110193527

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -204,6 +204,8 @@ suspend fun drainWork(store: JulesBoardStore) {
         receipt = receipt,
         at = 0L
     ))
+
+    drainSession10635169297110193527(store)
 }
 
 suspend fun drainReworkSynth3803389897151472172(store: JulesBoardStore) {
@@ -226,6 +228,31 @@ suspend fun drainReworkSynth3803389897151472172(store: JulesBoardStore) {
             ),
             claimedAt = 0L,
             prUrl = null
+        ),
+        at = 0L
+    ))
+}
+
+suspend fun drainSession10635169297110193527(store: JulesBoardStore) {
+    val workId = "session:10635169297110193527"
+    store.appendWork(workId, JulesCause.WorkDrained(
+        workId = workId,
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = workId,
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                summary = "Superseded necromanced work",
+                title = "[rework #1] [rework #1] Wire DoubleSeries into query engine",
+                content = "Superseded via drain script."
+            ),
+            claimedAt = 0L
         ),
         at = 0L
     ))


### PR DESCRIPTION
Supersede the stale queue entry for session 10635169297110193527 by appending a receipt-bearing WorkDrained event to JulesBoardStore in WorkDrain.kt.

---
*PR created automatically by Jules for task [16462739102037254084](https://jules.google.com/task/16462739102037254084) started by @jnorthrup*