### PR TITLE
⚡ Bolt: [performance improvement] Optimize CausalGraph.inPhase

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -53,3 +53,7 @@
 ## 2024-08-11 - Replace filterValues().keys.toList() with entries.removeAll() for zero-allocation map eviction
 **Learning:** In Kotlin, replacing functional chains like `map.filterValues { ... }.keys.toList()` followed by map removal inside a loop with the in-place iterator method `map.entries.removeAll { ... }` changes the operation to an efficient O(N) zero-allocation removal, avoiding redundant intermediate collection instances.
 **Action:** Always refactor iterative functional map evictions to use `.entries.removeAll { ... }` instead of building intermediate Lists and HashMaps.
+
+## 2024-05-18 - Avoid O(N^2) bottlenecks when resolving causal phases
+**Learning:** `CausalGraph.inPhase` previously resolved the distinct set of `workId`s and mapped each one individually using a backwards scan `phaseOf(it)`, producing an O(N^2) time complexity.
+**Action:** When deriving phase maps over a casual graph or continuous event stream, use a single-pass `LinkedHashMap` to maintain the causal ordinal order while maintaining O(N) linear time execution.

--- a/src/commonMain/kotlin/borg/trikeshed/causal/CausalKernel.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/causal/CausalKernel.kt
@@ -342,10 +342,15 @@ fun CausalGraph.phaseOf(workId: String): CausalPhase {
 
 /** All workIds in a given phase. Stays Series<String>. */
 fun CausalGraph.inPhase(phase: CausalPhase): Series<String> {
-    // Collect distinct workIds, then filter by phase. This is O(n²) but n is
-    // bounded by WAL size and the distinct set is small (≤ hundreds).
-    val wids = (0 until size).map { this[it].workId }.toSet()
-    val matches = wids.filter { phaseOf(it) == phase }
+    val phaseByWid = LinkedHashMap<String, CausalPhase>()
+    for (i in 0 until size) {
+        val node = this[i]
+        phaseByWid[node.workId] = CausalPhase.fromLatestKind(node.kind)
+    }
+    val matches = ArrayList<String>()
+    for ((wid, p) in phaseByWid) {
+        if (p == phase) matches.add(wid)
+    }
     return matches.size j { i -> matches[i] }
 }
 


### PR DESCRIPTION
💡 What: Replaced O(N^2) distinct `workId` and `phaseOf` resolution in `CausalGraph.inPhase` with an O(N) optimized scan mapping `workId` to its most recent phase.
🎯 Why: Avoid generating intermediate sets and performing redundant nested `latestFor` sweeps (each being O(N)), preventing GC pressure and latency spikes during graph evaluation.
📊 Impact: O(N^2) complexity reduced to O(N) single-pass scanning.
🔬 Measurement: Observe reduction in object allocations and execution time in `CausalGraph.inPhase` calls.

---
*PR created automatically by Jules for task [17631407667318715856](https://jules.google.com/task/17631407667318715856) started by @jnorthrup*