### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/PosixProcessOperations.kt
@@ -17,14 +17,14 @@ class PosixProcessOperations : ProcessOperations {
         val stdinPath = stdin?.let { createTempFile(it) }
         val stdoutPath = createTempFile(byteArrayOf())
         if (stdoutPath == null) {
-            withContext(Dispatchers.Default) {
+            withContext(Dispatchers.IO) {
                 stdinPath?.let(::unlink)
             }
             return@withContext ProcessResult(-1, byteArrayOf(), "mkstemp(stdout) failed".encodeToByteArray())
         }
         val stderrPath = createTempFile(byteArrayOf())
         if (stderrPath == null) {
-            withContext(Dispatchers.Default) {
+            withContext(Dispatchers.IO) {
                 stdinPath?.let(::unlink)
                 unlink(stdoutPath)
             }
@@ -91,7 +91,7 @@ class PosixProcessOperations : ProcessOperations {
         val stdout = readFile(stdoutPath)
         val stderr = readFile(stderrPath)
 
-        withContext(Dispatchers.Default) {
+        withContext(Dispatchers.IO) {
             stdinPath?.let(::unlink)
             unlink(stdoutPath)
             unlink(stderrPath)
@@ -100,7 +100,7 @@ class PosixProcessOperations : ProcessOperations {
         ProcessResult(exitCode = exitCode, stdout = stdout, stderr = stderr)
     }
 
-    private suspend fun createTempFile(bytes: ByteArray): String? = withContext(Dispatchers.Default) {
+    private suspend fun createTempFile(bytes: ByteArray): String? = withContext(Dispatchers.IO) {
         memScoped {
             val template = "/tmp/trikeshed-process-XXXXXX".cstr.placeTo(this)
             val fd = mkstemp(template)
@@ -126,7 +126,7 @@ class PosixProcessOperations : ProcessOperations {
         }
     }
 
-    private suspend fun readFile(path: String): ByteArray = withContext(Dispatchers.Default) {
+    private suspend fun readFile(path: String): ByteArray = withContext(Dispatchers.IO) {
         val fp = fopen(path, "rb") ?: return@withContext byteArrayOf()
         try {
             memScoped {


### PR DESCRIPTION
💡 What: Swapped Dispatchers.Default for Dispatchers.IO in PosixProcessOperations.kt where we are using blocking system calls like mkstemp, unlink, and read/write for temporary files.
🎯 Why: createTempFile and unlink are blocking and executed on the current thread, potentially blocking the event loop or other tasks using the default dispatcher in Kotlin Native.
📊 Impact: This ensures the system event loop won't hang when POSIX operations temporarily block.
🔬 Measurement: We cannot run the native test natively on Linux (host is incompatible with Mingw64 testing in gradle). However, statically, using IO for blocking operations strictly adheres to Kotlin/Native coroutines best practices.

---
*PR created automatically by Jules for task [13818454508754335254](https://jules.google.com/task/13818454508754335254) started by @jnorthrup*