### PR TITLE
Refactor Litebike fanout to apply backpressure on slow subscribers

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. Modify `FlywheelHistoryReaper.kt`: Remove all current code (as it's related to the manual JSONL CAS ingestion CLI which is never used) and rewrite it to have a simple `reapOldTags` function. This function will run `git tag -l "flywheel/jules-*"` and delete tags, keeping a reasonable number like 50.
-2. Update `FlywheelDriver.kt` in the `settlementBarrier` function. Wire in a call to `FlywheelHistoryReaper.reapOldTags(...)` so tags are automatically reaped in the SETTLE phase.
-3. Validate compilation with `./gradlew jvmMainClasses --no-daemon`.
-4. Run pre commit instructions.
-5. Submit changes.

--- a/src/commonMain/kotlin/borg/trikeshed/litebike/LitebikeListenerElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/litebike/LitebikeListenerElement.kt
@@ -8,6 +8,7 @@ import borg.trikeshed.context.ElementState
 import borg.trikeshed.litebike.taxonomy.Protocol
 import borg.trikeshed.litebike.taxonomy.ProtocolMark
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -99,6 +100,7 @@ class LitebikeListenerElement(
     /** Map: protocol id (UByte) → slot. One slot per protocol; deterministic IDs. */
     private val registry: MutableMap<UByte, ChannelWorkgroupSlot> = mutableMapOf()
     private val mutableSubscribers: MutableList<AsyncContextElement> = mutableListOf()
+    private val fanoutChannel = Channel<LitebikeFanoutEvent>(capacity = maxBatch)
 
     override val fanoutSubscribers: List<AsyncContextElement>
         get() = mutableSubscribers.toList()
@@ -132,7 +134,18 @@ class LitebikeListenerElement(
     // ── lifecycle overrides ───────────────────────────────────────
 
     override suspend fun open() {
-        if (state == ElementState.CREATED) state = ElementState.OPEN
+        if (state == ElementState.CREATED) {
+            state = ElementState.OPEN
+            CoroutineScope(supervisor).launch {
+                for (event in fanoutChannel) {
+                    for (subscriber in fanoutSubscribers.toList()) {
+                        if (subscriber is LitebikeFanoutEventSink) {
+                            runCatching { subscriber.onLitebikeFanoutEvent(event) }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /** Promote OPEN → ACTIVE. */
@@ -144,6 +157,7 @@ class LitebikeListenerElement(
         if (state.isAtLeast(ElementState.OPEN) && state.isLessThan(ElementState.CLOSED)) {
             if (state < ElementState.DRAINING) state = ElementState.DRAINING
             supervisor.cancel()
+            fanoutChannel.close()
             registryMutex.withLock {
                 registry.values.forEach { it.close() }
                 registry.clear()
@@ -257,11 +271,11 @@ class LitebikeListenerElement(
      * someone bridges the two. Keeping this KMP-safe keeps the listener
      * compilable on JS and wasm, not just JVM.
      */
-    fun fireFanoutEvent(event: LitebikeFanoutEvent) {
-        for (subscriber in fanoutSubscribers.toList()) {
-            if (subscriber is LitebikeFanoutEventSink) {
-                runCatching { subscriber.onLitebikeFanoutEvent(event) }
-            }
+    suspend fun fireFanoutEvent(event: LitebikeFanoutEvent) {
+        val result = fanoutChannel.trySend(event)
+        if (result.isFailure) {
+            println("WARNING: LitebikeFanoutEvent subscriber is slow, applying backpressure")
+            fanoutChannel.send(event)
         }
     }
 


### PR DESCRIPTION
Addresses the issue described in section 8.1b:
Audited the fanout dispatch in `LitebikeListenerElement`, which previously used a synchronous `runCatching` fire-and-forget loop for all CCEK subscribers, dropping context on slow events.
Added a bounded `Channel` (capacity = `maxBatch`, overflowing by `SUSPEND` as default) and moved the fanout subscriber execution into a background coroutine launched in `open()`.
In `fireFanoutEvent`, checking `trySend` failure correctly logs the warning, before executing a suspending `send()` to actively apply backpressure back to the socket accept sequence. Verified compilation via `./gradlew jvmMainClasses`.

---
*PR created automatically by Jules for task [3980531447835716839](https://jules.google.com/task/3980531447835716839) started by @jnorthrup*