### PR TITLE
🎨 Palette: Add ARIA label to document title input

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -75,7 +75,7 @@
           <div class="doc-cover-spacer"></div>
           <div class="doc-title-row">
             <div class="doc-icon" id="doc-icon" aria-hidden="true">▤</div>
-            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled"></h1>
+            <h1 class="doc-title" id="doc-title" contenteditable="true" spellcheck="false" data-placeholder="Untitled" aria-label="Document title"></h1>
           </div>
           <div class="doc-blocks" id="doc-blocks"></div>
           <div class="doc-hint" id="doc-hint">Type <span class="doc-hint-key">/</span> for commands</div>


### PR DESCRIPTION
💡 What: Added an `aria-label` to the document title `contenteditable` heading.
🎯 Why: To ensure screen readers can announce the empty `contenteditable` region acting as a standalone document title input, rather than just announcing "heading level 1" with no context.
📸 Before/After: Visual changes are not applicable for this a11y enhancement.
♿ Accessibility: Improved screen reader context for the document title input.

---
*PR created automatically by Jules for task [18078143602917286182](https://jules.google.com/task/18078143602917286182) started by @jnorthrup*