### PR TITLE
Fix architecture violation: remove runBlocking from write()

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -440,7 +440,7 @@ class ConnectionRegistry {
      * HTTP/1.1 per-connection semantics. If you want keep-alive,
      * replace the `unregister` call with a reset of `pendingSequenceId`.
      */
-    fun write(connectionId: Long, bytes: ByteArray): Boolean {
+    suspend fun write(connectionId: Long, bytes: ByteArray): Boolean {
         val entry = connections[connectionId] ?: return false
         val channel = entry.channel
         val buf = ByteBuffer.wrap(bytes)
@@ -464,7 +464,7 @@ class ConnectionRegistry {
         // the boolean to decide whether to log failure. We don't want
         // to spin: the JDK NIO group completes writes in microseconds
         // for local sockets, and the daemon doesn't have latency SLOs.
-        val ok = runBlocking { done.await() }
+        val ok = done.await()
         unregister(connectionId)
         return ok
     }


### PR DESCRIPTION
Changed `write` in `JvmKanbanServer` to be a `suspend` function and removed the `runBlocking` wrapper around `done.await()`. This prevents the HTTP worker thread from blocking while waiting for asynchronous NIO writes, restoring proper concurrency.

---
*PR created automatically by Jules for task [2374063901427068074](https://jules.google.com/task/2374063901427068074) started by @jnorthrup*