### PR TITLE
Make UserPrincipal.getName() abstract instead of a TODO stub

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/attribute/UserPrincipal.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/attribute/UserPrincipal.kt
@@ -5,5 +5,5 @@ package borg.trikeshed.userspace.nio.file.attribute
 // Generated from Amazon Corretto JDK 25 java.base NIO public/protected API via javap.
 // Declarations intentionally mirror JDK taxonomy and contain no implementations.
 public interface UserPrincipal {
-    fun getName(): String = TODO("NIO common stub")
+    fun getName(): String
 }


### PR DESCRIPTION
The `UserPrincipal` interface in the `borg.trikeshed.userspace.nio.file.attribute` package incorrectly defined `getName()` with a default implementation that threw a `TODO("NIO common stub")` exception. Since this interface is intended to mirror the Java NIO `UserPrincipal` interface which only has an abstract `getName()` method, I removed the default implementation. This makes `getName()` an abstract method in the Kotlin interface, which correctly represents the original API contract and allows implementing classes to fulfill the interface requirement.

---
*PR created automatically by Jules for task [5446214650212810094](https://jules.google.com/task/5446214650212810094) started by @jnorthrup*