### PR TITLE
Fix blocking preflight in OroborosDaemon

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -371,7 +371,7 @@ object OroborosDaemon {
             pollErrRef = { pollErrOccurred },
             setPollErr = { pollErrOccurred = it },
             runCycle = { runCycle() },
-            preflight = { preflight(repoDir, driver) },
+            preflight = { kotlinx.coroutines.runBlocking { preflight(repoDir, driver) } },
         )
         cycleBodyField = cycleBody
 
@@ -420,17 +420,22 @@ object OroborosDaemon {
         }
     }
 
-    private fun preflight(repoDir: File, driver: FlywheelDriver): Boolean {
+    private suspend fun preflight(repoDir: File, driver: FlywheelDriver): Boolean {
         // git fetch origin master (best-effort, 5s timeout)
-        val fetch = ProcessBuilder("git", "fetch", "origin", "master", "--dry-run")
-            .directory(repoDir).start()
-        val fetchOk = fetch.waitFor() == 0
+        val fetchOk = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            val fetch = ProcessBuilder("git", "fetch", "origin", "master", "--dry-run")
+                .directory(repoDir).start()
+            val finished = fetch.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) fetch.destroyForcibly()
+            finished && fetch.exitValue() == 0
+        }
         if (!fetchOk) return true // offline is OK, we'll poll anyway
 
-        fun command(vararg args: String): String {
+        suspend fun command(vararg args: String): String = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             val p = ProcessBuilder(*args).directory(repoDir).redirectErrorStream(true).start()
-            p.waitFor()
-            return p.inputStream.bufferedReader().readText().trim()
+            val finished = p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) p.destroyForcibly()
+            p.inputStream.bufferedReader().readText().trim()
         }
 
         val local = command("git", "rev-parse", "HEAD")


### PR DESCRIPTION
The `preflight` function in `OroborosDaemon.kt` was using `Process.waitFor()` which blocked the reactor, violating the architectural rule in AGENTS.md.
I modified `preflight` to be a `suspend` function and wrapped the `ProcessBuilder` execution blocks in `withContext(Dispatchers.IO)`. I also added a bounded timeout (5 seconds for `git fetch` and 10 seconds for other Git commands) and ensured that any processes exceeding the timeout are forcibly destroyed. Finally, I updated the instantiation of `CycleBody` to correctly invoke the now-suspending `preflight` function.

---
*PR created automatically by Jules for task [4217298738423539141](https://jules.google.com/task/4217298738423539141) started by @jnorthrup*