### PR TITLE
Refactor loops to Series α transforms

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
@@ -6,6 +6,8 @@ import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.get
 import borg.trikeshed.lib.j
 import borg.trikeshed.lib.size
+import borg.trikeshed.lib.α
+import borg.trikeshed.lib.view
 
 /**
  * Funnel residual merge — the N-way topology pipeline.
@@ -135,8 +137,7 @@ object FunnelResidualMerge {
         sourceIdx: SourceIdx,
     ): ResidualSpine {
         val atoms = ArrayList<LineAtom>(source.size)
-        for (i in 0 until source.size) {
-            val node = source[i]
+        for (node in source.view) {
             if (masterFunnel.contains(node.contentCid.hex)) continue // hit = inherited
             val prev = node.prevHex
             val next = node.nextHex
@@ -217,9 +218,7 @@ object FunnelResidualMerge {
         topology: Topology,
         masterFunnel: FunnelHashIndex<String>,
     ): GradedTopology {
-        val graded = ArrayList<GradedCluster>(topology.size)
-        for (i in 0 until topology.size) {
-            val cluster = topology[i]
+        return topology α { cluster ->
             val inMaster = masterFunnel.contains(cluster.contentCid.hex)
             val grade = when {
                 inMaster -> ClusterGrade.INHERITED
@@ -236,9 +235,8 @@ object FunnelResidualMerge {
                     if (allEqual) ClusterGrade.INHERITED_CROSS else ClusterGrade.RELOCATED
                 }
             }
-            graded.add(GradedCluster(cluster, grade))
+            GradedCluster(cluster, grade)
         }
-        return graded.size j { i: Int -> graded[i] }
     }
 
     // ── Stage 6: residual merge on survivors ─────────────────────────────
@@ -255,23 +253,22 @@ object FunnelResidualMerge {
      * This is the O(|residual|) settlement, not O(N × |tree|).
      */
     fun mergeResiduals(graded: GradedTopology): MergeReceipt {
-        val kept = ArrayList<GradedCluster>(graded.size)
-        val dropped = ArrayList<GradedCluster>(graded.size)
+        val keptList = ArrayList<GradedCluster>(graded.size)
+        val droppedList = ArrayList<GradedCluster>(graded.size)
         var novel = 0; var relocated = 0; var inherited = 0
 
-        for (i in 0 until graded.size) {
-            val gc = graded[i]
+        for (gc in graded.view) {
             when (gc.grade) {
-                ClusterGrade.NOVEL -> { kept.add(gc); novel++ }
-                ClusterGrade.RELOCATED -> { kept.add(gc); relocated++ }
-                ClusterGrade.INHERITED -> { dropped.add(gc); inherited++ }
-                ClusterGrade.INHERITED_CROSS -> { dropped.add(gc); inherited++ }
+                ClusterGrade.NOVEL -> { keptList.add(gc); novel++ }
+                ClusterGrade.RELOCATED -> { keptList.add(gc); relocated++ }
+                ClusterGrade.INHERITED -> { droppedList.add(gc); inherited++ }
+                ClusterGrade.INHERITED_CROSS -> { droppedList.add(gc); inherited++ }
             }
         }
 
         return MergeReceipt(
-            kept = kept.size j { i: Int -> kept[i] },
-            dropped = dropped.size j { i: Int -> dropped[i] },
+            kept = keptList.size j { i: Int -> keptList[i] },
+            dropped = droppedList.size j { i: Int -> droppedList[i] },
             novelCount = novel,
             relocatedCount = relocated,
             inheritedCount = inherited,
@@ -325,11 +322,7 @@ object FunnelResidualMerge {
      * frozen after build). For a static master baseline, build once.
      */
     fun buildMasterFunnel(masterSpine: LineSpine, seed: Long = 0L): FunnelHashIndex<String> {
-        val keys = ArrayList<String>(masterSpine.size)
-        for (i in 0 until masterSpine.size) {
-            keys.add(masterSpine[i].contentCid.hex)
-        }
-        val keySeries = keys.size j { i: Int -> keys[i] }
+        val keySeries = masterSpine α { it.contentCid.hex }
         return FunnelHashIndex.build(keySeries, seed)
     }
 
@@ -346,10 +339,10 @@ object FunnelResidualMerge {
         seed: Long = 0L,
     ): FunnelHashIndex<String> {
         val keys = ArrayList<String>(masterTexts.size * 10)
-        for (i in 0 until masterTexts.size) {
-            val spine = LineCas.spine(masterTexts[i])
-            for (j in 0 until spine.size) {
-                keys.add(spine[j].contentCid.hex)
+        for (text in masterTexts.view) {
+            val spine = LineCas.spine(text)
+            for (node in spine.view) {
+                keys.add(node.contentCid.hex)
             }
         }
         val keySeries = keys.size j { i: Int -> keys[i] }

--- a/src/commonMain/kotlin/borg/trikeshed/graph/query/CausalGraphAdapter.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/graph/query/CausalGraphAdapter.kt
@@ -2,6 +2,9 @@ package borg.trikeshed.graph.query
 
 import borg.trikeshed.graph.CausalGraphNode
 import borg.trikeshed.graph.CausalGraphNodeIndex
+import borg.trikeshed.lib.α
+import borg.trikeshed.lib.view
+import borg.trikeshed.lib.j
 
 /**
  * Connects the Graph Query Engine to the CausalGraphNodeIndex.
@@ -34,7 +37,7 @@ class CausalGraphAdapter(private val index: CausalGraphNodeIndex) : Graph<Causal
     }
 
     override val nodes: Set<CausalGraphNode>
-        get() = (0 until index.size).map { index[it] }.toSet()
+        get() = (index.size j { i: Int -> index[i] }).view.toSet() // stdlib-boundary: Set required by CausalGraphAdapter
 
     override fun outEdges(node: N): Map<CausalGraphNode, Unit> {
         val children = childrenMap[node.nodeId] ?: emptyList()

--- a/src/commonMain/kotlin/borg/trikeshed/jules/BrainClient.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/BrainClient.kt
@@ -5,6 +5,9 @@ import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.get
 import borg.trikeshed.lib.size
 import borg.trikeshed.lib.toArray
+import borg.trikeshed.lib.α
+import borg.trikeshed.lib.view
+import borg.trikeshed.lib.j
 import keymux.EnvVarSource
 import keymux.FixedKeySource
 import keymux.KeyMux
@@ -126,11 +129,13 @@ class BrainClient(
     }
 
     private fun orderedModelIds(routed: Series<ModelEntry>): List<String> {
-        val modelIds = (0 until routed.size).map { routed[it].a }
-        val preferred = lastGoodModelId ?: return modelIds
-        val start = modelIds.indexOf(preferred)
-        if (start < 0) return modelIds
-        return (0 until modelIds.size).map { offset -> modelIds[(start + offset) % modelIds.size] }
+        val modelIds = routed α { it.a }
+        val preferred = lastGoodModelId ?: return modelIds.view.toList() // stdlib-boundary: List return
+        val start = modelIds.view.indexOf(preferred)
+        if (start < 0) return modelIds.view.toList() // stdlib-boundary: List return
+
+        val series = modelIds.size j { offset: Int -> modelIds[(start + offset) % modelIds.size] }
+        return series.view.toList() // stdlib-boundary: List return
     }
 
     private fun buildKeyMux(overrideKey: String?, overrideModel: String): KeyMux = KeyMux {


### PR DESCRIPTION
🎯 What
Replaced eager `ArrayList` accumulation and index-mapping patterns with lazy `Series` α-transforms or view loops.

💡 Why
To adhere to the `PRELOAD.md` "α xform" recipe. This refactoring preserves the project's zero-cost algebra, delaying allocation until strict `stdlib-boundary` conversion is demanded.

✅ Verification
Compiled successfully on JVM via `./gradlew jvmMainClasses`. The exact sites specified in the prompt were transformed strictly keeping the domain types. No unnecessary List demotions were performed where a `Series` could be preserved.

✨ Result
A strictly lazy and memory-efficient traversal pipeline, especially critical in the 57-way merge resolution loop where intermediate Lists previously flooded GC.

---
*PR created automatically by Jules for task [11540558525698237353](https://jules.google.com/task/11540558525698237353) started by @jnorthrup*