### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2026-08-04 - Avoid O(N²) memory/eviction bottlenecks
 **Learning:** Replacing chunked buffered I/O with `joinToString` causes OOM regressions. Map eviction using `removeAll` inside a loop causes O(N²) freezing.
 **Action:** Always reconstruct map keys and use `.remove(key)` for O(1) cache eviction.
+## 2024-08-11 - Replace filterValues().keys.toList() with entries.removeAll() for zero-allocation map eviction
+**Learning:** In Kotlin, replacing functional chains like `map.filterValues { ... }.keys.toList()` followed by map removal inside a loop with the in-place iterator method `map.entries.removeAll { ... }` changes the operation to an efficient O(N) zero-allocation removal, avoiding redundant intermediate collection instances.
+**Action:** Always refactor iterative functional map evictions to use `.entries.removeAll { ... }` instead of building intermediate Lists and HashMaps.

--- a/src/commonMain/kotlin/borg/trikeshed/collections/associative/ContextEvictingMap.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/collections/associative/ContextEvictingMap.kt
@@ -70,9 +70,9 @@ class ContextEvictingMap<K : Any, V : Any>(
             return removed
         }
 
-        val dead = backing.filterValues { !it.isLive }.keys.toList()
-        dead.forEach(backing::remove)
-        return dead.size
+        val initialSize = backing.size
+        backing.entries.removeAll { !it.value.isLive }
+        return initialSize - backing.size
     }
 
     fun size(): Int {


### PR DESCRIPTION
💡 What: Replaced functional map filtering chains with in-place `.entries.removeAll()` in `ContextEvictingMap`.
🎯 Why: `backing.filterValues { ... }.keys.toList()` allocated multiple temporary collections (a LinkedHashMap and an ArrayList) during every map cleanup cycle, causing memory churn and GC pressure in tight loops.
📊 Impact: Transforms an O(N) map sweep from multiple allocation steps to zero-allocation, reducing garbage collection pauses in highly concurrent or high-churn scenarios.
🔬 Measurement: Can be verified using Java Memory profiler by observing heap allocations per GC tick under load.

---
*PR created automatically by Jules for task [6134959520020765618](https://jules.google.com/task/6134959520020765618) started by @jnorthrup*