### PR TITLE
🎨 Palette: Add aria-label attributes to property editors and HtmlBuilder

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-01-20 - Adding ARIA attributes to generated HTML in Kotlin React-like DSLs
 **Learning:** When using Kotlin string-builder-based DSLs (like `text("<button...")`) to generate HTML elements, ARIA attributes and titles need to be explicitly added as escaped strings (e.g., `aria-label="My Label"`). Icon-only buttons used in inline editors (like BlockEditor and DatabaseView) often lack these attributes by default because they are generated programmatically for brevity.
 **Action:** Always check programmatic HTML generation for missing accessibility attributes, especially for UI controls represented only by symbols (↑, ↓, +, x, ✎).
+
+## 2025-01-20 - Adding ARIA attributes to generic HTML Builder inputs
+**Learning:** When creating general-purpose HTML builder functions (like `HtmlBuilder.input()` in TrikeShed), it's crucial to include explicit parameter support for accessibility attributes like `aria-label`. Without this generic support, downstream property editors (Text, Number, Date, Url, Email, Phone) that rely on these builders will implicitly fail to provide accessible names, causing widespread a11y gaps across dynamic forms.
+**Action:** When auditing custom UI DSLs or HTML builder utilities, verify that accessibility attributes are exposed as top-level arguments, not just classes or IDs. Update upstream builder functions to accept and properly render these attributes.

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
@@ -62,7 +62,7 @@ class BlockEditor(var block: LcncBlock, val ingestState: IngestStateElement) {
                 // Block creation menu
                 text("<div class=\"lcnc-block-menu\">")
                 text("<button onclick=\"window.lcncInsertBlock('${block.id}')\" aria-label=\"Insert new block\" title=\"Insert new block\">+</button>")
-                text("<select onchange=\"window.lcncChangeBlockType('${block.id}', this.value)\">")
+                text("<select onchange=\"window.lcncChangeBlockType('${block.id}', this.value)\" aria-label=\"Change block type\">")
                 text("<option value=\"paragraph\"${if(block.type=="paragraph") " selected" else ""}>Text</option>")
                 text("<option value=\"heading_1\"${if(block.type=="heading_1") " selected" else ""}>Heading 1</option>")
                 text("<option value=\"heading_2\"${if(block.type=="heading_2") " selected" else ""}>Heading 2</option>")

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/HtmlBuilder.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/HtmlBuilder.kt
@@ -7,11 +7,12 @@ class HtmlBuilder {
         tag("div", classes, id, block)
     }
     
-    fun input(type: String, value: String, classes: String = "", id: String = "", onChange: String = "") {
+    fun input(type: String, value: String, classes: String = "", id: String = "", onChange: String = "", ariaLabel: String = "") {
         sb.append("<input type=\"$type\" value=\"$value\"")
         if (classes.isNotEmpty()) sb.append(" class=\"$classes\"")
         if (id.isNotEmpty()) sb.append(" id=\"$id\"")
         if (onChange.isNotEmpty()) sb.append(" onchange=\"$onChange\"")
+        if (ariaLabel.isNotEmpty()) sb.append(" aria-label=\"$ariaLabel\"")
         sb.append("/>")
     }
     

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/PropertyEditor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/PropertyEditor.kt
@@ -35,7 +35,8 @@ class TextPropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-text",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 
@@ -56,7 +57,7 @@ class MultiSelectPropertyEditor(
             // multiple select elements need a script to extract values. We'll simplify to string match or pass an array literal.
             // But lcncPropChange accepts `this.value`. For a multi-select, we need to collect selected options.
             // Using a basic select multiple logic:
-            text("<select multiple onchange=\"window.lcncPropChange('${schema.id}', Array.from(this.selectedOptions).map(o => o.value))\">")
+            text("<select multiple onchange=\"window.lcncPropChange('${schema.id}', Array.from(this.selectedOptions).map(o => o.value))\" aria-label=\"${schema.name}\">")
             for (opt in options) {
                 val selected = if (selectedValues.contains(opt)) " selected" else ""
                 text("<option value=\"$opt\"$selected>$opt</option>")
@@ -83,7 +84,7 @@ class SelectPropertyEditor(
         val options = (schema.configuration?.get("options") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
         val builder = HtmlBuilder()
         builder.div(classes = "lcnc-prop-select", id = "prop-${schema.id}") {
-            text("<select onchange=\"window.lcncPropChange('${schema.id}', this.value)\">")
+            text("<select onchange=\"window.lcncPropChange('${schema.id}', this.value)\" aria-label=\"${schema.name}\">")
             for (opt in options) {
                 val selected = if (opt == value?.toString()) " selected" else ""
                 text("<option value=\"$opt\"$selected>$opt</option>")
@@ -107,7 +108,7 @@ class CheckboxPropertyEditor(
     override fun renderHtml(): String = html {
         val isChecked = value as? Boolean ?: false
         val checkedAttr = if (isChecked) " checked" else ""
-        text("<input type=\"checkbox\" class=\"lcnc-prop-checkbox\" id=\"prop-${schema.id}\" onchange=\"window.lcncPropChange('${schema.id}', this.checked)\"$checkedAttr/>")
+        text("<input type=\"checkbox\" class=\"lcnc-prop-checkbox\" id=\"prop-${schema.id}\" onchange=\"window.lcncPropChange('${schema.id}', this.checked)\" aria-label=\"${schema.name}\"$checkedAttr/>")
     }
 
     override fun validate(input: Any?): Boolean = input is Boolean
@@ -124,7 +125,8 @@ class NumberPropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-number",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 
@@ -146,7 +148,8 @@ class DatePropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-date",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 
@@ -164,7 +167,8 @@ class UrlPropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-url",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 
@@ -186,7 +190,8 @@ class EmailPropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-email",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 
@@ -208,7 +213,8 @@ class PhonePropertyEditor(
             value = value?.toString() ?: "",
             classes = "lcnc-prop-phone",
             id = "prop-${schema.id}",
-            onChange = "window.lcncPropChange('${schema.id}', this.value)"
+            onChange = "window.lcncPropChange('${schema.id}', this.value)",
+            ariaLabel = schema.name
         )
     }
 


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: 
Added `ariaLabel` parameter to `HtmlBuilder.input()` and propagated it through all property editors (Text, Number, Date, Url, Email, Phone). Also added explicit `aria-label` attributes to raw HTML select and checkbox fields in `PropertyEditor.kt`, and the block type select dropdown in `BlockEditor.kt`.

🎯 Why: 
The database view and block editors dynamically render fields that previously lacked accessible names. Without `aria-label`s, screen readers could not determine the purpose of these dynamically generated input elements.

📸 Before/After: 
N/A - purely HTML semantic/a11y change.

♿ Accessibility: 
Ensures all inline configuration inputs and property fields announce their respective `schema.name` (or purpose) to screen readers.

---
*PR created automatically by Jules for task [5089432666783558495](https://jules.google.com/task/5089432666783558495) started by @jnorthrup*