### PR TITLE
⚡ Bolt: Optimize CausalWal append disk IO

### DIFF
--- a/plan_script.sh
+++ b/plan_script.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "creating plan"

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/persistence/CausalWal.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/persistence/CausalWal.kt
@@ -29,13 +29,21 @@ class CausalWal(private val path: File) {
 
     suspend fun append(causalKey: String, payload: ByteArray): Long = withContext(Dispatchers.IO) {
         val keyBytes = causalKey.encodeToByteArray()
+
+        // ⚡ Bolt Optimization: Pre-allocate a single ByteBuffer outside the synchronized block.
+        // By copying the header lengths and payload into this single buffer, we reduce
+        // 4 separate JNI / disk `write` calls into 1, vastly reducing disk I/O overhead
+        // and minimizing the lock duration on the RandomAccessFile.
+        val buffer = java.nio.ByteBuffer.allocate(8 + keyBytes.size + payload.size)
+        buffer.putInt(keyBytes.size)
+        buffer.put(keyBytes)
+        buffer.putInt(payload.size)
+        buffer.put(payload)
+
         synchronized(raf) {
             val offset = raf.length()
             raf.seek(offset)
-            raf.writeInt(keyBytes.size)
-            raf.write(keyBytes)
-            raf.writeInt(payload.size)
-            raf.write(payload)
+            raf.write(buffer.array())
             raf.fd.sync()
             offset
         }


### PR DESCRIPTION
💡 What: Combine 4 sequential disk write calls in CausalWal into a single byte buffer write.
🎯 Why: Writing sizes and payloads via separate `RandomAccessFile.writeInt`/`write` calls invokes disk/OS-level boundary crossings 4 times. Pre-allocating and filling a ByteBuffer before writing cuts this down to 1 call per append, vastly improving write-heavy performance.
📊 Impact: Expected to reduce JNI crossings and IO overhead in `CausalWal.append()` significantly.
🔬 Measurement: Run CausalWalTest and verify the JVM test passes successfully.

---
*PR created automatically by Jules for task [5782111103062078457](https://jules.google.com/task/5782111103062078457) started by @jnorthrup*