### PR TITLE
🧹 [code health improvement] Improve Usable.use() with inline and contracts

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/common/Usable.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/common/Usable.kt
@@ -1,7 +1,11 @@
 package borg.trikeshed.common
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 /**
- * a horrible hack to enable use() macro in kotlin mpp for our file messes
+ * Interface for resources that can be opened and closed.
  */
 interface Usable {
     /**
@@ -14,12 +18,32 @@ interface Usable {
     fun close()
 }
 
-/** this is not present in stdlib for kotlin mpp, we extend the functionality to return a value as needed.*/
-fun <T : Usable, R> T.use(block: (T) -> R): R {
+/**
+ * Executes the given [block] function on this resource and then closes it down correctly whether an exception
+ * is thrown or not.
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T : Usable, R> T.use(block: (T) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     open()
+    var exception: Throwable? = null
     try {
         return block(this)
+    } catch (e: Throwable) {
+        exception = e
+        throw e
     } finally {
-        close()
+        when (exception) {
+            null -> close()
+            else -> {
+                try {
+                    close()
+                } catch (closeException: Throwable) {
+                    exception.addSuppressed(closeException)
+                }
+            }
+        }
     }
 }

--- a/src/commonMain/kotlin/borg/trikeshed/lib/Usable.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/Usable.kt
@@ -1,7 +1,11 @@
 package borg.trikeshed.lib
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 /**
- * a horrible hack to enable use() macro in kotlin mpp for our file messes
+ * Interface for resources that can be opened and closed.
  */
 interface Usable : Closeable {
     /**
@@ -14,12 +18,32 @@ interface Usable : Closeable {
     override fun close()
 }
 
-/** this is not present in stdlib for kotlin mpp, we extend the functionality to return a value as needed.*/
-fun <T : Usable, R> T.use(block: (T) -> R): R {
+/**
+ * Executes the given [block] function on this resource and then closes it down correctly whether an exception
+ * is thrown or not.
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T : Usable, R> T.use(block: (T) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     open()
+    var exception: Throwable? = null
     try {
         return block(this)
+    } catch (e: Throwable) {
+        exception = e
+        throw e
     } finally {
-        close()
+        when (exception) {
+            null -> close()
+            else -> {
+                try {
+                    close()
+                } catch (closeException: Throwable) {
+                    exception.addSuppressed(closeException)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** The `Usable.use` function has been refactored to be an inline function using Kotlin contracts and properly handles suppressed exceptions during `close()`. The "horrible hack" comment has been removed and replaced with standard documentation.
💡 **Why:** This makes `use()` behave exactly like the standard library `AutoCloseable.use()`, enabling the compiler to know that variables assigned inside the block are definitely initialized, avoiding the 'horrible hack' limitations.
✅ **Verification:** Verified by compiling the codebase.
✨ **Result:** A safer, stdlib-compliant implementation of the `use` macro.

---
*PR created automatically by Jules for task [2521132160298689179](https://jules.google.com/task/2521132160298689179) started by @jnorthrup*