### PR TITLE
refactor: consolidate nio/channels and eliminate nio/channel collision

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/FileBuffer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/FileBuffer.kt
@@ -8,7 +8,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * An openable, closeable, mmap-style file buffer.
  *
- * @deprecated Use [SeekFileBufferCommon] routed through [borg.trikeshed.userspace.nio.channel.Channel].
+ * @deprecated Use [SeekFileBufferCommon] routed through [borg.trikeshed.userspace.nio.channels.UringChannel].
  * FileBuffer's CoroutineContext.Element coupling is being removed —
  * all file I/O now goes through the unified UringFacade.
  */

--- a/src/commonMain/kotlin/borg/trikeshed/lib/SeekFileBufferCommon.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/SeekFileBufferCommon.kt
@@ -2,8 +2,8 @@ package borg.trikeshed.lib
 
 import borg.trikeshed.lib.long.LongSeries
 import borg.trikeshed.userspace.ByteRegion
-import borg.trikeshed.userspace.nio.channel.Channel
-import borg.trikeshed.userspace.nio.channel.Channels
+import borg.trikeshed.userspace.nio.channels.UringChannel
+import borg.trikeshed.userspace.nio.channels.UringChannels
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.nio.file.Files
 import borg.trikeshed.userspace.nio.ByteBuffer
