### PR TITLE
🛡️ Sentinel: Fix Predictable Model Response Receipt ID

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/modelmux/ModelResponse.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/modelmux/ModelResponse.kt
@@ -1,5 +1,7 @@
 package borg.trikeshed.modelmux
 
+import modelmux.defaultSecureIdGenerator
+
 data class ModelResponse(
     val content: String,
     val usage: ModelUsage,
@@ -74,7 +76,7 @@ data class ModelResponseReceipt(
             sessionId: String? = null,
             error: Throwable? = null,
         ): ModelResponseReceipt = ModelResponseReceipt(
-            receiptId = "mrec-${kotlin.random.Random.nextLong().toString(16)}",
+            receiptId = defaultSecureIdGenerator.generateHexId("mrec", 8),
             modelId = modelId,
             providerId = providerId,
             requestHash = requestHash,


### PR DESCRIPTION
Replace `Random.nextLong()` with `SecureIdGenerator` to ensure IDs are generated using a cryptographically secure pseudo-random number generator (CSPRNG). Verified by running the test suite.

---
*PR created automatically by Jules for task [10796469202122064533](https://jules.google.com/task/10796469202122064533) started by @jnorthrup*