### PR TITLE
🎨 Palette: Add accessible loading indicator to PalettePicker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,11 @@
 ## 2025-01-20 - Hiding decorative icons with aria-hidden
 **Learning:** When using Unicode symbols (like ⌕, ⌂, ▦, ⬇, ▤) purely for visual decoration next to descriptive text, screen readers will try to announce the symbol. This creates unnecessary auditory noise and degrades the user experience.
 **Action:** Always apply `aria-hidden="true"` to decorative elements, especially Unicode symbols or SVGs, when they are paired with actual accessible text or contained within a parent element that already provides an adequate `aria-label`.
+
+## 2026-08-16 - Expanded context on aria-label for text buttons
+**Learning:** While WCAG 2.5.3 (Label in Name) dictates that an `aria-label` should contain the visible text of a button, it's often a mistake to remove an `aria-label` simply because the button has visible text. In many cases, the visible text is short (e.g., "New Doc", "Sync") to save UI space, while the `aria-label` provides crucial expanded context for screen reader users (e.g., "Create new document", "Synchronize workspace"). Removing the `aria-label` degrades accessibility in these scenarios.
+**Action:** Do not remove existing `aria-label` attributes from buttons with short visible text if the `aria-label` provides expanded, helpful context. Only remove them if they are truly redundant or negatively conflict with the visible text in a way that breaks accessibility tools.
+
+## 2026-08-16 - Accessible loading states
+**Learning:** When displaying a loading indicator (like a spinner or progress bar) that replaces the main content, keyboard users and screen readers might not immediately perceive the change in state.
+**Action:** When creating a Compose loading indicator that takes over the view, add a `FocusRequester`, apply the `focusable()` modifier to the indicator, and use a `LaunchedEffect` to request focus on the indicator when it becomes visible. This ensures the user's focus is directed to the loading state.

--- a/src/commonMain/kotlin/ui/palette/PalettePicker.kt
+++ b/src/commonMain/kotlin/ui/palette/PalettePicker.kt
@@ -1,0 +1,39 @@
+package ui.palette
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.foundation.focusable
+
+@Composable
+fun PalettePicker(isLoading: Boolean, colors: List<String>) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (isLoading) {
+            val focusRequester = remember { FocusRequester() }
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .focusable()
+                    .focusRequester(focusRequester)
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(colors) { color ->
+                    Text(text = color)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
💡 What: Created `PalettePicker` with a `CircularProgressIndicator` that shows while data is loading.
🎯 Why: Provides visual feedback during data fetching.
📸 Before/After: None (new file).
♿ Accessibility: Added a `FocusRequester` so the loading indicator receives focus when visible, ensuring keyboard users perceive the loading state.

---
*PR created automatically by Jules for task [9839882756147761028](https://jules.google.com/task/9839882756147761028) started by @jnorthrup*