### PR TITLE
Implement NioSupervisor backpressure on IO saturation

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,5 +1,0 @@
-refactor(userspace): implement suspend batchEnqueue for UserspaceChannelBackend
-
-- Add suspend `batchEnqueue` method to `UserspaceChannelBackend` and `FunctionalUringFacade`.
-- `FunctionalUringFacade` implements cancellation-safe completion harvesting by using `withContext(NonCancellable)` and buffering in an ArrayDeque to ensure results are correctly managed.
-- `UserspaceIO.jvm.kt` implements the backend component leveraging the JVM's `submitBatch` synchronously bridged in `withContext(Dispatchers.IO)`.

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/spi/NioSupervisor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/spi/NioSupervisor.kt
@@ -11,7 +11,23 @@ import kotlin.coroutines.CoroutineContext
  * Owns the lifecycle FSM ([AsyncContextElement]) and a service registry.
  * Platform providers are registered at [open] time and resolved via [service].
  */
-open class NioSupervisor : AsyncContextElement() {
+open class NioSupervisor(
+    private val maxConcurrentIo: Int = 10000,
+) : AsyncContextElement() {
+    private val ioSemaphore = kotlinx.coroutines.sync.Semaphore(maxConcurrentIo)
+
+    suspend fun acquireIo() {
+        ioSemaphore.acquire()
+    }
+
+    fun tryAcquireIo(): Boolean {
+        return ioSemaphore.tryAcquire()
+    }
+
+    fun releaseIo() {
+        ioSemaphore.release()
+    }
+
     companion object Key : AsyncContextKey<NioSupervisor>()
     override val key: CoroutineContext.Key<*> get() = Key
 

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -482,6 +482,7 @@ class ConnectionRegistry {
     fun unregister(connectionId: Long) {
         val entry = connections.remove(connectionId) ?: return
         runCatching { entry.channel.close() }
+        // NioSupervisor permit is released gracefully during drain or explicitly by adapter.
     }
 
     /**

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmLitebikeBindAdapter.kt
@@ -101,21 +101,49 @@ object JvmLitebikeBindAdapter {
         element: LitebikeListenerElement,
         connections: ConnectionRegistry,
     ) {
+        val supervisor = kotlinx.coroutines.currentCoroutineContext()[borg.trikeshed.userspace.nio.spi.NioSupervisor.Key]
         while (kotlinx.coroutines.currentCoroutineContext().isActive) {
-            val ch = kotlinx.coroutines.suspendCancellableCoroutine<AsynchronousSocketChannel> { cont ->
-                val handler = object : CompletionHandler<AsynchronousSocketChannel, Any?> {
-                    override fun completed(result: AsynchronousSocketChannel, attached: Any?) {
-                        cont.resume(result)
+            // NioSupervisor backpressure: acquire permit before accepting
+            if (supervisor?.tryAcquireIo() == false) {
+                // back-pressure: close the socket immediately
+                // Since this is AsynchronousServerSocketChannel, we must accept and then close
+                val ch = kotlinx.coroutines.suspendCancellableCoroutine<AsynchronousSocketChannel> { cont ->
+                    val handler = object : CompletionHandler<AsynchronousSocketChannel, Any?> {
+                        override fun completed(result: AsynchronousSocketChannel, attached: Any?) {
+                            cont.resume(result)
+                        }
+                        override fun failed(t: Throwable, attached: Any?) {
+                            if (cont.isActive) cont.resumeWithException(t)
+                        }
                     }
+                    server.accept(null, handler)
+                    cont.invokeOnCancellation {
+                        runCatching { server.close() }
+                    }
+                }
+                runCatching { ch.close() }
+                continue
+            }
 
-                    override fun failed(t: Throwable, attached: Any?) {
-                        if (cont.isActive) cont.resumeWithException(t)
+            val ch = try {
+                kotlinx.coroutines.suspendCancellableCoroutine<AsynchronousSocketChannel> { cont ->
+                    val handler = object : CompletionHandler<AsynchronousSocketChannel, Any?> {
+                        override fun completed(result: AsynchronousSocketChannel, attached: Any?) {
+                            cont.resume(result)
+                        }
+
+                        override fun failed(t: Throwable, attached: Any?) {
+                            if (cont.isActive) cont.resumeWithException(t)
+                        }
+                    }
+                    server.accept(null, handler)
+                    cont.invokeOnCancellation {
+                        runCatching { server.close() }
                     }
                 }
-                server.accept(null, handler)
-                cont.invokeOnCancellation {
-                    runCatching { server.close() }
-                }
+            } catch (e: Throwable) {
+                supervisor?.releaseIo()
+                throw e
             }
 
             // R05 — register the channel up front. The drain loop
@@ -125,7 +153,7 @@ object JvmLitebikeBindAdapter {
             val connId = connections.register(ch)
             // Read all bytes from the channel asynchronously, then
             // forward to the listener with the detected protocol.
-            drainOne(ch, element, connections, connId)
+            drainOne(ch, element, connections, connId, supervisor)
         }
     }
 
@@ -134,6 +162,7 @@ object JvmLitebikeBindAdapter {
         element: LitebikeListenerElement,
         connections: ConnectionRegistry,
         connId: Long,
+        supervisor: borg.trikeshed.userspace.nio.spi.NioSupervisor? = null,
     ) {
         val buf = ByteBuffer.allocate(8 * 1024)
         ch.read(
@@ -144,6 +173,7 @@ object JvmLitebikeBindAdapter {
                         // Peer closed — drop the registry entry.
                         connections.unregister(connId)
                         runCatching { ch.close() }
+                        supervisor?.releaseIo()
                         return
                     }
                     val bytes = ByteArray(read).also { buf.flip(); buf.get(it) }
@@ -156,11 +186,13 @@ object JvmLitebikeBindAdapter {
                         connections.unregister(connId)
                         runCatching { ch.close() }
                     }
+                    supervisor?.releaseIo()
                 }
 
                 override fun failed(t: Throwable, attached: Any?) {
                     connections.unregister(connId)
                     runCatching { ch.close() }
+                    supervisor?.releaseIo()
                 }
             }
         )


### PR DESCRIPTION
Implement NioSupervisor backpressure on IO saturation

This change implements a bounded backpressure mechanism in `NioSupervisor`
by guarding the point where I/O operations are handed off for processing.
A bounded Semaphore acts as the permit system to limit concurrent raw 
socket connections at the NIO accept boundary.

The backpressure policy is located in pure-Kotlin `commonMain`, while the 
NIO socket handling that enforces it is positioned in `jvmMain` within 
`JvmLitebikeBindAdapter`. When a permit cannot be acquired under saturation, 
the connection is immediately closed, shedding load. Permits are correctly 
released upon EOF, failure, or successful pipeline dispatch.

---
*PR created automatically by Jules for task [6276845508518918408](https://jules.google.com/task/6276845508518918408) started by @jnorthrup*