### PR TITLE
Add UserSimulationMarkerTest for red-only TDD

### DIFF
--- a/src/jvmTest/kotlin/borg/trikeshed/memory/ontology/UserSimulationMarkerTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/memory/ontology/UserSimulationMarkerTest.kt
@@ -1,0 +1,14 @@
+package borg.trikeshed.memory.ontology
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class UserSimulationMarkerTest {
+    @Test
+    fun userSimulationIsUserCentricMarker() {
+        val gloss = UserSimulation.gloss
+        assertTrue(gloss.isNotEmpty(), "UserSimulation gloss should not be empty")
+        val marker: UserCentricMemory = UserSimulation
+        assertTrue(marker === UserSimulation)
+    }
+}


### PR DESCRIPTION
🎯 What
Add a compilation-failing test for an unimplemented `UserSimulation` object in `src/jvmTest/kotlin/borg/trikeshed/memory/ontology/UserSimulationMarkerTest.kt`.

💡 Why
To practice red-only TDD. The object `UserSimulation` and interface `UserCentricMemory` are intentionally unresolved to assert the failing state before production code is written.

✅ Verification
Ran `./gradlew compileTestKotlinJvm` and observed the expected `unresolved UserSimulation` compilation error.

✨ Result
Added the unstaged test file `UserSimulationMarkerTest.kt` ensuring the compilation failure.

---
*PR created automatically by Jules for task [2337649437410446224](https://jules.google.com/task/2337649437410446224) started by @jnorthrup*