### PR TITLE
Add verify-registry.sh script for Traction Evidence generation

### DIFF
--- a/verify-registry.sh
+++ b/verify-registry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "=== Repository Vitals ==="
+echo "Commits: $(git rev-list --count HEAD)"
+echo "Kotlin files (src/): $(git ls-tree -r HEAD | grep -c 'src/.*\.kt$')"
+echo "Lines of code (src/): $(git ls-tree -r HEAD --name-only | grep '^src/.*\.kt$' | xargs -I{} git show HEAD:{} | wc -l)"
+echo "Test files: $(git ls-tree -r HEAD | grep -c 'Test\.kt$')"
+echo "Project age (First commit): $(git log --reverse --format=%ci | head -1)"


### PR DESCRIPTION
### Traction Evidence

Repository vitals (R13)
Metric | Value | Measured at | Re-run command
Commits | 1 | HEAD | git rev-list --count HEAD
Kotlin files (src/) | 1534 | HEAD | git ls-tree -r HEAD | grep -c 'src/.*\.kt$'
Lines of code (src/) | 132274 | HEAD | git ls-tree -r HEAD --name-only | grep '^src/.*\.kt$' | xargs -I{} git show HEAD:{} | wc -l
Test files | 343 | HEAD | git ls-tree -r HEAD | grep -c 'Test\.kt$'
Project age | 2026-08-16 | First commit HEAD | git log --reverse --format=%ci | head -1

Test suite status (M2 — not yet run)
Suite | Status | Command | Notes
commonTest | UNRUN | ./gradlew commonTest | Includes CanonicalCborTest, ContentIdTest, etc.
jvmTest | UNRUN | ./gradlew jvmTest | FlywheelDriver, Jules settlement, etc.
jsTest | UNRUN | ./gradlew jsTest | GalleryRenderer, etc.
Overall | NO GREEN RUN RECORDED | | M2 upgrades LIVE-r → LIVE on recorded green run

---
*PR created automatically by Jules for task [14902517865136453002](https://jules.google.com/task/14902517865136453002) started by @jnorthrup*