### PR TITLE
🎨 Palette: Add ARIA labels to contenteditable regions

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -75,7 +75,7 @@
           <div class="doc-cover-spacer"></div>
           <div class="doc-title-row">
             <div class="doc-icon" id="doc-icon" aria-hidden="true">▤</div>
-            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled"></h1>
+            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" aria-label="Document title" data-placeholder="Untitled"></h1>
           </div>
           <div class="doc-blocks" id="doc-blocks"></div>
           <div class="doc-hint" id="doc-hint">Type <span class="doc-hint-key">/</span> for commands</div>

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -307,6 +307,7 @@
     content.contentEditable = 'true';
     content.spellcheck = false;
     content.dataset.placeholder = def.placeholder;
+    content.setAttribute('aria-label', 'Block content');
     content.textContent = block.text || '';
     el.appendChild(content);
 


### PR DESCRIPTION
💡 What
Added `aria-label` attributes to the `contenteditable` regions in the UI. Specifically, `#doc-title` now has `aria-label="Document title"` and `.block-content` elements receive `aria-label="Block content"`.

🎯 Why
Empty `contenteditable` elements, like the document title placeholder, are invisible to screen readers without an accessible name. A screen reader user would land on the title field and hear "heading level 1" with no context of what the field is for. Adding `aria-label` ensures these editor regions provide the correct context to assistive technologies.

📸 Before/After
Before: 
`<h1 class="doc-title" id="doc-title" contenteditable="true" ...></h1>`
`<div class="block-content" contenteditable="true" ...></div>`

After: 
`<h1 class="doc-title" id="doc-title" contenteditable="true" aria-label="Document title" ...></h1>`
`<div class="block-content" contenteditable="true" aria-label="Block content" ...></div>`

♿ Accessibility
This directly improves the screen reader experience by labeling the main rich-text input areas, preventing them from being announced as empty or generic layout nodes.

---
*PR created automatically by Jules for task [2415992893472250768](https://jules.google.com/task/2415992893472250768) started by @jnorthrup*