### PR TITLE
Refactor: Consolidate Liburing unsupported stub implementation

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/Liburing.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/Liburing.kt
@@ -71,3 +71,9 @@ internal expect object LiburingImpl : LiburingFacade {
     override fun drain(): Result<Unit>
     override fun close(): Result<Unit>
 }
+
+internal fun <T> unsupported(): Result<T> = Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))
+
+internal fun unsupportedUnit(): Unit {
+    throw UnsupportedOperationException("liburing facade is only available on linux")
+}

--- a/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/userspace/Liburing.js.kt
@@ -17,12 +17,9 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun submit(): Result<Int> = unsupported()
     actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
-    actual override fun cqAdvance(count: Int) {}
-    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
-    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
+    actual override fun cqAdvance(count: Int) = unsupportedUnit()
+    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
+    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))

--- a/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
+++ b/src/macosMain/kotlin/borg/trikeshed/userspace/Liburing.macos.kt
@@ -13,15 +13,13 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun prepMunmap(addr: Long, len: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun prepSendmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun prepRecvmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
+
     actual override fun submit(): Result<Int> = unsupported()
     actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
-    actual override fun cqAdvance(count: Int) {}
-    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
-    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
+    actual override fun cqAdvance(count: Int) = unsupportedUnit()
+    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
+    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))

--- a/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/userspace/Liburing.wasm.kt
@@ -14,14 +14,11 @@ internal actual object LiburingImpl : LiburingFacade {
     actual override fun submit(): Result<Int> = unsupported()
     actual override fun waitCqe(): Result<UringCompletion?> = unsupported()
     actual override fun peekCqe(): Result<UringCompletion?> = unsupported()
-    actual override fun cqAdvance(count: Int) {}
-    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
-    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) {}
+    actual override fun cqAdvance(count: Int) = unsupportedUnit()
+    actual override fun registerFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
+    actual override fun removeFanoutHandler(token: Long, handler: (UringCompletion) -> Unit) = unsupportedUnit()
     actual override fun prepSendmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun prepRecvmsg(fd: Int, msgHdrPtr: Long, flags: Int, userData: Long): Result<Unit> = unsupported()
     actual override fun drain(): Result<Unit> = unsupported()
     actual override fun close(): Result<Unit> = unsupported()
 }
-
-private fun <T> unsupported(): Result<T> =
-    Result.failure(UnsupportedOperationException("liburing facade is only available on linux"))


### PR DESCRIPTION
Consolidate duplicate private `unsupported()` functions in js, macos, and wasmJs Liburing actuals into a single shared helper in commonMain.

---
*PR created automatically by Jules for task [16333286002831026552](https://jules.google.com/task/16333286002831026552) started by @jnorthrup*