### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix ProcessBuilder deadlock and reactor starvation

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
@@ -1,6 +1,7 @@
 package borg.trikeshed.userspace.nio.channels.spi
 
 import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.async
 
 class JvmProcessOperations : ProcessOperations {
 
@@ -21,27 +22,35 @@ class JvmProcessOperations : ProcessOperations {
         val pb = ProcessBuilder(command, *args.toTypedArray())
         env.forEach { (k, v) -> pb.environment()[k] = v }
 
-        val proc = pb.start()
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) { kotlinx.coroutines.coroutineScope {
+            val proc = pb.start()
 
-        // Feed stdin if provided
-        proc.outputStream.use {
-            if (stdin != null) {
-                it.write(stdin)
-                it.flush()
+            // Feed stdin if provided
+            proc.outputStream.use {
+                if (stdin != null) {
+                    it.write(stdin)
+                    it.flush()
+                }
             }
-        }
 
-        // Read stdout
-        val stdoutOut = ByteArrayOutputStream()
-        proc.inputStream.use { it.copyTo(stdoutOut) }
+            // Read stdout asynchronously to prevent deadlocks
+            val stdoutDeferred = this.async {
+                val stdoutOut = ByteArrayOutputStream()
+                proc.inputStream.use { it.copyTo(stdoutOut) }
+                stdoutOut.toByteArray()
+            }
 
-        // Read stderr
-        val stderrOut = ByteArrayOutputStream()
-        if (!pb.redirectErrorStream()) {
-            proc.errorStream.use { it.copyTo(stderrOut) }
-        }
+            // Read stderr asynchronously
+            val stderrDeferred = this.async {
+                val stderrOut = ByteArrayOutputStream()
+                if (!pb.redirectErrorStream()) {
+                    proc.errorStream.use { it.copyTo(stderrOut) }
+                }
+                stderrOut.toByteArray()
+            }
 
-        val exitCode = proc.waitFor()
-        return ProcessResult(exitCode, stdoutOut.toByteArray(), stderrOut.toByteArray())
+            val exitCode = proc.waitFor()
+            ProcessResult(exitCode, stdoutDeferred.await(), stderrDeferred.await())
+        } }
     }
 }

--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerJvm.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/process/ProcessWorkerJvm.kt
@@ -1,5 +1,7 @@
 package borg.trikeshed.userspace.nio.process
 
+import kotlinx.coroutines.async
+
 class ProcessWorkerJvm(private val capability: ProcessCapability) : ProcessWorker {
     override suspend fun spawn(spec: ProcessSpec): ProcessResult {
         val baseName = spec.command.substringAfterLast('/')
@@ -9,16 +11,24 @@ class ProcessWorkerJvm(private val capability: ProcessCapability) : ProcessWorke
         val pb = ProcessBuilder(spec.command, *spec.args.toTypedArray())
         if (spec.cwd != null) pb.directory(java.io.File(spec.cwd))
         pb.environment().putAll(spec.env)
-        val proc = pb.start()
-        val done = proc.waitFor(spec.timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
-        if (!done) {
-            proc.destroyForcibly()
-            throw RuntimeException("process timed out after ${spec.timeoutMs}ms")
-        }
-        return ProcessResult(
-            exitCode = proc.exitValue(),
-            stdout = proc.inputStream.readNBytes(capability.maxStdoutBytes),
-            stderr = proc.errorStream.readNBytes(capability.maxStderrBytes),
-        )
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) { kotlinx.coroutines.coroutineScope {
+            val proc = pb.start()
+            val stdoutDeferred = this.async {
+                proc.inputStream.readNBytes(capability.maxStdoutBytes)
+            }
+            val stderrDeferred = this.async {
+                proc.errorStream.readNBytes(capability.maxStderrBytes)
+            }
+            val done = proc.waitFor(spec.timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+            if (!done) {
+                proc.destroyForcibly()
+                throw RuntimeException("process timed out after ${spec.timeoutMs}ms")
+            }
+            ProcessResult(
+                exitCode = proc.exitValue(),
+                stdout = stdoutDeferred.await(),
+                stderr = stderrDeferred.await(),
+            )
+        } }
     }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `ProcessBuilder` execution blocked the reactor coroutine thread. Also, standard streams were read sequentially and synchronously, causing a deadlock if the child process filled the OS pipe buffer.
🎯 Impact: Could cause denial of service (thread starvation) and infinite deadlocks for subprocesses with large output.
🔧 Fix: Moved process execution to `Dispatchers.IO` and used `async` to read stdout and stderr concurrently, avoiding deadlocks.
✅ Verification: Code compiles successfully. Process calls are properly decoupled from the reactor pool.

---
*PR created automatically by Jules for task [8115995257719974432](https://jules.google.com/task/8115995257719974432) started by @jnorthrup*