### PR TITLE
🔒 Fix Markdown injection in HermesDonorTrace

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
@@ -67,8 +67,8 @@ object HermesDonorTrace {
                 while (rs.next()) {
                     hasWorkPackages = true
                     val id = rs.getString("id")
-                    val title = rs.getString("title")
-                    val body = rs.getString("body")
+                    val title = escapeMarkdown(rs.getString("title"))
+                    val body = escapeMarkdown(rs.getString("body"))
                     val parentIds = rs.getString("parent_ids")
 
                     // id needs to match "^([A-Z][0-9]+)$"
@@ -114,5 +114,10 @@ object HermesDonorTrace {
         val tmp = Files.createTempFile("sqlite-donor", ".md")
         Files.writeString(tmp, sourceDescription)
         return ForgeKanbanIngest.persistMarkdown(userId, tmp.toString())
+    }
+
+    private fun escapeMarkdown(text: String?): String? {
+        if (text == null) return null
+        return text.replace(Regex("""([\\`*_{}\[\]()#+\-.!])"""), "\\\\$1")
     }
 }


### PR DESCRIPTION
🎯 **What:** The `HermesDonorTrace` component was directly appending `title` and `body` fields from an SQLite database into a `StringBuilder` to create markdown content, leading to a Markdown injection vulnerability.

⚠️ **Risk:** If malicious data was present in the SQLite database, it could have been interpreted as markdown, allowing arbitrary and potentially dangerous markdown commands to be injected into the system's generated artifacts.

🛡️ **Solution:** Implemented a private `escapeMarkdown` function that uses a safe Regular Expression to identify and escape Markdown syntax characters (`\` `*` `_` `{` `}` `[` `]` `(` `)` `#` `+` `-` `.` `!`) in the `title` and `body` strings prior to appending them to the StringBuilder.

---
*PR created automatically by Jules for task [10332410821063235532](https://jules.google.com/task/10332410821063235532) started by @jnorthrup*