### PR TITLE
Add LineCas types and forge blackboard adapter

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
@@ -1,0 +1,25 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+
+enum class LineCasNeighbor {
+    NEIGHBOR_PREV,
+    NEIGHBOR_NEXT,
+    NEIGHBOR_SIBLING,
+    NEIGHBOR_PARENT,
+    NEIGHBOR_CHILD,
+    NEIGHBOR_UNKNOWN
+}
+
+data class LineCasEdge(
+    val sourceCid: ContentId,
+    val targetCid: ContentId,
+    val relationship: LineCasNeighbor,
+    val confidence: Double = 1.0
+)
+
+data class LineCasSpine(
+    val contentCid: ContentId,
+    val ordinal: Int,
+    val linkedKey: String? = null
+)

--- a/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/LineCasGraph.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/LineCasGraph.kt
@@ -1,0 +1,44 @@
+package borg.trikeshed.forge.blackboard
+
+import borg.trikeshed.cas.LineCasEdge
+import borg.trikeshed.cas.LineCasNeighbor
+import borg.trikeshed.cas.LineCasSpine
+import borg.trikeshed.cursor.BlackboardContext
+import borg.trikeshed.graph.CausalGraphNodeIndex
+import borg.trikeshed.graph.causalGraphNode
+
+fun lineSpineToCausalIndex(
+    spine: List<LineCasSpine>,
+    edges: List<LineCasEdge>
+): CausalGraphNodeIndex {
+    val index = CausalGraphNodeIndex()
+    val blackboard = BlackboardContext("line_cas_graph")
+
+    for (node in spine) {
+        val nodeId = node.linkedKey ?: "${node.contentCid.value}_${node.ordinal}"
+
+        val parentNodeIds = edges
+            .filter { it.targetCid == node.contentCid && (it.relationship == LineCasNeighbor.NEIGHBOR_PREV || it.confidence >= 0.9) }
+            .map { edge ->
+                val parentSpine = spine.find { it.contentCid == edge.sourceCid }
+                parentSpine?.linkedKey ?: "${edge.sourceCid.value}_${parentSpine?.ordinal ?: 0}"
+            }
+            .distinct()
+
+        val causalNode = causalGraphNode(
+            nodeId = nodeId,
+            opId = "line_cas",
+            opVersion = "1.0",
+            parentNodeIds = parentNodeIds,
+            inputFingerprint = node.contentCid.value,
+            blackboard = blackboard,
+            causalClock = 0L,
+            topoOrdinal = node.ordinal,
+            outputHash = null
+        )
+
+        index.addOrGet(causalNode)
+    }
+
+    return index
+}

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Plan for LineCasGraph"


### PR DESCRIPTION
💡 What: Added `LineCasSpine`, `LineCasEdge`, and `LineCasNeighbor` domain types to `cas`, and an adapter `lineSpineToCausalIndex` to map these lines and edges into a `CausalGraphNodeIndex` for `forge.blackboard`.

🎯 Why: Fulfills the task requirement to create a LineCas graph adapter for the forge blackboard ("Moneymaker"). Uses the requested logic for `nodeId` generation and parent/neighbor resolution based on `NEIGHBOR_PREV` and edge confidence. Stubs missing `LineCas` types in `cas` rather than duplicating stamp algebra into `forge`.

✅ Verification: Compiled successfully using `./gradlew jvmMainClasses --console=plain`. Code reviewed with #Correct# rating.

---
*PR created automatically by Jules for task [159776576896093967](https://jules.google.com/task/159776576896093967) started by @jnorthrup*