### PR TITLE
🧹 [Implement robust createDirectories stub]

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
@@ -103,8 +103,39 @@ public object Files {
     public fun mismatch(path: Path, other: Path): Long = TODO("memcmp")
 
     // Directory operations
-    public fun createDirectory(path: Path, vararg attrs: FileAttribute<*>): Path = TODO("mkdir")
-    public fun createDirectories(path: Path, vararg attrs: FileAttribute<*>): Path = TODO("mkdir -p")
+    public fun createDirectory(path: Path, vararg attrs: FileAttribute<*>): Path {
+        path.getFileSystem().provider().createDirectory(path, *attrs)
+        return path
+    }
+
+    public fun createDirectories(path: Path, vararg attrs: FileAttribute<*>): Path {
+        var parent: Path? = path.getParent()
+        while (parent != null) {
+            try {
+                parent.getFileSystem().provider().checkAccess(parent)
+                break
+            } catch (_: Exception) {}
+            parent = parent.getParent()
+        }
+        var dir: Path? = path
+        val stack = mutableListOf<Path>()
+        while (dir != null && dir != parent) {
+            stack.add(dir)
+            dir = dir.getParent()
+        }
+        for (d in stack.reversed()) {
+            try {
+                createDirectory(d, *attrs)
+            } catch (e: Exception) {
+                var isDir = false
+                try {
+                    isDir = isDirectory(d)
+                } catch (_: Exception) {}
+                if (!isDir) throw e
+            }
+        }
+        return path
+    }
     public fun createFile(path: Path, vararg attrs: FileAttribute<*>): Path = TODO("creat")
     public fun createTempFile(dir: Path?, prefix: String?, suffix: String?, vararg attrs: FileAttribute<*>): Path = TODO("mkstemp")
     public fun createTempFile(prefix: String?, suffix: String?, vararg attrs: FileAttribute<*>): Path = createTempFile(null, prefix, suffix, *attrs)


### PR DESCRIPTION
🎯 **What:** Implemented `createDirectory` and `createDirectories` in `Files.kt`.

💡 **Why:** To replace `TODO` stubs with robust Java NIO-like logic that gracefully handles missing parent directories and handles existing directories appropriately. This removes the code health issue.

✅ **Verification:** Verified compilation via `./gradlew :jvmMainClasses --no-daemon` and passed all check builds. Code matches standard Java NIO behavior.

✨ **Result:** A robust, standard-compliant `mkdir -p` behavior at the NIO facade level without swallowing genuine file-collision exceptions or hallucinating new SPIs.

---
*PR created automatically by Jules for task [14456543179664976223](https://jules.google.com/task/14456543179664976223) started by @jnorthrup*