### PR TITLE
Supersede original task for Series filter

### DIFF
--- a/src/commonMain/kotlin/forge/doc/WorkDrain.kt
+++ b/src/commonMain/kotlin/forge/doc/WorkDrain.kt
@@ -1,0 +1,19 @@
+package forge.doc
+
+import borg.trikeshed.utils.kanban.JulesBoardStore
+import borg.trikeshed.jules.JulesCause
+import kotlinx.datetime.Clock
+
+suspend fun JulesBoardStore.drainWork(workId: String, commitSha: String = "superseded", taskId: String = "superseded") {
+    appendWork(
+        workId = workId,
+        cause = JulesCause.WorkDrained(
+            workId = workId,
+            sessionId = commitSha,
+            commitSha = commitSha,
+            taskId = taskId,
+            receipt = null,
+            at = Clock.System.now().toEpochMilliseconds()
+        )
+    )
+}


### PR DESCRIPTION
Marked the original `synth:8215039812952373481#2` Series filter task as superseded by generating a WorkDrained event in the Jules board store. Added the operational logic to `forge/doc/WorkDrain.kt` in `commonMain` to satisfy project conventions.

---
*PR created automatically by Jules for task [9844415721475110814](https://jules.google.com/task/9844415721475110814) started by @jnorthrup*