@@ -25,7 +25,7 @@ class SeekFileBufferCommon(
 ) : LongSeries<Byte>, Usable {
 
     private var file: File? = null
-    private var channel: Channel? = null
+    private var channel: UringChannel? = null
     private var fileSize: Long = 0
 
     /** Windowed read buffer — 64KB amortizes syscalls, stays in L3. */
@@ -54,7 +54,7 @@ class SeekFileBufferCommon(
         if (isOpen()) return
         val f = Files.open(filename, readOnly)
         file = f
-        channel = Channels.open()
+        channel = UringChannels.open()
         fileSize = f.size()
         windowBase = -1
         windowLimit = -1

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/UserspaceWrappers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/UserspaceWrappers.kt
@@ -1,6 +1,6 @@
 package borg.trikeshed.userspace
 
-import borg.trikeshed.userspace.nio.channel.Channel
+import borg.trikeshed.userspace.nio.channels.UringChannel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
  * Coroutine integration around the userspace Channel.
  */
 class ChannelRunner(
-    val channel: Channel,
+    val channel: UringChannel,
     val scope: CoroutineScope,
 ) {
     private val pendingOps = mutableMapOf<Long, CompletableDeferred<SelectionResult>>()

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/Channel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/Channel.kt
@@ -8,7 +8,7 @@ import borg.trikeshed.lib.Closeable
 // Declarations intentionally mirror JDK taxonomy and contain no implementations.
 //
 // COMPATIBILITY SURFACE ONLY. The transport substrate is:
-//   borg.trikeshed.userspace.nio.channel.Channel         — operation queue (submit/wait/peek)
+//   borg.trikeshed.userspace.nio.channels.UringChannel         — operation queue (submit/wait/peek)
 //   borg.trikeshed.userspace.nio.file.File            — handle lifecycle (open/close/isOpen)
 //   borg.trikeshed.userspace.FunctionalUringFacade — SQE/CQE plumbing
 //   borg.trikeshed.userspace.ByteRegion      — mutable read sink

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/DatagramChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/DatagramChannel.kt
@@ -4,8 +4,6 @@ package borg.trikeshed.userspace.nio.channels
 
 import borg.trikeshed.userspace.ByteRegion
 import borg.trikeshed.userspace.nio.ByteBuffer
-import borg.trikeshed.userspace.nio.channel.Channel
-import borg.trikeshed.userspace.nio.channel.Channels
 import borg.trikeshed.userspace.nio.channels.spi.AbstractSelectableChannel
 import borg.trikeshed.userspace.nio.channels.spi.SelectorProvider
 import borg.trikeshed.userspace.nio.file.File
@@ -34,8 +32,8 @@ public abstract class DatagramChannel : AbstractSelectableChannel, ByteChannel, 
 
     companion object {
         fun `open`(): DatagramChannel {
-            val file = Channels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_DGRAM.mask, SocketProtocol.IPPROTO_UDP.posix)
-            val channel = Channels.open()
+            val file = UringChannels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_DGRAM.mask, SocketProtocol.IPPROTO_UDP.posix)
+            val channel = UringChannels.open()
             return UringDatagramChannel(file, channel)
         }
         fun `open`(protocolFamily: String): DatagramChannel = `open`()
@@ -44,7 +42,7 @@ public abstract class DatagramChannel : AbstractSelectableChannel, ByteChannel, 
 
 internal class UringDatagramChannel(
     private val file: File,
-    private val channel: Channel,
+    private val channel: UringChannel,
 ) : DatagramChannel(SelectorProvider.provider()) {
     private var nextToken: Long = 1
     private var open: Boolean = true

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/FileChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/FileChannel.kt
@@ -3,7 +3,6 @@
 package borg.trikeshed.userspace.nio.channels
 
 import borg.trikeshed.userspace.nio.ByteBuffer
-import borg.trikeshed.userspace.nio.channel.Channels
 import borg.trikeshed.userspace.nio.file.Path
 import borg.trikeshed.userspace.nio.file.OpenOption
 import borg.trikeshed.userspace.nio.file.StandardOpenOption
@@ -44,7 +43,7 @@ public abstract class FileChannel protected constructor() : AbstractInterruptibl
         fun open(path: Path, options: Set<OpenOption>, vararg attrs: FileAttribute<*>): FileChannel {
             val readOnly = !options.any { it is StandardOpenOption && it == StandardOpenOption.WRITE }
             val file = Files.open(path.toString(), readOnly)
-            val channel = Channels.open()
+            val channel = UringChannels.open()
             return UringFileChannel(file, channel)
         }
         fun open(path: Path, vararg options: OpenOption): FileChannel = open(path, options.toSet())

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/ServerSocketChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/ServerSocketChannel.kt
@@ -2,8 +2,6 @@
 
 package borg.trikeshed.userspace.nio.channels
 
-import borg.trikeshed.userspace.nio.channel.Channel
-import borg.trikeshed.userspace.nio.channel.Channels
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.nio.channels.spi.AbstractSelectableChannel
 import borg.trikeshed.userspace.nio.channels.spi.SelectorProvider
@@ -24,8 +22,8 @@ public abstract class ServerSocketChannel : AbstractSelectableChannel, NetworkCh
 
     companion object {
         fun open(): ServerSocketChannel {
-            val file = Channels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_STREAM.mask, SocketProtocol.IPPROTO_TCP.posix)
-            val channel = Channels.open()
+            val file = UringChannels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_STREAM.mask, SocketProtocol.IPPROTO_TCP.posix)
+            val channel = UringChannels.open()
             return UringServerSocketChannel(file, channel)
         }
 
@@ -35,7 +33,7 @@ public abstract class ServerSocketChannel : AbstractSelectableChannel, NetworkCh
 
 internal class UringServerSocketChannel(
     private val file: File,
-    private val channel: Channel,
+    private val channel: UringChannel,
 ) : ServerSocketChannel(SelectorProvider.provider()) {
     private var nextToken: Long = 1
     private var open: Boolean = true

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/SocketChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/SocketChannel.kt
@@ -2,8 +2,6 @@
 
 package borg.trikeshed.userspace.nio.channels
 
-import borg.trikeshed.userspace.nio.channel.Channel
-import borg.trikeshed.userspace.nio.channel.Channels
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.nio.ByteBuffer
 import borg.trikeshed.userspace.nio.channels.spi.AbstractSelectableChannel
@@ -31,8 +29,8 @@ public abstract class SocketChannel : AbstractSelectableChannel, ByteChannel, Sc
 
     companion object {
         fun open(): SocketChannel {
-            val file = Channels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_STREAM.mask, SocketProtocol.IPPROTO_TCP.posix)
-            val channel = Channels.open()
+            val file = UringChannels.socket(SocketDomain.AF_INET.posix, SocketType.SOCK_STREAM.mask, SocketProtocol.IPPROTO_TCP.posix)
+            val channel = UringChannels.open()
             return UringSocketChannel(file, channel)
         }
         fun openWithProtocolFamily(protocolFamily: String): SocketChannel = open()
@@ -42,7 +40,7 @@ public abstract class SocketChannel : AbstractSelectableChannel, ByteChannel, Sc
 
 internal class UringSocketChannel(
     private val file: File,
-    private val channel: Channel,
+    private val channel: UringChannel,
 ) : SocketChannel(SelectorProvider.provider()) {
     private var nextToken: Long = 1
     private var open: Boolean = true

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringChannel.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.userspace.nio.channel
+package borg.trikeshed.userspace.nio.channels
 
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.FunctionalUringFacade
@@ -15,7 +15,7 @@ import borg.trikeshed.userspace.nio.ByteBuffer
  * The typed API is sugar that creates [UringSubmission] internally.
  * New code should use the unified path exclusively.
  */
-class Channel(
+class UringChannel(
     private val facade: FunctionalUringFacade,
 ) {
     fun read(file: File, buffer: ByteBuffer, offset: Long, userData: Long) =

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringChannels.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringChannels.kt
@@ -1,4 +1,4 @@
-package borg.trikeshed.userspace.nio.channel
+package borg.trikeshed.userspace.nio.channels
 
 import borg.trikeshed.userspace.ChannelsImpl
 import borg.trikeshed.userspace.FileImpl
@@ -9,9 +9,9 @@ import borg.trikeshed.userspace.FunctionalUringFacade
 /**
  * Channel factory — backed by expect/actual [ChannelsImpl].
  */
-object Channels {
-    fun open(entries: Int = 256): Channel =
-        Channel(FunctionalUringFacade(entries, openUserspaceChannelBackend(entries)))
+object UringChannels {
+    fun open(entries: Int = 256): UringChannel =
+        UringChannel(FunctionalUringFacade(entries, openUserspaceChannelBackend(entries)))
 
     fun socket(domain: Int, type: Int, protocol: Int): File =
         File(ChannelsImpl.socket(domain, type, protocol))

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringFileChannel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/UringFileChannel.kt
@@ -1,12 +1,11 @@
 package borg.trikeshed.userspace.nio.channels
 
-import borg.trikeshed.userspace.nio.channel.Channel
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.nio.ByteBuffer
 
 internal class UringFileChannel(
     private val file: File,
-    private val channel: Channel,
+    private val channel: UringChannel,
 ) : FileChannel() {
     private var pos: Long = 0
     private var nextToken: Long = 1

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/ChannelOperations.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/ChannelOperations.kt
@@ -4,7 +4,7 @@ import borg.trikeshed.userspace.nio.ByteBuffer
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Platform channel/socket factory — replaces [borg.trikeshed.userspace.nio.channel.Channels] + ChannelImpl expect.
+ * Platform channel/socket factory — replaces [borg.trikeshed.userspace.nio.channels.UringChannels] + ChannelImpl expect.
  *
  * io_uring submission/completion ring abstraction: prepare operations, submit batch, wait for completions.
  */

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/File.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/File.kt
@@ -5,7 +5,7 @@ import borg.trikeshed.userspace.FileImpl
 /**
  * Open file handle — backed by [FileImpl] (expect/actual).
  *
- * Used by [borg.trikeshed.userspace.nio.channel.Channel] operations.
+ * Used by [borg.trikeshed.userspace.nio.channels.UringChannel] operations.
  * For directory-level operations use [Files].
  */
 class File internal constructor(internal val impl: FileImpl) {

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/platform/UserspaceIO.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/platform/UserspaceIO.kt
@@ -1,6 +1,6 @@
 package borg.trikeshed.userspace.nio.platform
 
-import borg.trikeshed.userspace.nio.channel.Channel
+import borg.trikeshed.userspace.nio.channels.UringChannel
 import borg.trikeshed.userspace.nio.file.File
 import borg.trikeshed.userspace.SelectionResult
 import borg.trikeshed.userspace.nio.ByteBuffer
@@ -19,5 +19,5 @@ typealias UserspaceFD = File
 @Deprecated("Use SelectionResult.", ReplaceWith("SelectionResult"))
 typealias UserspaceIOResult = SelectionResult
 
-@Deprecated("Use borg.trikeshed.userspace.nio.channel.Channel.", ReplaceWith("Channel"))
-typealias UserspaceRing = Channel
+@Deprecated("Use borg.trikeshed.userspace.nio.channels.UringChannel.", ReplaceWith("UringChannel"))
+typealias UserspaceRing = UringChannel


### PR DESCRIPTION
Reconciles the naming collision and partial duplication between `nio/channel` and `nio/channels`.

- Moved the low-level io_uring wrappers (`Channel.kt` and `Channels.kt`) from the singular `nio/channel` package into the plural `nio/channels` package.
- Renamed the low-level wrappers to `UringChannel` and `UringChannels` to disambiguate them from the NIO-style `Channel` API interfaces.
- Eliminated the singular `nio/channel` directory and package entirely.
- Updated all import statements and variable types codebase-wide to point to the new `nio/channels` locations and the `Uring`-prefixed names.
- Validated with `./gradlew :jvmMainClasses --no-daemon`.

---
*PR created automatically by Jules for task [2630390208154331807](https://jules.google.com/task/2630390208154331807) started by @jnorthrup*