### PR TITLE
🧪 [Testing] Add missing error path test in LinuxFileOperations.kt

### DIFF
--- a/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
+++ b/src/linuxTest/kotlin/borg/trikeshed/userspace/nio/file/spi/LinuxFileOperationsTest.kt
@@ -1,0 +1,36 @@
+package borg.trikeshed.userspace.nio.file.spi
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LinuxFileOperationsTest {
+
+    @Test
+    fun `readAllBytes fails on non-existent file`() {
+        val ops = LinuxFileOperations()
+        val exception = assertFailsWith<IllegalArgumentException> {
+            ops.readAllBytes("/does/not/exist/foo.txt")
+        }
+        assertEquals("open(/does/not/exist/foo.txt) failed", exception.message)
+    }
+
+    @Test
+    fun `write fails on invalid path`() {
+        val ops = LinuxFileOperations()
+        val exception = assertFailsWith<IllegalArgumentException> {
+            ops.write("/does/not/exist/foo.txt", ByteArray(0))
+        }
+        assertEquals("open(/does/not/exist/foo.txt) failed", exception.message)
+    }
+
+    @Test
+    fun `write fails on full device`() {
+        val ops = LinuxFileOperations()
+        val exception = assertFailsWith<IllegalArgumentException> {
+            ops.write("/dev/full", ByteArray(10) { 1 })
+        }
+        assertTrue(exception.message!!.startsWith("short write on /dev/full:"))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of coverage for short writes in LinuxFileOperations.kt.
📊 **Coverage:** Scenarios covered are read failing on a non-existent file, write failing on an invalid path, and write failing on short write using /dev/full.
✨ **Result:** Test coverage improved, and short writes are confidently caught and tested.

---
*PR created automatically by Jules for task [10662175649431500856](https://jules.google.com/task/10662175649431500856) started by @jnorthrup*