### PR TITLE
Report real Mux reactor lease reclamation

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/reactor/MuxReactorElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/reactor/MuxReactorElement.kt
@@ -367,6 +367,12 @@ class MuxReactorElement(
                         timestampMs = now,
                     ),
                 )
+                recordOperational(
+                    poolName = MuxOperationalPool.WORKER_UTILIZATION,
+                    key = "reclaimed_${key.keyId}_$now",
+                    labels = mapOf("key" to key.keyId, "provider" to key.provider),
+                    value = -1.0,
+                )
                 reclaimed++
             }
         }


### PR DESCRIPTION
- Report real Mux reactor lease reclamation by calling `recordOperational` before incrementing `reclaimed` inside `reclaimExpiredLeases`.
- Use `MuxOperationalPool.WORKER_UTILIZATION` pool to decrement (-1.0) worker utilization when a lease expires, updating the metrics correctly.

---
*PR created automatically by Jules for task [13404381873953696081](https://jules.google.com/task/13404381873953696081) started by @jnorthrup*