### PR TITLE
🧪 [testing improvement] Add test for sqeSubmit in KioUring.kt

### DIFF
--- a/src/linuxTest/kotlin/linux_uring/placeholder/KioUringTest.kt
+++ b/src/linuxTest/kotlin/linux_uring/placeholder/KioUringTest.kt
@@ -1,0 +1,19 @@
+package linux_uring.placeholder
+
+import kotlinx.cinterop.*
+import linux_uring.include.*
+import platform.posix.*
+import kotlin.test.*
+
+class KioUringTest {
+    @Test
+    fun testSqeSubmit() {
+        memScoped {
+            val s = KioUring()
+            val triple = with(s) { sqePreamble() }
+            s.sqeSubmit(triple)
+            assertEquals(triple.third, s.sqRing.array[triple.third.toInt()])
+            assertEquals(triple.second, s.sqRing.tail.pointed.value)
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The untested public function `sqeSubmit` in `KioUring.kt` now has unit tests.
📊 **Coverage:** The happy path of `sqeSubmit` functionality updating the `sqRing.array` at `index` and the updated `tail` pointer is now covered.
✨ **Result:** Test coverage and confidence in `KioUring` submissions are increased.

---
*PR created automatically by Jules for task [12267161360836928690](https://jules.google.com/task/12267161360836928690) started by @jnorthrup*