### PR TITLE
🎨 Palette: Add aria-label to block gutter buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-04 - Palette Journal Initialization
+**Learning:** Initializing the journal for tracking critical UX and accessibility learnings.
+**Action:** Use this file to record specific insights related to accessibility and UX patterns in the TrikeShed app.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -257,6 +257,7 @@
     addBtn.className = 'gutter-btn';
     addBtn.textContent = '+';
     addBtn.title = 'Add block below';
+    addBtn.setAttribute('aria-label', 'Add block below');
     addBtn.addEventListener('click', () => {
       insertBlock(idx + 1, { id: uid(), type: 'p', text: '' });
       focusBlock(activePage().blocks[idx + 1].id, true);
@@ -265,6 +266,7 @@
     dragBtn.className = 'gutter-btn gutter-drag';
     dragBtn.textContent = '⋮⋮';
     dragBtn.title = 'Drag to reorder';
+    dragBtn.setAttribute('aria-label', 'Drag to reorder block');
     gutter.append(addBtn, dragBtn);
     el.appendChild(gutter);
 


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only "+" and "⋮⋮" (drag) buttons in the block gutter.
🎯 Why: These buttons previously had `title` attributes for tooltips, but lacked explicit `aria-label`s, which can make them harder to understand or interact with for users relying on screen readers.
📸 Before/After: N/A - Visually identical, purely an accessibility improvement.
♿ Accessibility: Improved screen reader context for core editor controls by explicitly stating their actions ("Add block below" and "Drag to reorder block").

---
*PR created automatically by Jules for task [3905066885308424621](https://jules.google.com/task/3905066885308424621) started by @jnorthrup*