### PR TITLE
Refactor IndexedDB polyfill to use @JsModule instead of raw JS require

### DIFF
--- a/src/wasmJsTest/kotlin/borg/trikeshed/storage/volume/IndexedDbVolumeTest.kt
+++ b/src/wasmJsTest/kotlin/borg/trikeshed/storage/volume/IndexedDbVolumeTest.kt
@@ -6,14 +6,24 @@ import kotlin.test.BeforeTest
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.delay
 
-@JsFun("""() => {
-    // polyfill hack
+import kotlin.js.JsModule
+
+@JsModule("fake-indexeddb")
+external object FakeIndexedDB {
+    val indexedDB: JsAny
+    val IDBKeyRange: JsAny
+}
+
+@JsFun("(idb, keyRange) => { globalThis.indexedDB = idb; globalThis.IDBKeyRange = keyRange; }")
+private external fun setGlobalIndexedDB(indexedDB: JsAny, IDBKeyRange: JsAny)
+
+private fun setupPolyfill() {
     try {
-        globalThis.indexedDB = require('fake-indexeddb').indexedDB;
-        globalThis.IDBKeyRange = require('fake-indexeddb').IDBKeyRange;
-    } catch(e) { }
-}""")
-private external fun setupPolyfill()
+        setGlobalIndexedDB(FakeIndexedDB.indexedDB, FakeIndexedDB.IDBKeyRange)
+    } catch (e: Throwable) {
+        // Ignore
+    }
+}
 
 class IndexedDbVolumeTest {
     @BeforeTest


### PR DESCRIPTION
🎯 **What**
This PR refactors the IndexedDB polyfill setup in `IndexedDbVolumeTest.kt` for the `wasmJsTest` target. It replaces a brittle, dynamic `require` call embedded in a raw JS string with an idiomatic Kotlin/Wasm `@JsModule` import.

⚠️ **Risk**
The risk is low. This change isolates the modification to test code within the Wasm target, improving the test setup's robustness.

🛡️ **Solution**
I introduced a `FakeIndexedDB` external object annotated with `@JsModule("fake-indexeddb")` to statically import the Node module. This object is then passed into a simplified `@JsFun` function to safely attach the required API elements (`indexedDB` and `IDBKeyRange`) to `globalThis`. This prevents build-time masking and ensures standard interoperability.

---
*PR created automatically by Jules for task [827062362026591796](https://jules.google.com/task/827062362026591796) started by @jnorthrup*