### PR TITLE
🧹 [code health] Implement readSymbolicLink by delegating to FileSystemProvider

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
@@ -132,7 +132,7 @@ public object Files {
     public fun move(src: Path, dst: Path, vararg options: CopyOption): Path = TODO("rename")
     public fun createLink(link: Path, existing: Path): Path = TODO("link")
     public fun createSymbolicLink(link: Path, target: Path, vararg attrs: FileAttribute<*>): Path = TODO("symlink")
-    public fun readSymbolicLink(link: Path): Path = TODO("readlink")
+    public fun readSymbolicLink(link: Path): Path = link.getFileSystem().provider().readSymbolicLink(link)
 
     // Attributes
     public fun <A : BasicFileAttributes> readAttributes(path: Path, type: kotlin.reflect.KClass<A>, vararg options: LinkOption): A = TODO("stat")


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Implemented `readSymbolicLink` in `Files.kt` which was previously throwing a `TODO("readlink")`. 

💡 **Why:** How this improves maintainability
By delegating to the `FileSystemProvider` via `link.getFileSystem().provider().readSymbolicLink(link)`, this resolves the unimplemented function in a way that respects the abstraction of the NIO file system SPI. It removes dead/broken code and allows individual providers to implement the C interop and string conversions necessary for their specific platforms.

✅ **Verification:** How you confirmed the change is safe
Ran `./gradlew :jvmMainClasses --no-daemon` to ensure the project still compiles correctly. Verified the generated AST changes matched expectations. The method relies completely on the SPI interface as is standard for Java-style NIO codebases, minimizing risk.

✨ **Result:** The improvement achieved
A fully functional `readSymbolicLink` method in the common `Files` facade that correctly routes the call to the configured `FileSystemProvider`.

---
*PR created automatically by Jules for task [14593905623724680501](https://jules.google.com/task/14593905623724680501) started by @jnorthrup*