### PR TITLE
Implement InvalidPathException properties in commonMain

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/InvalidPathException.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/InvalidPathException.kt
@@ -5,9 +5,23 @@ package borg.trikeshed.userspace.nio.file
 // Generated from Amazon Corretto JDK 25 java.base NIO public/protected API via javap.
 // Declarations intentionally mirror JDK taxonomy and contain no implementations.
 public open class InvalidPathException : IllegalArgumentException {
-    constructor(p0: String, p1: String, p2: Int) : super("$p1 at index $p2 in $p0")
-    constructor(p0: String, p1: String) : super("$p1 in $p0")
-    fun getInput(): String = TODO("NIO common stub")
-    fun getReason(): String = TODO("NIO common stub")
-    fun getIndex(): Int = TODO("NIO common stub")
+    private val input: String
+    private val reason: String
+    private val index: Int
+
+    constructor(p0: String, p1: String, p2: Int) : super("$p1 at index $p2 in $p0") {
+        this.input = p0
+        this.reason = p1
+        this.index = p2
+    }
+
+    constructor(p0: String, p1: String) : super("$p1 in $p0") {
+        this.input = p0
+        this.reason = p1
+        this.index = -1
+    }
+
+    fun getInput(): String = input
+    fun getReason(): String = reason
+    fun getIndex(): Int = index
 }


### PR DESCRIPTION
Replaces the `TODO("NIO common stub")` default implementations in `InvalidPathException` with functional implementations that mimic the standard Java NIO behavior.

Changes made:
- Added `private val input: String`, `private val reason: String`, and `private val index: Int` to `InvalidPathException`.
- Updated constructors to correctly assign these properties, setting `index` to `-1` when the two-argument constructor is invoked.
- Implemented `getInput()`, `getReason()`, and `getIndex()` to return these backing properties.

Tested via targeted `jvmTest` and `compileTestKotlinJvm` runs.

---
*PR created automatically by Jules for task [4769302570343150873](https://jules.google.com/task/4769302570343150873) started by @jnorthrup*