### PR TITLE
Refactor: Unify LiburingFacade unsupported helper

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/Liburing.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/Liburing.kt
@@ -71,3 +71,6 @@ internal expect object LiburingImpl : LiburingFacade {
     override fun drain(): Result<Unit>
     override fun close(): Result<Unit>
 }
+
+internal fun <T> unsupported(): Result<T> =
+    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))

--- a/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
@@ -23,6 +23,3 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))

--- a/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
+++ b/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
@@ -22,6 +22,3 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))

--- a/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
@@ -22,6 +22,3 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))


### PR DESCRIPTION
Consolidated duplicated `unsupported()` helper function from macos, js, and wasmJs platforms to `commonMain`. This eliminates code duplication and ensures a single source of truth for the fallback exception logic.

---
*PR created automatically by Jules for task [8453726376912891800](https://jules.google.com/task/8453726376912891800) started by @jnorthrup*