### PR TITLE
fix: flaky assertions in ForceLayoutTest

### DIFF
--- a/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForceLayoutTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForceLayoutTest.kt
@@ -47,21 +47,11 @@ class ForceLayoutTest {
         // Assert camera has moved
         assertTrue(layoutCamera.zoom != camera.zoom || layoutCamera.x != camera.x || layoutCamera.y != camera.y, "Camera should have updated position/zoom")
 
-        val pos0 = positions.entries.firstOrNull { it.key.contains("node-0") && it.key.length == "node-0".length }?.value ?: positions.entries.firstOrNull()?.value
-        val pos1 = positions.entries.firstOrNull { it.key.contains("node-1") && it.key.length == "node-1".length }?.value ?: positions.entries.firstOrNull()?.value
-        val pos20 = positions.entries.firstOrNull { it.key.contains("node-20") && it.key.length == "node-20".length }?.value ?: positions.entries.firstOrNull()?.value
+        val pos0 = positions["node-0"] ?: throw AssertionError("Missing node-0 position")
+        val pos1 = positions["node-1"] ?: throw AssertionError("Missing node-1 position")
+        val pos20 = positions["node-20"] ?: throw AssertionError("Missing node-20 position")
 
-        if (pos0 == null || pos1 == null || pos20 == null) {
-            throw AssertionError("Missing node positions")
-        }
-
-        val dist1 = sqrt((pos0.screenX - pos1.screenX) * (pos0.screenX - pos1.screenX) + (pos0.screenY - pos1.screenY) * (pos0.screenY - pos1.screenY))
-        val dist20 = sqrt((pos0.screenX - pos20.screenX) * (pos0.screenX - pos20.screenX) + (pos0.screenY - pos20.screenY) * (pos0.screenY - pos20.screenY))
-
-        // Use a softer assertion that doesn't fail the build if it misses, or actually fix the mapping logic
-        // Since we are not guaranteed layout will put 1 closer than 20 if iterations don't converge enough,
-        // we can just assert that nodes have different positions.
-        assertTrue(dist1 >= 0.0)
-        assertTrue(dist20 >= 0.0)
+        assertNotEquals(pos0, pos1, "node-0 and node-1 should not have the same position")
+        assertNotEquals(pos0, pos20, "node-0 and node-20 should not have the same position")
     }
 }


### PR DESCRIPTION
Fixes the flaky distance assertions in `ForceLayoutTest.kt` by asserting that the computed node positions are unique and valid, rather than measuring specific un-guaranteed convergence distances.

---
*PR created automatically by Jules for task [12013806545813285011](https://jules.google.com/task/12013806545813285011) started by @jnorthrup*