### PR TITLE
⚡ Bolt: Avoid intermediate list allocations from .toList().map in DescriptorFragments

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
@@ -366,6 +366,18 @@ fun ClosedRange<Int>.toSeries(): Series<Int> = (endInclusive - start + 1) j { i:
 fun <T> Sequence<T>.toSeries(): Series<T> = toList().toSeries()
 fun <T> Series<T>.toSequence(): Sequence<T> = Sequence { iterator() }
 
+// Bolt: inline map extensions to avoid allocating intermediate lists for Series operations.
+inline fun <T, R> Series<T>.map(transform: (T) -> R): List<R> {
+    val result = ArrayList<R>(size)
+    for (i in 0 until size) result.add(transform(this[i]))
+    return result
+}
+inline fun <T, R> Series<T>.mapIndexed(transform: (Int, T) -> R): List<R> {
+    val result = ArrayList<R>(size)
+    for (i in 0 until size) result.add(transform(i, this[i]))
+    return result
+}
+
 /** Materialize any Collection into a Series by copying into a List first. */
 fun <T> Collection<T>.toSeries(): Series<T> = toList().let { list -> list.size j list::get }
 

--- a/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
@@ -148,10 +148,10 @@ object StructuredParserSupport {
         val value = node.reify()
         val children =
             when (node) {
-                is YamlMappingNode -> node.entries.toList().map { entry ->
+                is YamlMappingNode -> node.entries.map { entry ->
                     describeYamlNode(entry.key.asString(), entry.value, depth + 1, totalLines)
                 }
-                is YamlSequenceNode -> node.items.toList().mapIndexed { index, child ->
+                is YamlSequenceNode -> node.items.mapIndexed { index, child ->
                     describeYamlNode(index.toString(), child, depth + 1, totalLines)
                 }
                 is YamlScalarNode -> emptyList()


### PR DESCRIPTION
💡 What: Implemented `map` and `mapIndexed` inline extensions for `Series` type and applied them in `DescriptorFragments.kt`.
🎯 Why: Calling `.toList().map { ... }` on a custom `Series` collection creates intermediate allocations (a temporary `List` from `toList()`, and the standard library `Iterable.map` which allocates an `Iterator` and creates the final `List`). By adding `inline` extensions for `Series.map` and `Series.mapIndexed`, we avoid the intermediate `toList()` allocation, avoid the `Iterator` allocation (by using a traditional `for` loop with index-based access `this[i]`), and pre-allocate the exact required `ArrayList` capacity.
📊 Impact: Reduces intermediate object allocations (`AbstractList`, `Iterator`, and intermediate `ArrayList` resizes) during YAML parsing, improving memory efficiency and GC pauses.
🔬 Measurement: Verify by compiling and running `DescriptorFragmentInteropTest` and profiling allocations during large YAML parsing tasks.

---
*PR created automatically by Jules for task [5643437272886105169](https://jules.google.com/task/5643437272886105169) started by @jnorthrup*