### PR TITLE
fix: Close and flush trace writer on --once

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -651,6 +651,7 @@ object OroborosDaemon {
                     System.err.println("[OROBOROS] cycleBody.run escaped: ${t.javaClass.simpleName}: ${t.message?.take(200)}")
                 }
                 isRunning = false
+                try { currentTw?.flush(); currentTw?.close() } catch (_: Exception) {}
                 mainJob?.cancel()
                 return
             }


### PR DESCRIPTION
🎯 What
Fixed a bug in `OroborosDaemon` where the JSONL trace file wasn't flushed when run with the `--once` flag.

⚠️ Risk
Low risk. Adding safe I/O closures (`flush()` and `close()`) surrounded by a try-catch block on the exit path.

🛡️ Solution
Added `currentTw?.flush()` and `currentTw?.close()` to the shutdown block in the `--once` branch of `OroborosDaemon`.

---
*PR created automatically by Jules for task [7974636332556662763](https://jules.google.com/task/7974636332556662763) started by @jnorthrup*