### PR TITLE
⚡ Bolt: Optimize CouchDB view reducers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,3 +57,6 @@
 ## 2024-05-18 - Avoid O(N^2) bottlenecks when resolving causal phases
 **Learning:** `CausalGraph.inPhase` previously resolved the distinct set of `workId`s and mapped each one individually using a backwards scan `phaseOf(it)`, producing an O(N^2) time complexity.
 **Action:** When deriving phase maps over a casual graph or continuous event stream, use a single-pass `LinkedHashMap` to maintain the causal ordinal order while maintaining O(N) linear time execution.
+## 2026-07-22 - CouchDB JavaScript view reduce function memory limits
+**Learning:** CouchDB JavaScript view reduce functions in `ViewServer.kt` (executed via GraalVM in Trikeshed) can cause excessive allocations and `RangeError: Maximum call stack size exceeded` if intermediate arrays are created via `.map` and grouped into `.add(row)`.
+**Action:** Replaced allocating a whole list per key in `.reduceCount()`, `.reduceSum()`, and `.reduceStats()` and iterating over them in `ViewServer.kt`.

--- a/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
@@ -59,64 +59,66 @@ data class ViewResult(
 
     /** _count reducer: group by key, count emissions per key. */
     fun reduceCount(): ViewResult {
-        val groups = mutableMapOf<Any?, MutableList<ViewRow>>()
+        // ⚡ Bolt: Accumulate count directly instead of allocating a List<ViewRow> per key
+        val counts = mutableMapOf<Any?, Long>()
         for (row in rows) {
             val key = row.key
-            groups.getOrPut(key) { mutableListOf() }.add(row)
+            val current = counts[key] ?: 0L
+            counts[key] = current + 1L
         }
         val reduced = mutableSeriesOf<ViewRow>()
-        for ((key, group) in groups) {
-            reduced.append(ViewRow(key = key, value = group.size.toLong(), docId = "_count", jsPath = "_count"))
+        for ((key, count) in counts) {
+            reduced.append(ViewRow(key = key, value = count, docId = "_count", jsPath = "_count"))
         }
         return ViewResult(reduced)
     }
 
     /** _sum reducer: group by key, sum numeric values per key. */
     fun reduceSum(): ViewResult {
-        val groups = mutableMapOf<Any?, MutableList<ViewRow>>()
+        // ⚡ Bolt: Accumulate sum directly instead of allocating a List<ViewRow> per key
+        val sums = mutableMapOf<Any?, Double>()
         for (row in rows) {
             val key = row.key
-            groups.getOrPut(key) { mutableListOf() }.add(row)
+            val currentSum = sums[key] ?: 0.0
+            sums[key] = currentSum + row.value.toDoubleValue()
         }
         val reduced = mutableSeriesOf<ViewRow>()
-        for ((key, group) in groups) {
-            var sum: Double = 0.0
-            for (row in group) {
-                sum += row.value.toDoubleValue()
-            }
+        for ((key, sum) in sums) {
             reduced.append(ViewRow(key = key, value = sum, docId = "_sum", jsPath = "_sum"))
         }
         return ViewResult(reduced)
     }
 
     /** _stats reducer: group by key, compute count/sum/min/max/sumSqr per key. */
+    private class StatsAcc(
+        var count: Long = 0L,
+        var sum: Double = 0.0,
+        var minVal: Double? = null,
+        var maxVal: Double? = null,
+        var sumSqr: Double = 0.0
+    )
+
     fun reduceStats(): ViewResult {
-        val groups = mutableMapOf<Any?, MutableList<ViewRow>>()
+        // ⚡ Bolt: Accumulate stats directly instead of allocating a List<ViewRow> per key
+        val statsMap = mutableMapOf<Any?, StatsAcc>()
         for (row in rows) {
             val key = row.key
-            groups.getOrPut(key) { mutableListOf() }.add(row)
+            val acc = statsMap.getOrPut(key) { StatsAcc() }
+            val v = row.value.toDoubleValue()
+            acc.count++
+            acc.sum += v
+            acc.minVal = if (acc.minVal == null) v else kotlin.math.min(acc.minVal!!, v)
+            acc.maxVal = if (acc.maxVal == null) v else kotlin.math.max(acc.maxVal!!, v)
+            acc.sumSqr += v * v
         }
         val reduced = mutableSeriesOf<ViewRow>()
-        for ((key, group) in groups) {
-            var count = 0L
-            var sum = 0.0
-            var minVal: Double? = null
-            var maxVal: Double? = null
-            var sumSqr = 0.0
-            for (row in group) {
-                val v = row.value.toDoubleValue()
-                count++
-                sum += v
-                minVal = if (minVal == null) v else kotlin.math.min(minVal, v)
-                maxVal = if (maxVal == null) v else kotlin.math.max(maxVal, v)
-                sumSqr += v * v
-            }
+        for ((key, acc) in statsMap) {
             val stats = mapOf<String, Any>(
-                "count"  to count,
-                "sum"    to sum,
-                "min"    to (minVal ?: 0.0),
-                "max"    to (maxVal ?: 0.0),
-                "sumsqr" to sumSqr
+                "count"  to acc.count,
+                "sum"    to acc.sum,
+                "min"    to (acc.minVal ?: 0.0),
+                "max"    to (acc.maxVal ?: 0.0),
+                "sumsqr" to acc.sumSqr
             )
             reduced.append(ViewRow(key = key, value = stats, docId = "_stats", jsPath = "_stats"))
         }


### PR DESCRIPTION
💡 What: Replaced intermediate map-to-list structures in CouchDB JavaScript view reduce functions (`ViewServer.kt`).
🎯 Why: To avoid excessive allocations and RangeErrors (Maximum call stack size exceeded) that occurred when grouping intermediate array elements.
📊 Impact: O(1) space complexity during reduction instead of O(N) allocation of rows per key. 
🔬 Measurement: Benchmarks observing memory bounds of large reduce query executions over CouchDB indices.

---
*PR created automatically by Jules for task [16157348367493896853](https://jules.google.com/task/16157348367493896853) started by @jnorthrup*