### PR TITLE
⚡ Bolt: [Remove redundant list allocation when mapping arrays in KeyMux API source]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,4 +16,6 @@
 
 ## 2026-08-04 - Avoid O(N²) memory/eviction bottlenecks
 **Learning:** Replacing chunked buffered I/O with `joinToString` causes OOM regressions. Map eviction using `removeAll` inside a loop causes O(N²) freezing.
-**Action:** Always reconstruct map keys and use `.remove(key)` for O(1) cache eviction.
+**Action:** Always reconstruct map keys and use `.remove(key)` for O(1) cache eviction.## 2024-05-18 - Removing redundant list allocation when mapping arrays
+**Learning:** When mapping `vararg` parameters or `Array` types in Kotlin, calling `.toList().map { ... }` creates a redundant intermediate `ArrayList` which is immediately discarded. Kotlin standard library has `.map { ... }` extension on Arrays.
+**Action:** Avoid calling `.toList()` before `.map { ... }` on varargs or arrays to prevent unnecessary memory allocation and reduce GC overhead.

--- a/src/commonMain/kotlin/keymux/KeyMux.kt
+++ b/src/commonMain/kotlin/keymux/KeyMux.kt
@@ -383,7 +383,7 @@ class KeyMuxBuilder {
     }
 
     fun api(baseUrl: String, vararg hdrs: Pair<String, String>): KeyMuxBuilder = apply {
-        val h = hdrs.toList().map { it.first j it.second }.toSeries()
+        val h = hdrs.map { it.first j it.second }.toSeries()
         sources.add("*".toKeyPath() j ApiSource(baseUrl, h))
     }
 

--- a/src/jvmMain/kotlin/borg/trikeshed/utils/keymuxd/KeyMux.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/utils/keymuxd/KeyMux.kt
@@ -340,7 +340,7 @@ class KeyMuxBuilder {
     }
 
     fun api(baseUrl: String, vararg hdrs: Pair<String, String>): KeyMuxBuilder = apply {
-        val h = hdrs.toList().map { it.first j it.second }.toSeries()
+        val h = hdrs.map { it.first j it.second }.toSeries()
         sources.add("*".toKeyPath() j ApiSource(baseUrl, h))
     }
 


### PR DESCRIPTION
⚡ Bolt: [Remove redundant list allocation when mapping arrays in KeyMux API source]

💡 What: Replaced `.toList().map { ... }` with direct `.map { ... }` on varargs arrays.
🎯 Why: Avoids creating a redundant `ArrayList` when mapping an `Array` parameter before turning it into a `Series`, solving a tiny performance bottleneck as requested by Bolt's journal memory.
📊 Impact: Saves an intermediate list allocation on KeyMux initialization for API sources.
🔬 Measurement: Observe memory footprint and garbage collection in microbenchmarks during KeyMux initialization.

---
*PR created automatically by Jules for task [7116920748480217338](https://jules.google.com/task/7116920748480217338) started by @jnorthrup*