### PR TITLE
test(cas): add FunnelResidualMerge 57-way evidence test

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/cas/FunnelResidualMerge57WayEvidenceTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/cas/FunnelResidualMerge57WayEvidenceTest.kt
@@ -1,0 +1,113 @@
+package borg.trikeshed.cas
+
+/*
+ * MEASURED
+ * sources.size = 57
+ * receipt.novelCount = 7
+ * receipt.relocatedCount = 0
+ * receipt.inheritedCount = 1
+ * receipt.kept.size = 7
+ * receipt.dropped.size = 1
+ * residualAtoms = 14
+ * totalSourceAtoms = 2294
+ */
+
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.size
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import borg.trikeshed.lib.get
+
+class FunnelResidualMerge57WayEvidenceTest {
+
+    @Test
+    fun test57WayMerge() {
+        val masterLines = (0 until 40).map { "L${it.toString().padStart(2, '0')}" }
+        val masterText = masterLines.joinToString("\n")
+        val masterSpine = LineCas.spine(masterText)
+        val masterFunnel = FunnelResidualMerge.buildMasterFunnel(masterSpine)
+
+        val sources = mutableListOf<LineSpine>()
+
+        // S0..S6 (7 sources): share ONE identical novel line
+        val novelSharedLine = "NOVEL_SHARED"
+        for (i in 0 until 7) {
+            val lines = masterLines.toMutableList()
+            lines.add(10, novelSharedLine)
+            sources.add(LineCas.spine(lines.joinToString("\n")))
+        }
+
+        // S7..S13 (7 sources): each adds a UNIQUE novel line
+        for (i in 0 until 7) {
+            val lines = masterLines.toMutableList()
+            lines.add(20, "NOVEL_$i")
+            sources.add(LineCas.spine(lines.joinToString("\n")))
+        }
+
+        // S14..S20 (7 sources): relocate one master line
+        for (i in 0 until 7) {
+            val lines = masterLines.toMutableList()
+            val relocated = lines.removeAt(30)
+            lines.add(5, relocated)
+            sources.add(LineCas.spine(lines.joinToString("\n")))
+        }
+
+        // S21..S56 (36 sources): identical to M
+        for (i in 0 until 36) {
+            sources.add(LineCas.spine(masterText))
+        }
+
+        assertEquals(57, sources.size)
+
+        val sourcesSeries = sources.size j { i: Int -> sources[i] }
+        val receipt = FunnelResidualMerge.merge(sourcesSeries, masterFunnel)
+
+        val totalSourceAtoms = sources.sumOf { it.size }
+        val residualAtoms = sources.indices.sumOf { s ->
+            FunnelResidualMerge.residualsOf(sources[s], masterFunnel, FunnelResidualMerge.SourceIdx(s)).size
+        }
+
+        println("sources.size = ${sources.size}")
+        println("receipt.novelCount = ${receipt.novelCount}")
+        println("receipt.relocatedCount = ${receipt.relocatedCount}")
+        println("receipt.inheritedCount = ${receipt.inheritedCount}")
+        println("receipt.kept.size = ${receipt.kept.size}")
+        println("receipt.dropped.size = ${receipt.dropped.size}")
+        println("residualAtoms = $residualAtoms")
+        println("totalSourceAtoms = $totalSourceAtoms")
+
+        assertEquals(7, receipt.novelCount)
+        // Red test: Expected relocated behavior according to the 57-way test spec.
+        assertTrue(receipt.relocatedCount >= 1, "receipt.relocatedCount should be >= 1 but was ${receipt.relocatedCount}")
+        assertTrue(receipt.inheritedCount >= 1 || receipt.dropped.size > 0)
+        assertEquals(receipt.novelCount + receipt.relocatedCount, receipt.kept.size)
+
+        // Assert every kept NOVEL cluster comes from a single SourceIdx
+        for (i in 0 until receipt.kept.size) {
+            val gc = receipt.kept[i]
+            if (gc.grade == FunnelResidualMerge.ClusterGrade.NOVEL) {
+                val copyCount = gc.cluster.copies.size
+                assertTrue(copyCount == 1, "Expected NOVEL to have 1 copy, found $copyCount")
+            }
+        }
+
+        // Check NOVEL_SHARED logic (it should be INHERITED_CROSS)
+        var sharedFound = false
+        for (i in 0 until receipt.dropped.size) {
+            val gc = receipt.dropped[i]
+            if (gc.grade == FunnelResidualMerge.ClusterGrade.INHERITED_CROSS && gc.cluster.copies.size == 7) {
+                sharedFound = true
+            }
+        }
+        for (i in 0 until receipt.kept.size) {
+            val gc = receipt.kept[i]
+            if (gc.grade == FunnelResidualMerge.ClusterGrade.INHERITED_CROSS && gc.cluster.copies.size == 7) {
+                sharedFound = true
+            }
+        }
+        assertTrue(sharedFound, "Expected one cluster with copy-count 7 for NOVEL_SHARED")
+
+        assertTrue(residualAtoms < totalSourceAtoms)
+    }
+}


### PR DESCRIPTION
🎯 What
Added `FunnelResidualMerge57WayEvidenceTest` to test `FunnelResidualMerge.merge()` with a deterministic 57-source corpus. The test asserts cross-source logic for NOVEL and INHERITED clusters, cost reductions, and accurately captures the failing assertion for `relocatedCount` (measuring `0` instead of `>= 1`). Measured outcomes are documented at the top of the test file.

💡 Why
To provide actionable evidence proving whether the PRELOAD 57-way funnel residual merge algebra behaves according to its contract. Testing revealed a real behavioral divergence for relocated lines, which is documented as truthful RED evidence rather than being masked.

✅ Verification
Ran the `FunnelResidualMerge57WayEvidenceTest` using `./gradlew :jvmTest` focused run. 
Verified the measured output exactly matches the `MEASURED` block comment metrics (57 sources, 7 novel clusters, 0 relocated, 1 inherited, 7 kept, 1 dropped).

✨ Result
Provides the verifiable 57-way merge evidence as requested, documenting the current working claim accurately along with the discovered divergence.

---
*PR created automatically by Jules for task [14882254713366140435](https://jules.google.com/task/14882254713366140435) started by @jnorthrup*