### PR TITLE
Fix Gap R5: deterministically reject xattr/mode/stat accessors

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
@@ -135,13 +135,13 @@ public object Files {
     public fun readSymbolicLink(link: Path): Path = link.getFileSystem().provider().readSymbolicLink(link)
 
     // Attributes
-    public fun <A : BasicFileAttributes> readAttributes(path: Path, type: kotlin.reflect.KClass<A>, vararg options: LinkOption): A = TODO("stat")
-    public fun readAttributes(path: Path, attributes: String, vararg options: LinkOption): Map<String, Any> = TODO("stat")
-    public fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Path = TODO("setxattr")
-    public fun getAttribute(path: Path, attribute: String, vararg options: LinkOption): Any = TODO("getxattr")
-    public fun getPosixFilePermissions(path: Path, vararg options: LinkOption): Set<PosixFilePermission> = TODO("stat mode")
-    public fun setPosixFilePermissions(path: Path, perms: Set<PosixFilePermission>): Path = TODO("chmod")
-    public fun <V : FileAttributeView> getFileAttributeView(path: Path, type: kotlin.reflect.KClass<V>, vararg options: LinkOption): V = TODO("attribute view")
+    public fun <A : BasicFileAttributes> readAttributes(path: Path, type: kotlin.reflect.KClass<A>, vararg options: LinkOption): A = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun readAttributes(path: Path, attributes: String, vararg options: LinkOption): Map<String, Any> = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Path = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun getAttribute(path: Path, attribute: String, vararg options: LinkOption): Any = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun getPosixFilePermissions(path: Path, vararg options: LinkOption): Set<PosixFilePermission> = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun setPosixFilePermissions(path: Path, perms: Set<PosixFilePermission>): Path = throw UnsupportedOperationException("Deterministic rejection: channel closed")
+    public fun <V : FileAttributeView> getFileAttributeView(path: Path, type: kotlin.reflect.KClass<V>, vararg options: LinkOption): V = throw UnsupportedOperationException("Deterministic rejection: channel closed")
 
     // Streams
     public fun newInputStream(path: Path, vararg options: OpenOption): Any = TODO("InputStream")


### PR DESCRIPTION
Fix Gap R5: deterministically reject xattr/mode/stat accessors

Replaced TODO() implementations in `src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt` with `UnsupportedOperationException("Deterministic rejection: channel closed")` for the following methods:
- readAttributes
- setAttribute
- getAttribute
- getPosixFilePermissions
- setPosixFilePermissions
- getFileAttributeView

This resolves the Gap R5 requirement to close covert channels instead of leaving them open with stub code.

📸 Before/After: Screenshots if visual change
(Not applicable - backend changes only)

---
*PR created automatically by Jules for task [468074489675977315](https://jules.google.com/task/468074489675977315) started by @jnorthrup*