### PR TITLE
🎨 Palette: Improve accessibility on contenteditable doc title

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -75,7 +75,7 @@
           <div class="doc-cover-spacer"></div>
           <div class="doc-title-row">
             <div class="doc-icon" id="doc-icon" aria-hidden="true">▤</div>
-            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled"></h1>
+            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled" aria-label="Document title"></h1>
           </div>
           <div class="doc-blocks" id="doc-blocks"></div>
           <div class="doc-hint" id="doc-hint">Type <span class="doc-hint-key">/</span> for commands</div>


### PR DESCRIPTION
💡 What: Added `aria-label="Document title"` to the `contenteditable` `<h1>` for the document title in `index.html`.

🎯 Why: Heading elements that act as rich-text inputs (`contenteditable="true"`) but are visually empty relying on CSS `data-placeholder` are completely invisible to screen readers without an explicit label. This change ensures screen reader users have the necessary context when navigating to edit the document title.

📸 Before/After: N/A - pure DOM attribute change.

♿ Accessibility: Ensures assistive technologies can accurately describe the purpose of the empty, editable heading to visually impaired users, conforming to standard a11y practices for rich text inputs.

---
*PR created automatically by Jules for task [16296128346207533126](https://jules.google.com/task/16296128346207533126) started by @jnorthrup*