### PR TITLE
Add LineCas for LineNode CAS spine extraction

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt
@@ -1,0 +1,26 @@
+package borg.trikeshed.cas
+
+import borg.trikeshed.job.ContentId
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.get
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.size
+
+data class LineNode(
+    val contentCid: ContentId,
+    val ordinal: Int
+)
+
+fun contentOf(line: String): ContentId =
+    ContentId.of(line.trim().encodeToByteArray())
+
+fun spine(text: String): Series<LineNode> {
+    val validLines = text.lines()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toList()
+
+    return validLines.size j { i ->
+        LineNode(contentOf(validLines[i]), i)
+    }
+}


### PR DESCRIPTION
Creates `src/commonMain/kotlin/borg/trikeshed/cas/LineCas.kt` to parse strings into a Series of LineNodes containing CAS and ordinal index, satisfying task requirements without relying on forge.

---
*PR created automatically by Jules for task [5264137680086730403](https://jules.google.com/task/5264137680086730403) started by @jnorthrup*