### PR TITLE
Refactor IndexedDb polyfill test hack to use idiomatic @JsModule

### DIFF
--- a/src/wasmJsTest/kotlin/borg/trikeshed/storage/volume/IndexedDbVolumeTest.kt
+++ b/src/wasmJsTest/kotlin/borg/trikeshed/storage/volume/IndexedDbVolumeTest.kt
@@ -6,19 +6,19 @@ import kotlin.test.BeforeTest
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.delay
 
-@JsFun("""() => {
-    // polyfill hack
-    try {
-        globalThis.indexedDB = require('fake-indexeddb').indexedDB;
-        globalThis.IDBKeyRange = require('fake-indexeddb').IDBKeyRange;
-    } catch(e) { }
-}""")
-private external fun setupPolyfill()
+@JsModule("fake-indexeddb")
+private external object FakeIndexedDb {
+    val indexedDB: JsAny
+    val IDBKeyRange: JsAny
+}
+
+@JsFun("(indexedDB, IDBKeyRange) => { globalThis.indexedDB = indexedDB; globalThis.IDBKeyRange = IDBKeyRange; }")
+private external fun setupPolyfill(indexedDB: JsAny, IDBKeyRange: JsAny)
 
 class IndexedDbVolumeTest {
     @BeforeTest
     fun setup() {
-        setupPolyfill()
+        setupPolyfill(FakeIndexedDb.indexedDB, FakeIndexedDb.IDBKeyRange)
     }
 
     @Test


### PR DESCRIPTION
🎯 What
This PR refactors the IndexedDB polyfill hack in `IndexedDbVolumeTest.kt` to use idiomatic Kotlin/Wasm interop. 

⚠️ Risk
Low. Replaces runtime `require()` calls inside raw JS strings with standard `@JsModule` external definitions, which improves compatibility with JS module bundlers.

🛡️ Solution
Created an `@JsModule("fake-indexeddb")` external object to represent the `fake-indexeddb` library and passed its properties statically to a revised `@JsFun` function to attach them to `globalThis`.

---
*PR created automatically by Jules for task [9453402176356471800](https://jules.google.com/task/9453402176356471800) started by @jnorthrup*