### PR TITLE
Implement weighted force layout edges based on link confidence

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/MatchGrade.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/MatchGrade.kt
@@ -1,0 +1,13 @@
+package borg.trikeshed.cas
+
+enum class MatchGrade(val rampScore: Double) {
+    CONFIRMED(1.0),
+    PROVISIONAL(0.45),
+    CANDIDATE(0.12)
+}
+
+enum class LinkConfidence(val rampScore: Double) {
+    CONFIRMED(1.0),
+    PROVISIONAL(0.45),
+    CANDIDATE(0.12)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ForceLayout.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ForceLayout.kt
@@ -19,6 +19,15 @@ fun forceLayout(
     camera: ForgeBlackboardCamera,
     iterations: Int = 100
 ): Pair<ForgeBlackboardCamera, Map<String, ProjectedPoint>> {
+    return forceLayoutWeighted(graph, camera, iterations) { _, _ -> 1.0 }
+}
+
+fun forceLayoutWeighted(
+    graph: CausalGraphNodeIndex,
+    camera: ForgeBlackboardCamera,
+    iterations: Int = 100,
+    edgeWeight: (parentId: String, childId: String) -> Double = { _, _ -> 1.0 }
+): Pair<ForgeBlackboardCamera, Map<String, ProjectedPoint>> {
     val size = graph.size
     if (size == 0) return Pair(camera, emptyMap())
 
@@ -81,7 +90,8 @@ fun forceLayout(
                 val dy = posY[parentIndex] - posY[i]
                 val dist = sqrt(dx * dx + dy * dy)
                 if (dist > 0.0) {
-                    val force = kSpring * (dist - restingLength)
+                    val weight = edgeWeight(parentId, node.nodeId)
+                    val force = kSpring * weight * (dist - restingLength)
                     val fx = (dx / dist) * force
                     val fy = (dy / dist) * force
                     forceX[i] += fx


### PR DESCRIPTION
Implement weighted node relationships in the layout engine using link confidences.

- Added `MatchGrade` and `LinkConfidence` enums with `rampScore` values.
- Migrated `forceLayout` to delegate to `forceLayoutWeighted`.
- Plumbed edge weight lambda through the spring force math.

---
*PR created automatically by Jules for task [12960657647362713482](https://jules.google.com/task/12960657647362713482) started by @jnorthrup*