### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in FlywheelHistoryReaper

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/util/oroboros/FlywheelHistoryReaper.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/util/oroboros/FlywheelHistoryReaper.kt
@@ -12,6 +12,7 @@ object FlywheelHistoryReaper {
 
             val tagsToDelete = tags.drop(keepLatest)
             for (tag in tagsToDelete) {
+                if (tag.isBlank() || !tag.startsWith("flywheel/jules-") || tag.contains("..") || tag.startsWith("-")) continue
                 ProcessBuilder("git", "-C", repoDir.path, "tag", "-d", tag).start().waitFor()
                 ProcessBuilder("git", "-C", repoDir.path, "push", "origin", "--delete", tag).start().waitFor()
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command/Argument injection via unvalidated git tags fed to ProcessBuilder.
🎯 Impact: An attacker could create malicious tags in a shared repository that execute arbitrary commands when processed by the daemon.
🔧 Fix: Added strict validation ensuring tags start with expected prefix and contain no traversal or flag characters.
✅ Verification: Compiled cleanly and verified the new validation logic in FlywheelHistoryReaper.kt.

---
*PR created automatically by Jules for task [4595578251372190673](https://jules.google.com/task/4595578251372190673) started by @jnorthrup*