### PR TITLE
🧪 [testing improvement] Add test for KioUring.opCloseFd

### DIFF
--- a/src/linuxTest/kotlin/linux_uring/placeholder/KioUringTest.kt
+++ b/src/linuxTest/kotlin/linux_uring/placeholder/KioUringTest.kt
@@ -1,0 +1,19 @@
+package linux_uring.placeholder
+
+import kotlinx.cinterop.*
+import linux_uring.include.*
+import zlinux_uring.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KioUringTest {
+    @Test
+    fun testOpCloseFd() = memScoped {
+        val kio = KioUring()
+        val sqe = alloc<io_uring_sqe>()
+        kio.opCloseFd(sqe.ptr, 42)
+        assertEquals(42, sqe.fd)
+        assertEquals(UringSqeFlags.sqeIo_link.ub, sqe.flags)
+        assertEquals(UringOpcode.Op_Close.opConstant.toUByte(), sqe.opcode)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Tested untestable public function KioUring.opCloseFd
📊 **Coverage:** Covered KioUring.opCloseFd with simple test case checking flags, fd and opcode
✨ **Result:** Improved test coverage for io_uring kotlin API

---
*PR created automatically by Jules for task [6990214843052430028](https://jules.google.com/task/6990214843052430028) started by @jnorthrup*