### PR TITLE
⚡ Bolt: Replace map.toList().toTypedArray() with zero-allocation idiom in ViewServer

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
@@ -489,9 +489,10 @@ private fun documentBytes(document: Document): ByteArray = canonicalFields(
 
 private fun resultBytes(result: ViewResult): ByteArray = canonicalFields(
     "view-result-v1",
-    *result.rows.sequence().map { row ->
+    *(result.rows.size j { i: Int ->
+        val row = result.rows[i]
         canonicalFields(row.docId, row.jsPath, canonicalValue(row.key), canonicalValue(row.value))
-    }.toList().toTypedArray(),
+    }).toArray<String>(),
 ).encodeToByteArray()
 
 private fun mapFunctionValue(map: MapFunction): String = when (map) {


### PR DESCRIPTION
💡 What: Replaced `.sequence().map { ... }.toList().toTypedArray()` with `(result.rows.size j { i -> ... }).toArray<String>()` in `ViewServer.resultBytes`.
🎯 Why: `ViewServer.resultBytes` used an inefficient chained map and conversion mapping across `Series`, creating unnecessary intermediate objects (`Sequence` and `List`).
📊 Impact: Avoids allocating redundant intermediate `List` instances when formatting ViewResult rows, improving throughput and reducing GC pressure during cache evaluation/receipts.
🔬 Measurement: Use of `j` array creation maps directly to Java Array without intermediary allocations in memory.

---
*PR created automatically by Jules for task [15930742661817423885](https://jules.google.com/task/15930742661817423885) started by @jnorthrup*