### PR TITLE
🔒 Fix SQLite JDBC connection string injection in HermesDonorTrace

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
@@ -53,7 +53,7 @@ object HermesDonorTrace {
         require(Files.exists(dbPath)) { "SQLite donor db not found at: $dbPath" }
 
         val dataSource = SQLiteDataSource().apply {
-            url = "jdbc:sqlite:${dbPath.toAbsolutePath()}"
+            url = "jdbc:sqlite:${dbPath.toUri()}"
         }
 
         var sourceDescription = ""


### PR DESCRIPTION
🎯 **What:** Fixed a SQL injection vulnerability in `HermesDonorTrace.kt` where SQLite JDBC connection parameters could be injected via a crafted database path.

⚠️ **Risk:** An attacker could provide a malicious path containing `?` and `&` (e.g. `file:/path/to/db?enable_load_extension=true`) to inject dangerous SQLite JDBC connection properties, potentially leading to arbitrary extension execution or denial of service by altering memory and cache settings.

🛡️ **Solution:** Changed `dbPath.toAbsolutePath()` to `dbPath.toUri()` when constructing the SQLite JDBC URL. The `toUri()` method percent-encodes any query string characters (e.g., `?` becomes `%3F`), ensuring that the SQLite JDBC driver treats the entire input strictly as a filepath, thereby neutralizing the parameter injection attack vector.

---
*PR created automatically by Jules for task [473626102950417571](https://jules.google.com/task/473626102950417571) started by @jnorthrup*