### PR TITLE
🎨 Palette: Add accessible names to block editor controls

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -257,6 +257,7 @@
     addBtn.className = 'gutter-btn';
     addBtn.textContent = '+';
     addBtn.title = 'Add block below';
+    addBtn.setAttribute('aria-label', 'Add block below');
     addBtn.addEventListener('click', () => {
       insertBlock(idx + 1, { id: uid(), type: 'p', text: '' });
       focusBlock(activePage().blocks[idx + 1].id, true);
@@ -265,6 +266,7 @@
     dragBtn.className = 'gutter-btn gutter-drag';
     dragBtn.textContent = '⋮⋮';
     dragBtn.title = 'Drag to reorder';
+    dragBtn.setAttribute('aria-label', 'Drag to reorder');
     gutter.append(addBtn, dragBtn);
     el.appendChild(gutter);
 
@@ -278,6 +280,7 @@
       cb.type = 'checkbox';
       cb.className = 'todo-checkbox';
       cb.checked = !!block.checked;
+      cb.setAttribute('aria-label', 'Toggle todo status');
       cb.addEventListener('change', () => {
         mutate(() => { block.checked = cb.checked; });
         el.classList.toggle('done', cb.checked);


### PR DESCRIPTION
💡 What: Added aria-label attributes to the "Add block below" button, "Drag to reorder" button, and inline todo checkbox inputs in the block editor.
🎯 Why: These elements relied purely on visual context (icons) or layout, rendering them confusing or inaccessible to screen reader users. Adding semantic labels ensures assistive technologies can announce their purpose clearly.
📸 Before/After: Visuals remain unchanged; DOM elements now include 'aria-label' attributes.
♿ Accessibility: Improved screen reader navigation and semantic clarity for interactive editor controls.

---
*PR created automatically by Jules for task [5753355952184411365](https://jules.google.com/task/5753355952184411365) started by @jnorthrup*