### PR TITLE
Supersede necromanced zoom(path) work with WorkDrained receipt

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -103,6 +103,34 @@ suspend fun drainWork(store: JulesBoardStore) {
         receipt = receipt,
         at = 0L
     ))
+
+    drainReworkSynth12930517035041184470(store)
+}
+
+suspend fun drainReworkSynth12930517035041184470(store: JulesBoardStore) {
+    val targetWorkId = "rework:synth:12930517035041184470#1"
+    store.appendWork(targetWorkId, JulesCause.WorkDrained(
+        workId = targetWorkId,
+        sessionId = "necromanced",
+        commitSha = "superseded-by-review",
+        taskId = "supersede-pass",
+        receipt = MergeReceipt(
+            workId = targetWorkId,
+            producer = "necromancer",
+            producerRef = "necromanced",
+            patchCid = ContentId("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+            revision = "superseded-by-review",
+            versionTag = "superseded-by-review",
+            lexicalMemory = LexicalMemory(
+                summary = "Superseded necromanced work",
+                title = "[rework #1] Implement zoom(path): Cursor returning sub-cursor",
+                content = "Superseded via drain script. Feature already covered by landed session."
+            ),
+            claimedAt = 0L,
+            prUrl = null
+        ),
+        at = 0L
+    ))
 }
 
 suspend fun drainReworkSynth3803389897151472172(store: JulesBoardStore) {


### PR DESCRIPTION
The original necromanced task requested the implementation of `zoom(path): Cursor` to return sub-cursors. Upon inspection, this functionality is already fully provided by `fun Cursor.zoom(vararg path: CharSequence): Cursor`. 

Following the task's fallback instructions ("If the original locality is already covered by a landed session, supersede with a receipt-bearing WorkDrained and stop"), this commit adds `drainReworkSynth12930517035041184470` to `WorkDrain.kt` and registers it within `drainWork` to correctly emit the superseding receipt.

---
*PR created automatically by Jules for task [6683569197790152718](https://jules.google.com/task/6683569197790152718) started by @jnorthrup*