### PR TITLE
🎨 Palette: Add aria-label to document title

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@
 ## 2025-01-20 - Adding ARIA attributes to placeholders and contenteditable regions
 **Learning:** Inputs that only use the `placeholder` attribute for context (like a search bar or a column filter input) lack a reliable accessible name for screen readers, as the placeholder often disappears during typing or isn't spoken properly. Additionally, `contenteditable` elements, acting essentially as rich-text textareas, are opaque to screen readers if they lack an explicit label or `aria-label`.
 **Action:** Ensure that standalone inputs (especially search or filter fields without explicit `<label>` elements) always carry an `aria-label`. For interactive editor components like `contenteditable` divs, treat them as input regions and explicitly annotate them with an `aria-label` (e.g., `aria-label="Block content"`) to provide necessary context for screen reader users.
+
+## 2025-01-20 - Adding ARIA attributes to empty contenteditable headings
+**Learning:** Heading elements (like `<h1>`) that have `contenteditable="true"` but rely entirely on CSS pseudo-elements or data attributes (like `data-placeholder="Untitled"`) for empty states are completely invisible to screen readers' context. A screen reader will land on the element and report "heading level 1" or blank, omitting the crucial context of what text field the user is actually editing.
+**Action:** Always provide an explicit `aria-label` (e.g., `aria-label="Document title"`) on empty, editable heading or rich-text elements to ensure assistive technologies can describe the input intent accurately.

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -75,7 +75,7 @@
           <div class="doc-cover-spacer"></div>
           <div class="doc-title-row">
             <div class="doc-icon" id="doc-icon">▤</div>
-            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled"></h1>
+            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled" aria-label="Document title"></h1>
           </div>
           <div class="doc-blocks" id="doc-blocks"></div>
           <div class="doc-hint" id="doc-hint">Type <span class="doc-hint-key">/</span> for commands</div>


### PR DESCRIPTION
💡 What: Added `aria-label="Document title"` to the `doc-title` `<h1>` element in `index.html`, and documented the learning in `.Jules/palette.md`.
🎯 Why: Empty `contenteditable` headings (like the document title) are invisible to screen reader context if they rely on CSS/data-attributes for placeholders. This change provides explicit intent description for visually impaired users.
📸 Before/After: Visuals unchanged. Screen reader focus transitions from announcing "heading level 1" to "Document title, heading level 1, text edit".
♿ Accessibility: Ensures the primary input region has an explicit accessible name.

---
*PR created automatically by Jules for task [5097647521256844095](https://jules.google.com/task/5097647521256844095) started by @jnorthrup*