### PR TITLE
Transport: Implement HtxMessage EOM block boundary logic

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxMessage.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxMessage.kt
@@ -1,0 +1,15 @@
+package borg.trikeshed.htx
+
+object HtxMessage {
+    private val EOM = byteArrayOf(0x00.toByte(), 0xFF.toByte(), 0x00.toByte())
+
+    fun findEomOffset(data: ByteArray): Int {
+        val window = 3
+        for (i in 0 until data.size - window + 1) {
+            if (data[i] == EOM[0] && data[i + 1] == EOM[1] && data[i + 2] == EOM[2]) {
+                return i
+            }
+        }
+        return -1
+    }
+}


### PR DESCRIPTION
Created `HtxMessage.kt` with sliding-window `findEomOffset` implementation to fulfill the necromanced EOM boundary audit task.

---
*PR created automatically by Jules for task [17686120748820725827](https://jules.google.com/task/17686120748820725827) started by @jnorthrup*