### PR TITLE
🧪 [testing improvement] Add error path test for LinuxFileOperations

### DIFF
--- a/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
+++ b/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.userspace.nio.file.spi
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class LinuxFileOperationsTest {
+    @Test
+    fun testReadAllBytesFileNotFound() {
+        val ops = LinuxFileOperations()
+        assertFailsWith<IllegalArgumentException> {
+            ops.readAllBytes("/does/not/exist/very/unlikely/to/exist.txt")
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `LinuxFileOperations.readAllBytes` in `LinuxFileOperations.kt`.
📊 **Coverage:** The scenario where the file being read does not exist is now covered.
✨ **Result:** Improved test coverage and reliability for Linux file operations by ensuring `IllegalArgumentException` is thrown as expected.

---
*PR created automatically by Jules for task [13259731249323610336](https://jules.google.com/task/13259731249323610336) started by @jnorthrup*