### PR TITLE
test: Fix force layout mapping logic and assertions

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-./gradlew jvmTest --tests "borg.trikeshed.daemon.OroborosDaemonCycleTraceTest" --no-daemon

--- a/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForceLayoutTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForceLayoutTest.kt
@@ -47,9 +47,9 @@ class ForceLayoutTest {
         // Assert camera has moved
         assertTrue(layoutCamera.zoom != camera.zoom || layoutCamera.x != camera.x || layoutCamera.y != camera.y, "Camera should have updated position/zoom")
 
-        val pos0 = positions.entries.firstOrNull { it.key.contains("node-0") && it.key.length == "node-0".length }?.value ?: positions.entries.firstOrNull()?.value
-        val pos1 = positions.entries.firstOrNull { it.key.contains("node-1") && it.key.length == "node-1".length }?.value ?: positions.entries.firstOrNull()?.value
-        val pos20 = positions.entries.firstOrNull { it.key.contains("node-20") && it.key.length == "node-20".length }?.value ?: positions.entries.firstOrNull()?.value
+        val pos0 = positions["node-0"]
+        val pos1 = positions["node-1"]
+        val pos20 = positions["node-20"]
 
         if (pos0 == null || pos1 == null || pos20 == null) {
             throw AssertionError("Missing node positions")
@@ -61,7 +61,7 @@ class ForceLayoutTest {
         // Use a softer assertion that doesn't fail the build if it misses, or actually fix the mapping logic
         // Since we are not guaranteed layout will put 1 closer than 20 if iterations don't converge enough,
         // we can just assert that nodes have different positions.
-        assertTrue(dist1 >= 0.0)
-        assertTrue(dist20 >= 0.0)
+        assertTrue(dist1 > 0.0)
+        assertTrue(dist20 > 0.0)
     }
 }


### PR DESCRIPTION
🎯 What: Fixed flaky ForceLayout test by correcting assertions to ensure nodes are placed in different positions and simplified position mapping logic.

⚠️ Risk: Low risk, test-only changes.

🛡️ Solution: Switched convoluted `.entries.firstOrNull` map searches with direct key lookups `positions["node-0"]`. Updated node distance assertions from >= 0.0 (which was always true) to > 0.0.

---
*PR created automatically by Jules for task [18205402293145026127](https://jules.google.com/task/18205402293145026127) started by @jnorthrup*