### PR TITLE
🔒 Fix command/parameter injection vulnerability in PanamaKanbanMovie

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/movie/PanamaKanbanMovie.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/movie/PanamaKanbanMovie.kt
@@ -210,6 +210,16 @@ object PanamaKanbanMovie {
         }
         
         val outputFile = File("causal-movie.mp4")
+
+        // Validate outputFile path to prevent command/parameter injection
+        if (outputFile.name.startsWith("-")) {
+            throw IllegalArgumentException("Output file name cannot start with '-' to prevent parameter injection")
+        }
+        val shellMetachars = setOf(';', '&', '|', '>', '<', '$', '\\', '\n', '\r', '\'', '"', '`')
+        if (outputFile.name.any { it in shellMetachars }) {
+            throw IllegalArgumentException("Output file name contains invalid shell metacharacters")
+        }
+
         val tempDir = File("temp-frames")
         tempDir.mkdirs()
         

--- a/test_fix.sh
+++ b/test_fix.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-# I will modify OroborosDaemon.kt and FlywheelDriver.kt to take multiple HtxElements.


### PR DESCRIPTION
🎯 **What:** Fixed a potential command/parameter injection vulnerability in `PanamaKanbanMovie.kt` where a `File` path was passed to a `ProcessBuilder` executing `ffmpeg`.
⚠️ **Risk:** If the `outputFile` were to come from user input, an attacker could supply a filename starting with `-` to inject arbitrary parameters into `ffmpeg` or use shell metacharacters to potentially achieve command execution or write files out of bounds.
🛡️ **Solution:** Added explicit path validation in `encodeToMp4`. It now ensures the `outputFile.name` does not start with `-` and does not contain shell metacharacters (`;&|><$\`\n\r'"`). We intentionally check `.name` instead of `.canonicalPath` so we do not break if the user's host directory path happens to contain these characters. Note: No new unit tests were added as per standard project convention and because the `jvmTest` suite currently contains unrelated compilation errors.

---
*PR created automatically by Jules for task [16035895843443799306](https://jules.google.com/task/16035895843443799306) started by @jnorthrup*