### PR TITLE
chore: implement xattr reject policy (M3b)

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/Files.kt
@@ -137,8 +137,8 @@ public object Files {
     // Attributes
     public fun <A : BasicFileAttributes> readAttributes(path: Path, type: kotlin.reflect.KClass<A>, vararg options: LinkOption): A = TODO("stat")
     public fun readAttributes(path: Path, attributes: String, vararg options: LinkOption): Map<String, Any> = TODO("stat")
-    public fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Path = TODO("setxattr")
-    public fun getAttribute(path: Path, attribute: String, vararg options: LinkOption): Any = TODO("getxattr")
+    public fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Path = throw UnsupportedOperationException("xattr policy: reject")
+    public fun getAttribute(path: Path, attribute: String, vararg options: LinkOption): Any = throw UnsupportedOperationException("xattr policy: reject")
     public fun getPosixFilePermissions(path: Path, vararg options: LinkOption): Set<PosixFilePermission> = TODO("stat mode")
     public fun setPosixFilePermissions(path: Path, perms: Set<PosixFilePermission>): Path = TODO("chmod")
     public fun <V : FileAttributeView> getFileAttributeView(path: Path, type: kotlin.reflect.KClass<V>, vararg options: LinkOption): V = TODO("attribute view")


### PR DESCRIPTION
Implementation of the `M3b` xattr policy decision.

**Changes:**
- Modified `Files.kt` `setAttribute` and `getAttribute` to throw an explicitly typed `UnsupportedOperationException("xattr policy: reject")` instead of throwing the standard `TODO()` stub (`NotImplementedError`).

This formalizes the operational decision to categorically reject extended attribute reading and writing through the TrikeShed Substrate user space API, thereby securing the overt covert channel.

---
*PR created automatically by Jules for task [1720730778086506754](https://jules.google.com/task/1720730778086506754) started by @jnorthrup*