### PR TITLE
🧹 Suppress LongMethod for cards

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/blackboard/BlackboardSurface.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/blackboard/BlackboardSurface.kt
@@ -70,6 +70,7 @@ class BlackboardSurface private constructor(
     /** Cursor over the projected rows so UI code can read it via the canonical algebra. */
     fun asCursor(): Cursor = rows.size j { i -> rowToRowVec(rows[i]) }
 
+    @Suppress("LongMethod")
     fun cards(): List<KanbanCard> = board.cards
 
     fun columns(): List<KanbanColumn> = board.columns


### PR DESCRIPTION
🎯 **What:** Suppress false positive `LongMethod` warning for `cards()`
💡 **Why:** A static analysis tool incorrectly flagged a one-liner expression body as a long function.
✅ **Verification:** Compiled the project successfully.
✨ **Result:** Silenced false positive.

---
*PR created automatically by Jules for task [12843218809532661627](https://jules.google.com/task/12843218809532661627) started by @jnorthrup*