### PR TITLE
🎨 Palette: [UX improvement] Make workspace switcher keyboard accessible

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -18,8 +18,8 @@
   <div class="app">
     <aside class="sidebar" id="sidebar">
       <div class="sidebar-top">
-        <div class="workspace-switcher">
-          <div class="workspace-icon">F</div>
+        <div class="workspace-switcher" role="button" tabindex="0" aria-label="Switch workspace">
+          <div class="workspace-icon" aria-hidden="true">F</div>
           <div class="workspace-name">Forge workspace</div>
         </div>
         <div class="sidebar-actions">

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -379,7 +379,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 button:focus-visible,
 .page-tree-item:focus-visible,
-.board-card:focus-visible {
+.board-card:focus-visible,
+.workspace-switcher:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }


### PR DESCRIPTION
💡 What: Added keyboard accessibility and semantic roles to the workspace-switcher element in the sidebar.
🎯 Why: The workspace-switcher component had an interactive hover state and `onclick` behavior but was not focusable by keyboard users and lacked semantic meaning for screen readers.
📸 Before/After: Added a visible outline to the element when it receives keyboard focus, matching the design system's existing focus states.
♿ Accessibility:
- Added `role="button"` and `tabindex="0"` to the container.
- Added `aria-label="Switch workspace"` to provide screen reader context.
- Added `aria-hidden="true"` to the decorative "F" icon.
- Added `.workspace-switcher:focus-visible` to the global focus styles for visible keyboard indication.

---
*PR created automatically by Jules for task [14030767467195144487](https://jules.google.com/task/14030767467195144487) started by @jnorthrup*