### PR TITLE
🧪 [testing improvement] Add error path test for LinuxFileOperations.deleteRecursively

### DIFF
--- a/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
+++ b/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
@@ -1,0 +1,31 @@
+package borg.trikeshed.userspace.nio.file.spi
+
+import borg.trikeshed.common.createTempDirectory
+import kotlinx.cinterop.convert
+import platform.posix.chmod
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class LinuxFileOperationsTest {
+
+    @Test
+    fun deleteRecursivelyHandlesUnreadableDirectories() {
+        val files = LinuxFileOperations()
+        val baseDir = createTempDirectory("trikeshed-native")
+        val path = "$baseDir/unreadable_dir"
+        files.mkdirs(path)
+        assertTrue(files.isDir(path))
+
+        // Make the directory unreadable so opendir fails
+        chmod(path, 0u.convert())
+
+        try {
+            // This should not throw an exception (such as NullPointerException) if opendir returns null
+            files.deleteRecursively(path)
+        } finally {
+            // Restore permissions so we can clean up
+            chmod(path, 0x1FFu.convert())
+            files.deleteRecursively(baseDir)
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing error path test for `deleteRecursively` when `opendir` fails in `LinuxFileOperations.kt`.
📊 **Coverage:** The scenario where a directory cannot be read (e.g. no read permissions) during a recursive delete is now tested.
✨ **Result:** Improved test coverage and reliability for native file operations error handling.

---
*PR created automatically by Jules for task [7943428793048960233](https://jules.google.com/task/7943428793048960233) started by @jnorthrup*