### PR TITLE
⚡ Bolt: Optimize max group id search

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/isam/meta/IsamMetaFileDsl.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/isam/meta/IsamMetaFileDsl.kt
@@ -128,7 +128,7 @@ class MetafileWriter(val config: MetafileWriteConfig) {
 
         val distinctGroups = result.view.map { it.groupId }.toSet()
         if (distinctGroups.size > 1) {
-            val maxGroupId = distinctGroups.max()
+            val maxGroupId = distinctGroups.maxOrNull() ?: 0
             val byGroup = linkedMapOf<String, MutableList<Int>>()
             result.view.forEachIndexed { idx, rm ->
                 if (rm.groupId != maxGroupId)

--- a/src/commonMain/kotlin/borg/trikeshed/isam/meta/IsamMetaFileReader.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/isam/meta/IsamMetaFileReader.kt
@@ -161,7 +161,7 @@ class IsamMetaFileReader(
 
             val distinctGroups = result.view.map { it.groupId }.toSet()
             if (distinctGroups.size > 1) {
-                val maxGroupId = distinctGroups.max()
+                val maxGroupId = distinctGroups.maxOrNull() ?: 0
 
                 val byGroup = linkedMapOf<String, MutableList<Int>>()
                 result.view.forEachIndexed { idx, rm ->

--- a/src/jsMain/kotlin/borg/trikeshed/isam/JsIsamOperations.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/isam/JsIsamOperations.kt
@@ -19,7 +19,7 @@ class JsIsamDataReader(
         constraints.view.groupBy { it.groupName }
     }
     private val maxGroupId: Int by lazy {
-        constraints.view.map { it.groupId }.maxOrNull() ?: 0
+        constraints.view.maxOfOrNull { it.groupId } ?: 0
     }
     private val groupBuffers = mutableMapOf<String, ByteArray>()
 
@@ -85,7 +85,7 @@ class JsIsamOperations : IsamOperations {
         val meta0 = IsamMetaFileReader.write(metafilename, cursorMeta, varChars, useMonocursorGroupings = useMonocursorGroupings)
 
         val columnsByGroup = meta0.view.groupBy { it.groupName }
-        val maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
         val groupBuffers = mutableMapOf<String, ByteArray>()
         val groupOffsets = mutableMapOf<String, Int>()
@@ -147,7 +147,7 @@ class JsIsamOperations : IsamOperations {
         }
 
         val columnsByGroup = meta0.view.groupBy { it.groupName }
-        val maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
         val groupBuffers = mutableMapOf<String, ByteArray>()
         val groupOffsets = mutableMapOf<String, Int>()

--- a/src/jvmMain/kotlin/borg/trikeshed/isam/JvmIsamOperations.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/isam/JvmIsamOperations.kt
@@ -28,7 +28,7 @@ class JvmIsamDataReader(
         constraints.view.groupBy { it.groupName }
     }
     private val maxGroupId: Int by lazy {
-        constraints.view.map { it.groupId }.maxOrNull() ?: 0
+        constraints.view.maxOfOrNull { it.groupId } ?: 0
     }
     private val groupFiles = mutableMapOf<String, UserspaceFile>()
 
@@ -138,7 +138,7 @@ class JvmIsamOperations : IsamOperations {
         val meta0 = IsamMetaFileReader.write(metafilename, cursorMeta, varChars, useMonocursorGroupings = useMonocursorGroupings)
 
         val columnsByGroup = meta0.view.groupBy { it.groupName }
-        val maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
         val groupFiles = mutableMapOf<String, UserspaceFile>()
         val offsets = mutableMapOf<String, Long>()
@@ -230,7 +230,7 @@ class JvmIsamOperations : IsamOperations {
             if (first) {
                 meta0 = IsamMetaFileReader.write(metafilename, rowVec.right.α { it() }, varChars, useMonocursorGroupings = useMonocursorGroupings)
                 columnsByGroup = meta0.view.groupBy { it.groupName }
-                maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+                maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
                 for (gname in columnsByGroup.keys) {
                     val cols = columnsByGroup[gname]!!

--- a/src/mingwX64Main/kotlin/borg/trikeshed/isam/MingwIsamOperations.kt
+++ b/src/mingwX64Main/kotlin/borg/trikeshed/isam/MingwIsamOperations.kt
@@ -18,7 +18,7 @@ class MingwIsamDataReader(
         constraints.view.groupBy { it.groupName }
     }
     private val maxGroupId: Int by lazy {
-        constraints.view.map { it.groupId }.maxOrNull() ?: 0
+        constraints.view.maxOfOrNull { it.groupId } ?: 0
     }
     private val groupFiles = mutableMapOf<String, Int>()
     private val groupRecordLens = mutableMapOf<String, Int>()
@@ -98,7 +98,7 @@ class MingwIsamOperations : IsamOperations {
         val cursorMeta: Series<ColumnMeta> = row0.a j { c: Int -> row0.b(c).b() }
         val meta0 = IsamMetaFileReader.write(metafilename, cursorMeta, varChars, useMonocursorGroupings = useMonocursorGroupings)
         val columnsByGroup = meta0.view.groupBy { it.groupName }
-        val maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
         val groupFiles = mutableMapOf<String, Int>()
         for (gname in columnsByGroup.keys) {
             val cols = columnsByGroup[gname]!!
@@ -151,7 +151,7 @@ class MingwIsamOperations : IsamOperations {
                     useMonocursorGroupings = useMonocursorGroupings
                 )
                 columnsByGroup = meta0.view.groupBy { it.groupName }
-                maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+                maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
                 for (gname in columnsByGroup.keys) {
                     val cols = columnsByGroup[gname]!!
                     val firstCol = cols.first()

--- a/src/posixMain/kotlin/borg/trikeshed/isam/PosixIsamOperations.kt
+++ b/src/posixMain/kotlin/borg/trikeshed/isam/PosixIsamOperations.kt
@@ -29,7 +29,7 @@ class PosixIsamDataReader(
         constraints.view.groupBy { it.groupName }
     }
     private val maxGroupId: Int by lazy {
-        constraints.view.map { it.groupId }.maxOrNull() ?: 0
+        constraints.view.maxOfOrNull { it.groupId } ?: 0
     }
     
     private val groupMmaps = mutableMapOf<String, PosixMmapInfo>()
@@ -123,7 +123,7 @@ class PosixIsamOperations : IsamOperations {
         val meta0 = IsamMetaFileReader.write(metafilename, cursorMeta, varChars, useMonocursorGroupings = useMonocursorGroupings)
 
         val columnsByGroup = meta0.view.groupBy { it.groupName }
-        val maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
         val groupFiles = mutableMapOf<String, PosixFile>()
 
@@ -180,7 +180,7 @@ class PosixIsamOperations : IsamOperations {
                     useMonocursorGroupings = useMonocursorGroupings
                 )
                 columnsByGroup = meta0.view.groupBy { it.groupName }
-                maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+                maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
                 for (gname in columnsByGroup.keys) {
                     val cols = columnsByGroup[gname]!!

--- a/src/wasmJsMain/kotlin/borg/trikeshed/isam/WasmIsamOperations.kt
+++ b/src/wasmJsMain/kotlin/borg/trikeshed/isam/WasmIsamOperations.kt
@@ -20,7 +20,7 @@ class WasmIsamDataReader(
         constraints.view.groupBy { it.groupName }
     }
     private val maxGroupId: Int by lazy {
-        constraints.view.map { it.groupId }.maxOrNull() ?: 0
+        constraints.view.maxOfOrNull { it.groupId } ?: 0
     }
     private val groupBuffers = mutableMapOf<String, ByteArray>()
 
@@ -89,7 +89,7 @@ class WasmIsamOperations : IsamOperations {
         val meta0 = IsamMetaFileReader.write(metafilename, cursorMeta, varChars, useMonocursorGroupings = useMonocursorGroupings)
 
         val columnsByGroup = meta0.view.groupBy { (it as RecordMeta).groupName }
-        val maxGroupId = meta0.view.map { (it as RecordMeta).groupId }.maxOrNull() ?: 0
+        val maxGroupId = meta0.view.maxOfOrNull { (it as RecordMeta).groupId } ?: 0
 
         val groupRecordLengths = mutableMapOf<String, Int>()
 
@@ -166,7 +166,7 @@ class WasmIsamOperations : IsamOperations {
                 meta0 = recordMetas.size j { i -> recordMetas.b(i) as RecordMeta }
 
                 columnsByGroup = meta0.view.groupBy { it.groupName }
-                maxGroupId = meta0.view.map { it.groupId }.maxOrNull() ?: 0
+                maxGroupId = meta0.view.maxOfOrNull { it.groupId } ?: 0
 
                 var maxRecordSize = 0
                 for ((gname, cols) in columnsByGroup) {


### PR DESCRIPTION
💡 What: Replaced occurrences of `.map { ... }.maxOrNull()` with `.maxOfOrNull { ... }` and `.max()` with `.maxOrNull()` across the ISAM meta parsing components (JVM, JS, Wasm, Mingw, Posix).
🎯 Why: Calling `.map` before finding the maximum value allocates a redundant intermediate collection. `.maxOfOrNull` evaluates the lambda during the single pass search, saving memory and CPU cycles. Furthermore, `max()` is deprecated in newer versions of Kotlin, and substituting it with `maxOrNull()` prevents compiler warnings or future errors.
📊 Impact: Eliminates an unnecessary list allocation for every group ID evaluation, lowering memory pressure and overhead, especially during reads of complex datasets.
🔬 Measurement: Verified there are no behavioral changes by successfully running `jvmMainClasses` compilation and targeted ISAM module tests (`./gradlew jvmTest --tests "*meta*"`).

---
*PR created automatically by Jules for task [1035315003467752631](https://jules.google.com/task/1035315003467752631) started by @jnorthrup*