### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in SecureRandom

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 ## 2024-05-15 - Hardcoded Secrets Mitigation
 **Learning:** Found mock API keys in test files. Although these aren't live secrets, it highlights the importance of providing a structured way for developers to inject secrets locally without committing them.
 **Action:** Added `.env.example` with placeholder keys to document the required environment variables (e.g., `JULES_API_KEY`, `OPENAI_API_KEY`) and provide a secure template for local configuration, reinforcing the practice of keeping secrets out of version control.
+
+## 2024-05-15 - DoS Vulnerability in Random Number Generation
+**Vulnerability:** The codebase was using `java.security.SecureRandom.getInstanceStrong()` to generate random bytes for temporary passwords and peer IDs.
+**Learning:** On Linux/Unix systems, `getInstanceStrong()` often defaults to the blocking `/dev/random` pool. If system entropy is depleted, any thread calling `nextBytes()` on this instance will block indefinitely, leading to a Denial of Service (DoS) and application hang.
+**Prevention:** Use the default `SecureRandom()` constructor instead. It utilizes the non-blocking CSPRNG (`/dev/urandom`), which is cryptographically strong enough for general application use and immune to entropy-depletion blocking.

--- a/src/commonMain/kotlin/borg/trikeshed/torrent/PeerWireProtocol.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/torrent/PeerWireProtocol.kt
@@ -187,7 +187,7 @@ data class PeerHandshake(
         fun azureusPeerId(client: String = "TR", version: String = "0.01"): ByteArray {
             val s = "-${client}${version}-"
             val random = ByteArray(20 - s.length)
-            java.security.SecureRandom.getInstanceStrong().nextBytes(random)
+            java.security.SecureRandom().nextBytes(random)
             return (s.toByteArray() + random).copyOf(20)
         }
     }

--- a/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/reactor/JvmTlsCodecBackend.kt
@@ -312,7 +312,7 @@ class JvmTlsCodecBackend : TlsCodecBackend, KeyedService {
         // In-memory KeyStore; use a randomly generated password if none provided
         val password = (config.privateKeyPassword ?: run {
             val bytes = ByteArray(16)
-            SecureRandom.getInstanceStrong().nextBytes(bytes)
+            SecureRandom().nextBytes(bytes)
             Base64.getEncoder().encodeToString(bytes)
         }).toCharArray()
         val keyStore = KeyStore.getInstance(KeyStore.getDefaultType())

--- a/src/jvmMain/kotlin/modelmux/SecureIdGenerator.jvm.kt
+++ b/src/jvmMain/kotlin/modelmux/SecureIdGenerator.jvm.kt
@@ -3,7 +3,7 @@ package modelmux
 import java.security.SecureRandom
 
 actual val defaultSecureIdGenerator: SecureIdGenerator = object : SecureIdGenerator {
-    private val random = SecureRandom.getInstanceStrong()
+    private val random = SecureRandom()
 
     override fun generateHexId(prefix: String, byteLength: Int): String {
         val bytes = ByteArray(byteLength)


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The use of `SecureRandom.getInstanceStrong()` defaults to the blocking `/dev/random` on Linux/Unix systems, which can cause threads to hang indefinitely if the system runs low on entropy.
* 🎯 Impact: Can cause a Denial of Service (DoS) and application unresponsiveness as threads block waiting for entropy to generate random bytes for peer IDs or temporary passwords.
* 🔧 Fix: Replaced `SecureRandom.getInstanceStrong()` with the non-blocking `SecureRandom()` constructor, which safely utilizes `/dev/urandom`.
* ✅ Verification: Ran the project build gate `./gradlew :jvmMainClasses --no-daemon` successfully. Tested and verified that no functionality is broken and code review passed.

---
*PR created automatically by Jules for task [15437091275677586606](https://jules.google.com/task/15437091275677586606) started by @jnorthrup*