### PR TITLE
🔒 Fix Command Injection in GapReducerCli

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/flywheel/cli/GapReducerCli.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/flywheel/cli/GapReducerCli.kt
@@ -474,7 +474,7 @@ class GapReducer(
         pattern: String,
         excludedFiles: Set<File> = emptySet(),
     ): List<String> {
-        val cmd = listOf("grep", "-rn", "--include=*.kt", pattern, sourceRoot.absolutePath)
+        val cmd = listOf("grep", "-rn", "--include=*.kt", "-e", pattern, "--", sourceRoot.absolutePath)
         val proc = ProcessBuilder(cmd).redirectErrorStream(true).start()
         val output = proc.inputStream.bufferedReader().readText()
         proc.waitFor()


### PR DESCRIPTION
🎯 **What:** 
The `grepProduction` function in `GapReducerCli.kt` used a `ProcessBuilder` with `val cmd = listOf("grep", "-rn", "--include=*.kt", pattern, sourceRoot.absolutePath)`. This was vulnerable to argument injection if `pattern` or `sourceRoot.absolutePath` started with a hyphen.

⚠️ **Risk:** 
If an attacker or a malicious file crafted a specific `pattern` or path, `grep` would misinterpret them as command-line options. This could lead to unexpected behavior, read-access to unauthorized files, or a crash, posing a severe security and reliability risk.

🛡️ **Solution:** 
Updated the `grep` command to use explicit flags and option terminators:
`val cmd = listOf("grep", "-rn", "--include=*.kt", "-e", pattern, "--", sourceRoot.absolutePath)`.
- `-e` forces the following string to be treated as a pattern.
- `--` forces the following string to be treated as a file path.
This securely mitigates the argument injection vulnerability.

---
*PR created automatically by Jules for task [2105284501938436371](https://jules.google.com/task/2105284501938436371) started by @jnorthrup*