### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Adding ARIA attributes to generated HTML in Kotlin React-like DSLs
+**Learning:** When using Kotlin string-builder-based DSLs (like `text("<button...")`) to generate HTML elements, ARIA attributes and titles need to be explicitly added as escaped strings (e.g., `aria-label=\"My Label\"`). Icon-only buttons used in inline editors (like BlockEditor and DatabaseView) often lack these attributes by default because they are generated programmatically for brevity.
+**Action:** Always check programmatic HTML generation for missing accessibility attributes, especially for UI controls represented only by symbols (↑, ↓, +, x, ✎).

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
@@ -54,14 +54,14 @@ class BlockEditor(var block: LcncBlock, val ingestState: IngestStateElement) {
             
             // Block Controls (Move up, move down, insert, delete, indent, outdent)
             div(classes = "lcnc-block-controls") {
-                text("<button onclick=\"window.lcncMoveBlockUp('${block.id}')\">↑</button>")
-                text("<button onclick=\"window.lcncMoveBlockDown('${block.id}')\">↓</button>")
-                text("<button onclick=\"window.lcncIndentBlock('${block.id}')\">→</button>")
-                text("<button onclick=\"window.lcncOutdentBlock('${block.id}')\">←</button>")
+                text("<button onclick=\"window.lcncMoveBlockUp('${block.id}')\" aria-label=\"Move block up\" title=\"Move block up\">↑</button>")
+                text("<button onclick=\"window.lcncMoveBlockDown('${block.id}')\" aria-label=\"Move block down\" title=\"Move block down\">↓</button>")
+                text("<button onclick=\"window.lcncIndentBlock('${block.id}')\" aria-label=\"Indent block\" title=\"Indent block\">→</button>")
+                text("<button onclick=\"window.lcncOutdentBlock('${block.id}')\" aria-label=\"Outdent block\" title=\"Outdent block\">←</button>")
                 
                 // Block creation menu
                 text("<div class=\"lcnc-block-menu\">")
-                text("<button onclick=\"window.lcncInsertBlock('${block.id}')\">+</button>")
+                text("<button onclick=\"window.lcncInsertBlock('${block.id}')\" aria-label=\"Insert new block\" title=\"Insert new block\">+</button>")
                 text("<select onchange=\"window.lcncChangeBlockType('${block.id}', this.value)\">")
                 text("<option value=\"paragraph\"${if(block.type=="paragraph") " selected" else ""}>Text</option>")
                 text("<option value=\"heading_1\"${if(block.type=="heading_1") " selected" else ""}>Heading 1</option>")
@@ -72,7 +72,7 @@ class BlockEditor(var block: LcncBlock, val ingestState: IngestStateElement) {
                 text("</select>")
                 text("</div>")
 
-                text("<button onclick=\"window.lcncDeleteBlock('${block.id}')\">x</button>")
+                text("<button onclick=\"window.lcncDeleteBlock('${block.id}')\" aria-label=\"Delete block\" title=\"Delete block\">x</button>")
             }
 
             // Block Content editable area

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
@@ -74,8 +74,8 @@ class DatabaseView(var database: LcncDatabase, val ingestState: IngestStateEleme
             for (prop in schema.properties.values) {
                 text("<th>")
                 text("<button class=\"lcnc-database-sort\" data-column=\"${prop.id}\" onclick=\"window.lcncSortColumn('${database.id}', '${prop.id}')\">${prop.name}</button>")
-                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\">x</button>")
-                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\">✎</button>")
+                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\" aria-label=\"Delete column\" title=\"Delete column\">x</button>")
+                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\" aria-label=\"Rename column\" title=\"Rename column\">✎</button>")
                 text("</th>")
             }
             text("<th>Actions</th>")


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons in the LCNC editors.
🎯 Why: Buttons represented only by symbols (↑, ↓, +, x, ✎) are inaccessible to screen readers and lack context on hover for visual users.
📸 Before/After: Not a visual design change, but tooltips now appear on hover.
♿ Accessibility: Improved screen reader navigation and intent comprehension for core editor controls.

---
*PR created automatically by Jules for task [13066076043090619981](https://jules.google.com/task/13066076043090619981) started by @jnorthrup*