### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons by hiding decorative icons

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/BlockEditor.kt
@@ -54,14 +54,14 @@ class BlockEditor(var block: LcncBlock, val ingestState: IngestStateElement) {
             
             // Block Controls (Move up, move down, insert, delete, indent, outdent)
             div(classes = "lcnc-block-controls") {
-                text("<button onclick=\"window.lcncMoveBlockUp('${block.id}')\" aria-label=\"Move block up\" title=\"Move block up\">↑</button>")
-                text("<button onclick=\"window.lcncMoveBlockDown('${block.id}')\" aria-label=\"Move block down\" title=\"Move block down\">↓</button>")
-                text("<button onclick=\"window.lcncIndentBlock('${block.id}')\" aria-label=\"Indent block\" title=\"Indent block\">→</button>")
-                text("<button onclick=\"window.lcncOutdentBlock('${block.id}')\" aria-label=\"Outdent block\" title=\"Outdent block\">←</button>")
+                text("<button onclick=\"window.lcncMoveBlockUp('${block.id}')\" aria-label=\"Move block up\" title=\"Move block up\"><span aria-hidden=\"true\">↑</span></button>")
+                text("<button onclick=\"window.lcncMoveBlockDown('${block.id}')\" aria-label=\"Move block down\" title=\"Move block down\"><span aria-hidden=\"true\">↓</span></button>")
+                text("<button onclick=\"window.lcncIndentBlock('${block.id}')\" aria-label=\"Indent block\" title=\"Indent block\"><span aria-hidden=\"true\">→</span></button>")
+                text("<button onclick=\"window.lcncOutdentBlock('${block.id}')\" aria-label=\"Outdent block\" title=\"Outdent block\"><span aria-hidden=\"true\">←</span></button>")
                 
                 // Block creation menu
                 text("<div class=\"lcnc-block-menu\">")
-                text("<button onclick=\"window.lcncInsertBlock('${block.id}')\" aria-label=\"Insert new block\" title=\"Insert new block\">+</button>")
+                text("<button onclick=\"window.lcncInsertBlock('${block.id}')\" aria-label=\"Insert new block\" title=\"Insert new block\"><span aria-hidden=\"true\">+</span></button>")
                 text("<select onchange=\"window.lcncChangeBlockType('${block.id}', this.value)\" aria-label=\"Change block type\">")
                 text("<option value=\"paragraph\"${if(block.type=="paragraph") " selected" else ""}>Text</option>")
                 text("<option value=\"heading_1\"${if(block.type=="heading_1") " selected" else ""}>Heading 1</option>")
@@ -74,7 +74,7 @@ class BlockEditor(var block: LcncBlock, val ingestState: IngestStateElement) {
                 text("</select>")
                 text("</div>")
 
-                text("<button onclick=\"window.lcncDeleteBlock('${block.id}')\" aria-label=\"Delete block\" title=\"Delete block\">x</button>")
+                text("<button onclick=\"window.lcncDeleteBlock('${block.id}')\" aria-label=\"Delete block\" title=\"Delete block\"><span aria-hidden=\"true\">x</span></button>")
             }
 
             // Block Content editable area

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
@@ -74,8 +74,8 @@ class DatabaseView(var database: LcncDatabase, val ingestState: IngestStateEleme
             for (prop in schema.properties.values) {
                 text("<th>")
                 text("<button class=\"lcnc-database-sort\" data-column=\"${prop.id}\" onclick=\"window.lcncSortColumn('${database.id}', '${prop.id}')\" aria-label=\"Sort by ${prop.name}\" title=\"Sort by ${prop.name}\">${prop.name}</button>")
-                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\" aria-label=\"Delete column\" title=\"Delete column\">x</button>")
-                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\" aria-label=\"Rename column\" title=\"Rename column\">✎</button>")
+                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\" aria-label=\"Delete column\" title=\"Delete column\"><span aria-hidden=\"true\">x</span></button>")
+                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\" aria-label=\"Rename column\" title=\"Rename column\"><span aria-hidden=\"true\">✎</span></button>")
                 text("</th>")
             }
             text("<th>Actions</th>")


### PR DESCRIPTION
**💡 What:** Wrapped unicode symbols (`↑`, `↓`, `→`, `←`, `+`, `x`, `✎`) inside icon-only buttons with `<span aria-hidden="true">` in `BlockEditor.kt` and `DatabaseView.kt`.
**🎯 Why:** To reduce screen reader noise. When an icon-only button already has an `aria-label`, the unicode symbol inside should be hidden from assistive technologies to avoid redundant or confusing announcements.
**♿ Accessibility:** Hidden decorative elements from screen readers while preserving the accessible name provided by the parent button's `aria-label`.

---
*PR created automatically by Jules for task [8525627826776804877](https://jules.google.com/task/8525627826776804877) started by @jnorthrup*