### PR TITLE
🧹 code health: remove unused UserspaceIORunner typealias

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/UserspaceWrappers.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/UserspaceWrappers.kt
@@ -38,6 +38,3 @@ class ChannelRunner(
         return deferred.await()
     }
 }
-
-@Deprecated("Use ChannelRunner.", ReplaceWith("ChannelRunner"))
-typealias UserspaceIORunner = ChannelRunner


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `UserspaceIORunner` typealias from `src/commonMain/kotlin/borg/trikeshed/userspace/UserspaceWrappers.kt`.
💡 **Why:** To improve code health by removing unused and deprecated code, reducing clutter.
✅ **Verification:** Verified via `grep` that there are no usages of the typealias across the codebase. Ran `./gradlew :jvmMainClasses --no-daemon --offline` to ensure no regressions are introduced.
✨ **Result:** A cleaner codebase with the unused deprecated typealias removed.

---
*PR created automatically by Jules for task [16788446061452946765](https://jules.google.com/task/16788446061452946765) started by @jnorthrup*