### PR TITLE
feat(tspy): add GraalPy Context resource config

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/tspy/TspyPolyglotHost.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/tspy/TspyPolyglotHost.kt
@@ -1,0 +1,41 @@
+package borg.trikeshed.tspy
+
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.HostAccess
+import org.graalvm.polyglot.ResourceLimits
+
+/**
+ * Configuration for the GraalPy Context in TrikeShed's tspy module.
+ */
+object ContextConfig {
+    /**
+     * Path to the Python module sources, specifically pointing to the tspy bootstrap module.
+     */
+    const val PYTHON_PATH = "utils/tspy/src/python"
+
+    /**
+     * Statement limit for sandboxed eval.
+     */
+    const val STATEMENT_LIMIT = 10000L
+}
+
+class TspyPolyglotHost : AutoCloseable {
+
+    private val context: Context = Context.newBuilder("python")
+        .allowHostAccess(HostAccess.NONE)
+        .option("python.Path", ContextConfig.PYTHON_PATH)
+        .resourceLimits(
+            ResourceLimits.newBuilder()
+                .statementLimit(ContextConfig.STATEMENT_LIMIT, null)
+                .build()
+        )
+        .build()
+
+    fun eval(sourceCode: String): org.graalvm.polyglot.Value {
+        return context.eval("python", sourceCode)
+    }
+
+    override fun close() {
+        context.close()
+    }
+}


### PR DESCRIPTION
💡 What
Added `TspyPolyglotHost` and `ContextConfig` to properly initialize and configure the GraalPy Context for the `tspy` module. 

🎯 Why
Debt in `build.gradle.kts:222-224` declares `org.graalvm.polyglot:python-community` but no context/engine configuration was present for module loading (e.g., `python.Path`, statement limits for sandboxed eval).

✅ Verification
Compiled successfully with `./gradlew jvmMainClasses --console=plain --no-daemon`.

---
*PR created automatically by Jules for task [2791542844799691260](https://jules.google.com/task/2791542844799691260) started by @jnorthrup*