### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in GalleryRenderer

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/forge/gallery/GalleryRenderer.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/forge/gallery/GalleryRenderer.kt
@@ -34,11 +34,20 @@ class GalleryRenderer {
         }
     }
 
+    private fun sanitizeHtml(input: String): String {
+        return input.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#039;")
+    }
+
     private fun renderTextCard(item: dynamic): Element {
         val el = createBaseCard(item)
         val content = item.content as? String ?: ""
+        val safeContent = sanitizeHtml(content)
         // Minimal markdown parser
-        val htmlContent = content
+        val htmlContent = safeContent
             .replace(Regex("\\*\\*(.*?)\\*\\*"), "<b>$1</b>")
             .replace(Regex("_(.*?)_"), "<i>$1</i>")
             .replace(Regex("`(.*?)`"), "<code>$1</code>")
@@ -87,8 +96,9 @@ class GalleryRenderer {
     private fun renderCodeCard(item: dynamic): Element {
         val el = createBaseCard(item)
         val content = item.content as? String ?: ""
+        val safeContent = sanitizeHtml(content)
         // Naive JS syntax highlighting
-        val highlighted = content
+        val highlighted = safeContent
             .replace("fun ", "<span style='color: #7aa2f7;'>fun </span>")
             .replace("val ", "<span style='color: #7aa2f7;'>val </span>")
             .replace("var ", "<span style='color: #7aa2f7;'>var </span>")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS from unsanitized item content before using innerHTML in GalleryRenderer
🎯 Impact: Arbitrary HTML/JS injection allowing cross-site scripting when rendering untrusted text or code blocks in the gallery.
🔧 Fix: Introduced `sanitizeHtml` to properly HTML-escape inputs (escaping `<`, `>`, `&`, `"`, `'`) before performing any naive markdown/syntax-highlighting string replacements, ensuring safe insertion via `.innerHTML`.
✅ Verification: Code reviewed to confirm the sanitize function correctly escapes inputs in `renderTextCard` and `renderCodeCard`.

---
*PR created automatically by Jules for task [16458842108360954244](https://jules.google.com/task/16458842108360954244) started by @jnorthrup*