### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-08-04 - Avoid O(N²) memory/eviction bottlenecks
 **Learning:** Replacing chunked buffered I/O with `joinToString` causes OOM regressions. Map eviction using `removeAll` inside a loop causes O(N²) freezing.
 **Action:** Always reconstruct map keys and use `.remove(key)` for O(1) cache eviction.
+## 2026-08-07 - Avoid intermediate ArrayList allocation in array mapping
+**Learning:** When applying map transformations to `Array` types (such as `vararg` parameters) that will be immediately converted to another collection (e.g., `Series`), calling `.toList().map { ... }` is inefficient. It allocates a redundant, intermediate `ArrayList`. Kotlin arrays support the `.map` function natively.
+**Action:** Always map arrays directly (e.g., `hdrs.map { ... }`) instead of chaining `.toList().map { ... }` to avoid unnecessary intermediate allocations and reduce GC pressure.

--- a/src/commonMain/kotlin/keymux/KeyMux.kt
+++ b/src/commonMain/kotlin/keymux/KeyMux.kt
@@ -383,7 +383,8 @@ class KeyMuxBuilder {
     }
 
     fun api(baseUrl: String, vararg hdrs: Pair<String, String>): KeyMuxBuilder = apply {
-        val h = hdrs.toList().map { it.first j it.second }.toSeries()
+        // Bolt: avoid intermediate list allocations from .toList().map
+        val h = hdrs.map { it.first j it.second }.toSeries()
         sources.add("*".toKeyPath() j ApiSource(baseUrl, h))
     }
 

--- a/src/jvmMain/kotlin/borg/trikeshed/utils/keymuxd/KeyMux.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/utils/keymuxd/KeyMux.kt
@@ -340,7 +340,8 @@ class KeyMuxBuilder {
     }
 
     fun api(baseUrl: String, vararg hdrs: Pair<String, String>): KeyMuxBuilder = apply {
-        val h = hdrs.toList().map { it.first j it.second }.toSeries()
+        // Bolt: avoid intermediate list allocations from .toList().map
+        val h = hdrs.map { it.first j it.second }.toSeries()
         sources.add("*".toKeyPath() j ApiSource(baseUrl, h))
     }
 


### PR DESCRIPTION
💡 What: Removed `.toList()` call before mapping `vararg` array in `KeyMux.kt` (in both `jvmMain` and `commonMain`).
🎯 Why: Calling `.toList().map { ... }` on an array allocates a redundant, intermediate `ArrayList`. Kotlin arrays support `.map` directly.
📊 Impact: Eliminates an intermediate list allocation, reducing GC pressure during `KeyMux` construction and configuration.
🔬 Measurement: Verify by checking that `.toList()` is no longer called before `.map()` on `hdrs` in `KeyMux.kt`.

---
*PR created automatically by Jules for task [17707417310673242503](https://jules.google.com/task/17707417310673242503) started by @jnorthrup*