### PR TITLE
test: RED-ONLY TDD for LatentState marker

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/memory/ontology/LatentStateMarkerTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/memory/ontology/LatentStateMarkerTest.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.memory.ontology
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class LatentStateMarkerTest {
+
+    @Test
+    fun latentStateIsInternalParametricMarker() {
+        val marker = LatentState
+        assertTrue(marker is InternalParametric)
+        assertTrue(marker.gloss.isNotEmpty())
+    }
+}


### PR DESCRIPTION
🎯 What: Added failing JVM unit test for the missing `LatentState` marker.
💡 Why: Start the RED-ONLY TDD cycle to ensure new marker objects in `borg.trikeshed.memory.ontology` are verified against `InternalParametric` boundaries.
✅ Verification: `./gradlew compileTestKotlinJvm` fails as expected on unresolved references for `LatentState`, `InternalParametric`, and `gloss`.
✨ Result: Missing functionality properly codified as an initial failing test, establishing the baseline before production code implementation.

---
*PR created automatically by Jules for task [14648490754224441424](https://jules.google.com/task/14648490754224441424) started by @jnorthrup*