### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and tooltips to PwaGallery buttons

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/pwa/PwaGallery.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/pwa/PwaGallery.kt
@@ -68,12 +68,12 @@ class PwaGallery(val items: Series<GalleryItem>, val id: String = "gallery") {
         } else {
             // Render viewer
             sb.append("<div class=\"pwa-gallery-viewer\">")
-            sb.append("<button class=\"pwa-gallery-close\" onclick=\"window.pwaGalleryClose('${id}')\">Close</button>")
+            sb.append("<button class=\"pwa-gallery-close\" onclick=\"window.pwaGalleryClose('${id}')\" aria-label=\"Close viewer\" title=\"Close viewer\">Close</button>")
             sb.append("<img src=\"${activeItem.url}\" alt=\"${activeItem.title}\" class=\"pwa-gallery-viewer-img\" />")
             sb.append("<div class=\"pwa-gallery-viewer-title\">${activeItem.title}</div>")
             sb.append("<div class=\"pwa-gallery-viewer-controls\">")
-            sb.append("<button class=\"pwa-gallery-prev\" onclick=\"window.pwaGalleryPrev('${id}')\">Prev</button>")
-            sb.append("<button class=\"pwa-gallery-next\" onclick=\"window.pwaGalleryNext('${id}')\">Next</button>")
+            sb.append("<button class=\"pwa-gallery-prev\" onclick=\"window.pwaGalleryPrev('${id}')\" aria-label=\"Previous image\" title=\"Previous image\">Prev</button>")
+            sb.append("<button class=\"pwa-gallery-next\" onclick=\"window.pwaGalleryNext('${id}')\" aria-label=\"Next image\" title=\"Next image\">Next</button>")
             sb.append("</div>")
             sb.append("</div>")
         }


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the Close, Prev, and Next buttons in the PwaGallery viewer component.
🎯 Why: The buttons used abbreviated text (e.g., "Prev") which is less descriptive for screen readers. Adding tooltips and ARIA labels provides a better UX for mouse users and essential context for assistive technologies.
📸 Before/After: Visual tooltips will now appear on hover; screen readers will announce "Previous image" instead of "Prev".
♿ Accessibility: Improves accessibility for screen reader users by providing descriptive labels for navigation controls.

---
*PR created automatically by Jules for task [4051894201770304045](https://jules.google.com/task/4051894201770304045) started by @jnorthrup*