### PR TITLE
🧹 Replace todo:abc placeholder in FlywheelClaimPatchTest

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/jules/FlywheelClaimPatchTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/jules/FlywheelClaimPatchTest.kt
@@ -55,7 +55,7 @@ class FlywheelClaimPatchTest {
             commitSha = headSha,
             patch = patch,
             sessionId = "sessions/7395203169723873685",
-            workId = "todo:abc",
+            workId = "w-claim-test",
             title = "Wire CAS receipt",
             content = "Wire the CAS receipt so patchCid is backed by a blob",
         )
@@ -86,7 +86,7 @@ class FlywheelClaimPatchTest {
             commitSha = headSha,
             patch = patch,
             sessionId = "sessions/7395203169723873685",
-            workId = "todo:abc",
+            workId = "w-claim-test",
             title = "Wire CAS receipt",
             content = "Wire the CAS receipt so patchCid is backed by a blob",
         )


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded `todo:abc` string with `w-claim-test` for `workId` assignments in `FlywheelClaimPatchTest.kt`.
💡 **Why:** To improve code health by removing "TODO" placeholder strings from test data, keeping the tests clean and consistent with other established placeholders.
✅ **Verification:** Ran `./gradlew :jvmMainClasses --no-daemon` to ensure the build gate passes and confirmed via `git diff` that the correct replacements were made.
✨ **Result:** The `todo:abc` placeholder is fully removed from `FlywheelClaimPatchTest.kt`, improving test readability.

---
*PR created automatically by Jules for task [10521399272449940766](https://jules.google.com/task/10521399272449940766) started by @jnorthrup*