### PR TITLE
🧹 [code health improvement] Refactor long decode method in ActionDecoder

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/wireproto/ActionDecoder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/wireproto/ActionDecoder.kt
@@ -4,6 +4,7 @@ import borg.trikeshed.context.nuid.Capability
 import borg.trikeshed.context.nuid.Nonce
 import borg.trikeshed.context.nuid.Subnet
 import borg.trikeshed.context.nuid.nuid
+import borg.trikeshed.context.nuid.Nuid
 
 class ActionDecoder {
     fun decode(bytes: ByteArray): ReactorActionEnvelope {
@@ -13,65 +14,41 @@ class ActionDecoder {
 
         var offset = 0
 
-        // Magic
-        val m1 = bytes[offset++].toInt() and 0xFF
-        val m2 = bytes[offset++].toInt() and 0xFF
-        val m3 = bytes[offset++].toInt() and 0xFF
-        val m4 = bytes[offset++].toInt() and 0xFF
-        val magic = (m1 shl 24) or (m2 shl 16) or (m3 shl 8) or m4
+        val magic = readInt(bytes, offset).also { offset += 4 }
         if (magic != WireprotoFrame.MAGIC) {
             throw WireprotoFormatException(WireprotoFormatException.BAD_MAGIC + magic.toUInt().toString(16).uppercase())
         }
 
-        // Version
-        val v1 = bytes[offset++].toInt() and 0xFF
-        val v2 = bytes[offset++].toInt() and 0xFF
-        val version = ((v1 shl 8) or v2).toShort()
+        val version = readShort(bytes, offset).also { offset += 2 }
         if (version != WireprotoFrame.VERSION) {
             throw WireprotoFormatException(WireprotoFormatException.BAD_VERSION + version)
         }
 
-        // NUID length
-        val nl1 = bytes[offset++].toInt() and 0xFF
-        val nl2 = bytes[offset++].toInt() and 0xFF
-        val nuidLen = (nl1 shl 8) or nl2
-
+        val nuidLen = readUShort(bytes, offset).also { offset += 2 }
         if (bytes.size < offset + nuidLen) {
             throw WireprotoFormatException(WireprotoFormatException.BAD_NUID_LENGTH + nuidLen)
         }
 
-        val nuidBytes = bytes.copyOfRange(offset, offset + nuidLen)
+        val nuidStr = bytes.decodeToString(offset, offset + nuidLen)
         offset += nuidLen
-        val nuidStr = nuidBytes.decodeToString()
 
         if (bytes.size < offset + 2) {
             throw WireprotoFormatException(WireprotoFormatException.TRUNCATED + (offset + 2))
         }
 
-        // Verb length
-        val vl1 = bytes[offset++].toInt() and 0xFF
-        val vl2 = bytes[offset++].toInt() and 0xFF
-        val verbLen = (vl1 shl 8) or vl2
-
+        val verbLen = readUShort(bytes, offset).also { offset += 2 }
         if (bytes.size < offset + verbLen) {
             throw WireprotoFormatException(WireprotoFormatException.TRUNCATED + (offset + verbLen))
         }
 
-        val verbBytes = bytes.copyOfRange(offset, offset + verbLen)
+        val verb = bytes.decodeToString(offset, offset + verbLen)
         offset += verbLen
-        val verb = verbBytes.decodeToString()
 
         if (bytes.size < offset + 4) {
             throw WireprotoFormatException(WireprotoFormatException.TRUNCATED + (offset + 4))
         }
 
-        // Payload length
-        val pl1 = bytes[offset++].toInt() and 0xFF
-        val pl2 = bytes[offset++].toInt() and 0xFF
-        val pl3 = bytes[offset++].toInt() and 0xFF
-        val pl4 = bytes[offset++].toInt() and 0xFF
-        val payloadLen = (pl1 shl 24) or (pl2 shl 16) or (pl3 shl 8) or pl4
-
+        val payloadLen = readInt(bytes, offset).also { offset += 4 }
         if (payloadLen > WireprotoFrame.MAX_PAYLOAD) {
             throw WireprotoFormatException(WireprotoFormatException.OVERSIZE_PAYLOAD)
         }
@@ -81,12 +58,30 @@ class ActionDecoder {
         }
 
         val payload = bytes.copyOfRange(offset, offset + payloadLen)
-        offset += payloadLen
 
-        // Deserialize Nuid
-        // Note: as instructed, using custom format as fallback when Nuid toString is used.
-        // Wait, I am asked to use canonical Nuid.toString. But Nuid doesn't override toString.
-        // We will just decode what we serialized in ActionEncoder.
+        val nuid = parseNuid(nuidStr)
+
+        return ReactorActionEnvelope(nuid, verb, payload)
+    }
+
+    private fun readInt(bytes: ByteArray, offset: Int): Int {
+        return ((bytes[offset].toInt() and 0xFF) shl 24) or
+               ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+               ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+               (bytes[offset + 3].toInt() and 0xFF)
+    }
+
+    private fun readShort(bytes: ByteArray, offset: Int): Short {
+        return (((bytes[offset].toInt() and 0xFF) shl 8) or
+                (bytes[offset + 1].toInt() and 0xFF)).toShort()
+    }
+
+    private fun readUShort(bytes: ByteArray, offset: Int): Int {
+        return ((bytes[offset].toInt() and 0xFF) shl 8) or
+               (bytes[offset + 1].toInt() and 0xFF)
+    }
+
+    private fun parseNuid(nuidStr: String): Nuid {
         val parts = nuidStr.split("|", limit = 3)
         if (parts.size != 3) {
             throw WireprotoFormatException("bad nuid format")
@@ -114,8 +109,6 @@ class ActionDecoder {
         val nonce = if (nonceType == "derived") Nonce.Derived(nBytes.decodeToString()) else Nonce.Restored(nBytes)
 
         val subnet = Subnet.parse(parts[2])
-        val nuid = nuid(cap, nonce, subnet)
-
-        return ReactorActionEnvelope(nuid, verb, payload)
+        return nuid(cap, nonce, subnet)
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted byte parsing and NUID parsing logic into separate private helper methods (`readInt`, `readShort`, `readUShort`, and `parseNuid`) within `ActionDecoder`. \n💡 **Why:** To improve code maintainability and readability by breaking down a very long function into smaller, well-named, and focused units. \n✅ **Verification:** Ran `./gradlew :jvmMainClasses --no-daemon` to ensure compilation continues to succeed without regressions. \n✨ **Result:** The `decode` method is now much shorter and easier to understand.

---
*PR created automatically by Jules for task [13698382519284585001](https://jules.google.com/task/13698382519284585001) started by @jnorthrup*