### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded private key password

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
@@ -304,8 +304,8 @@ class JvmTlsCodecBackend : TlsCodecBackend, KeyedService {
 
         val certs = loadCertificates(Path.of(config.certificateFile))
         val privateKey = loadPrivateKey(Path.of(config.privateKeyFile), certs.first().publicKey.algorithm)
-        // In-memory KeyStore; password never persisted or exposed — safe to hardcode
-        val password = (config.privateKeyPassword ?: "changeit").toCharArray()
+        // In-memory KeyStore; use a randomly generated password if none provided
+        val password = (config.privateKeyPassword ?: java.util.UUID.randomUUID().toString()).toCharArray()
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
         keyStore.load(null, null)
         keyStore.setKeyEntry("tls", privateKey, password, certs.toTypedArray())


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded private key password 'changeit'
🎯 Impact: Predictable credentials for in-memory KeyStore
🔧 Fix: Use UUID.randomUUID() as fallback
✅ Verification: Compile and tests pass

---
*PR created automatically by Jules for task [3654383590408717690](https://jules.google.com/task/3654383590408717690) started by @jnorthrup*