### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command spoofing vulnerability in process workers

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerJvm.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerJvm.kt
@@ -2,9 +2,8 @@ package borg.trikeshed.userspace.nio.process
 
 class ProcessWorkerJvm(private val capability: ProcessCapability) : ProcessWorker {
     override suspend fun spawn(spec: ProcessSpec): ProcessResult {
-        val baseName = spec.command.substringAfterLast('/')
-        if (baseName !in capability.allowedCommands) {
-            throw SecurityException("command '$baseName' not in allowedCommands")
+        if (spec.command !in capability.allowedCommands) {
+            throw SecurityException("command '${spec.command}' not in allowedCommands")
         }
         val pb = ProcessBuilder(spec.command, *spec.args.toTypedArray())
         if (spec.cwd != null) pb.directory(java.io.File(spec.cwd))

--- a/src/nativeMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerNative.kt
+++ b/src/nativeMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerNative.kt
@@ -4,9 +4,8 @@ import borg.trikeshed.userspace.nio.channels.spi.PosixProcessOperations
 
 class ProcessWorkerNative(private val capability: ProcessCapability) : ProcessWorker {
     override suspend fun spawn(spec: ProcessSpec): ProcessResult {
-        val baseName = spec.command.substringAfterLast('/')
-        if (baseName !in capability.allowedCommands) {
-            throw SecurityException("command '$baseName' not in allowedCommands")
+        if (spec.command !in capability.allowedCommands) {
+            throw SecurityException("command '${spec.command}' not in allowedCommands")
         }
         val posix = PosixProcessOperations()
         // Use posix.execve + posix.waitpid, capture stdout/stderr via pipes.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command spoofing/path traversal. `ProcessWorkerJvm` and `ProcessWorkerNative` validated commands by extracting the string after the last `/` (`substringAfterLast('/')`) and checking it against `allowedCommands`. This allowed attackers to execute arbitrary binaries from arbitrary paths as long as the binary's name matched an allowed command (e.g., `/tmp/malicious/echo` was allowed because `"echo"` is in the list).
🎯 Impact: Attackers could execute arbitrary local commands.
🔧 Fix: Replaced the `substringAfterLast` check with an exact match check (`spec.command !in capability.allowedCommands`) to strictly enforce the command allowlist.
✅ Verification: Ran unit tests which include negative test cases ensuring commands not in the allowlist are rejected (`ProcessWorkerContractTest.kt`).

---
*PR created automatically by Jules for task [11174346401771458835](https://jules.google.com/task/11174346401771458835) started by @jnorthrup*