### PR TITLE
🧹 [code health] Remove unused import in ForgeTaxonomy.kt

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/isam/ForgeTaxonomy.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/isam/ForgeTaxonomy.kt
@@ -1,7 +1,6 @@
 package borg.trikeshed.lcnc.isam
 
 import borg.trikeshed.lib.Series
-import borg.trikeshed.lib.j
 
 /**
  * Represents random access gems (ID-based, hierarchical structures) for the Forge taxonomy.


### PR DESCRIPTION
🎯 **What:** Removed unused `import borg.trikeshed.lib.j` from `src/commonMain/kotlin/borg/trikeshed/lcnc/isam/ForgeTaxonomy.kt`.
💡 **Why:** To improve maintainability and readability by removing dead code.
✅ **Verification:** Verified by running `./gradlew :jvmMainClasses --no-daemon` and confirming successful compilation.
✨ **Result:** The code is cleaner without modifying the existing functionality.

---
*PR created automatically by Jules for task [10304829346246483770](https://jules.google.com/task/10304829346246483770) started by @jnorthrup*