### PR TITLE
⚡ Bolt: avoid intermediate list allocations from .toList().map

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
@@ -148,10 +148,12 @@ object StructuredParserSupport {
         val value = node.reify()
         val children =
             when (node) {
-                is YamlMappingNode -> node.entries.toList().map { entry ->
+                // ⚡ Bolt: Removed .toList() before .map to avoid creating intermediate ArrayLists during AST traversal.
+                is YamlMappingNode -> node.entries.map { entry ->
                     describeYamlNode(entry.key.asString(), entry.value, depth + 1, totalLines)
                 }
-                is YamlSequenceNode -> node.items.toList().mapIndexed { index, child ->
+                // ⚡ Bolt: Removed .toList() before .mapIndexed to prevent O(N) allocation per YAML sequence element.
+                is YamlSequenceNode -> node.items.mapIndexed { index, child ->
                     describeYamlNode(index.toString(), child, depth + 1, totalLines)
                 }
                 is YamlScalarNode -> emptyList()


### PR DESCRIPTION
💡 What:
Removed `.toList()` calls prior to `.map` and `.mapIndexed` in `DescriptorFragments.kt` for `YamlMappingNode` and `YamlSequenceNode` serialization paths.

🎯 Why:
The application of `.toList()` before `.map` creates an unnecessary intermediate `ArrayList` allocation. By directly using the `Series` inline extensions (`.map` / `.mapIndexed`), the elements are transformed directly into the result `List`, eliminating the intermediate step and avoiding O(N) allocation per YAML sequence/mapping element during AST traversal.

📊 Impact:
Reduces intermediate `ArrayList` memory allocations by O(N) where N is the number of elements in a YAML mapping or sequence being processed. This reduces GC pressure, especially when parsing large or deeply nested YAML structures.

🔬 Measurement:
Verified via code review and successful build execution. Tests in `DescriptorFragmentInteropTest` continue to pass successfully.

---
*PR created automatically by Jules for task [5485923324510712179](https://jules.google.com/task/5485923324510712179) started by @jnorthrup*