### PR TITLE
🔒 Fix arbitrary code execution vulnerability via eval()

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/lib/JsNode.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/lib/JsNode.kt
@@ -4,20 +4,20 @@ import kotlin.js.Date
 import kotlin.random.Random
 
 // Node.js module access that is invisible to webpack's static analysis.
-// eval("require(...)") prevents webpack from generating a static require stub,
+// module.require(...) prevents webpack from generating a static require stub,
 // which would crash the browser bundle with "Cannot find module 'fs'".
 // Browser code paths never call these — only Node paths do.
 
 private fun nodeRequire(name: String): dynamic {
     require(name == "fs" || name == "os" || name == "path") { "Unauthorized Node.js module: $name" }
-    return js("eval(\"require\")(name)")
+    return js("typeof module !== 'undefined' ? module.require(name) : null")
 }
 
 val fs: dynamic get() = nodeRequire("fs")
 val os: dynamic get() = nodeRequire("os")
 val path: dynamic get() = nodeRequire("path")
-val processObj: dynamic get() = js("eval(\"process\")")
-val Buffer: dynamic get() = js("eval(\"globalThis.Buffer\")")
+val processObj: dynamic get() = js("typeof process !== 'undefined' ? process : null")
+val Buffer: dynamic get() = js("typeof globalThis !== 'undefined' ? globalThis.Buffer : null")
 
 internal fun jsCwd(): String = processObj.cwd() as String
 


### PR DESCRIPTION
🎯 **What:** Replaced the `eval("require\")(name)")` calls with direct `module.require(name)` access shielded by `typeof module !== 'undefined'` checks. Replaced other `eval` usages similarly.
⚠️ **Risk:** The code uses `eval("require(...)")` and `eval("process")` for dynamic module loading. Even though module names are restricted, using `eval()` exposes the application to arbitrary code execution if user input ever makes its way to the parameter or if an attacker bypasses the constraints. It is generally a security antipattern.
🛡️ **Solution:** Replaced `eval()` with `typeof module !== 'undefined' ? module.require(name) : null` to load modules securely without triggering Webpack's static analysis.

---
*PR created automatically by Jules for task [8416375234139268150](https://jules.google.com/task/8416375234139268150) started by @jnorthrup*