### PR TITLE
⚡ Bolt: Optimize YAML descriptor generation by removing redundant .toList() allocations

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/parse/interop/DescriptorFragments.kt
@@ -148,10 +148,10 @@ object StructuredParserSupport {
         val value = node.reify()
         val children =
             when (node) {
-                is YamlMappingNode -> node.entries.toList().map { entry ->
+                is YamlMappingNode -> node.entries.map { entry ->
                     describeYamlNode(entry.key.asString(), entry.value, depth + 1, totalLines)
                 }
-                is YamlSequenceNode -> node.items.toList().mapIndexed { index, child ->
+                is YamlSequenceNode -> node.items.mapIndexed { index, child ->
                     describeYamlNode(index.toString(), child, depth + 1, totalLines)
                 }
                 is YamlScalarNode -> emptyList()


### PR DESCRIPTION
💡 What: The optimization removes two `.toList()` conversions inside `DescriptorFragments.kt`'s `describeYamlNode` function, allowing `.map` and `.mapIndexed` to operate directly on the Series without pre-allocating an intermediate list.
🎯 Why: In Trikeshed, mapping operations over `Series` (which is functionally an indexed interface) typically generate a target representation in one pass. By invoking `.toList()` before `.map {}` or `.mapIndexed {}`, the code unnecessarily forces the creation and immediate garbage collection of intermediate Java `ArrayList`s inside a highly recursive YAML syntax tree traversal.
📊 Impact: Eliminates O(N) intermediate `ArrayList` allocations across every single node and mapping entry in an incoming YAML document, drastically reducing GC pressure on large configurations.
🔬 Measurement: Run `./gradlew :jvmMainClasses` to verify build success, then profile a standard JVM process generating descriptor fragments on large YAML documents to observe reduced allocations in the young generation.

---
*PR created automatically by Jules for task [7541678469339298467](https://jules.google.com/task/7541678469339298467) started by @jnorthrup*