### PR TITLE
Add LineCas confidence scoring and ramp score mapping

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
@@ -1,0 +1,30 @@
+package borg.trikeshed.cas
+
+enum class MatchGrade {
+    CONTENT_ONLY,
+    PARTIAL_LEFT,
+    PARTIAL_RIGHT,
+    LINKED
+}
+
+enum class LinkConfidence {
+    CANDIDATE,
+    PROVISIONAL,
+    CONFIRMED
+}
+
+fun confidenceOf(grade: MatchGrade): LinkConfidence = when (grade) {
+    MatchGrade.CONTENT_ONLY -> LinkConfidence.CANDIDATE
+    MatchGrade.PARTIAL_LEFT, MatchGrade.PARTIAL_RIGHT -> LinkConfidence.PROVISIONAL
+    MatchGrade.LINKED -> LinkConfidence.CONFIRMED
+}
+
+/**
+ * Returns a log-ish spaced confidence score based on match grade.
+ * Note: This score is a prior confidence, not a probability proof.
+ */
+fun rampScore(grade: MatchGrade): Double = when (grade) {
+    MatchGrade.CONTENT_ONLY -> 0.12
+    MatchGrade.PARTIAL_LEFT, MatchGrade.PARTIAL_RIGHT -> 0.45
+    MatchGrade.LINKED -> 1.0
+}


### PR DESCRIPTION
Adds `LinkConfidence`, `confidenceOf` and `rampScore` mapping for LineCas. This exposes ConfidenceRamp needed for forge edge paint.

1.  Created `LinkConfidence` (CANDIDATE, PROVISIONAL, CONFIRMED).
2.  Added `MatchGrade` enum containing `CONTENT_ONLY`, `PARTIAL_LEFT`, `PARTIAL_RIGHT`, and `LINKED`.
3.  Implemented `confidenceOf(MatchGrade)` to map to `LinkConfidence`.
4.  Implemented `rampScore(MatchGrade)` to provide log-ish spacing scores (0.12, 0.45, 1.0) and documented it as a prior confidence, not a probability proof.
5.  No forge imports were added.

---
*PR created automatically by Jules for task [2416106438265065004](https://jules.google.com/task/2416106438265065004) started by @jnorthrup*