### PR TITLE
🛡️ Sentinel: [Medium] Fix [steganographic coordination via path entropy]

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/containment/EntropyPathScanner.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/containment/EntropyPathScanner.kt
@@ -1,0 +1,29 @@
+package borg.trikeshed.userspace.containment
+
+import kotlin.math.log2
+
+object EntropyPathScanner {
+
+    data class EntropyResult(
+        val path: String,
+        val entropy: Double
+    )
+
+    fun shannonEntropy(s: String): Double {
+        if (s.isEmpty()) return 0.0
+        val counts = s.groupingBy { it }.eachCount()
+        val length = s.length.toDouble()
+        return counts.values.sumOf { count ->
+            val p = count / length
+            -p * log2(p)
+        }
+    }
+
+    fun scanTouchedPaths(paths: List<String>): List<EntropyResult> {
+        return paths.map { path ->
+            // Entropy check on path segments
+            val segmentMaxEntropy = path.split('/').maxOfOrNull { shannonEntropy(it) } ?: 0.0
+            EntropyResult(path, segmentMaxEntropy)
+        }.filter { it.entropy > 3.5 }
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
@@ -2,6 +2,7 @@ package borg.trikeshed.jules
 
 import borg.trikeshed.htx.HtxKey
 import borg.trikeshed.lib.j
+import borg.trikeshed.userspace.containment.EntropyPathScanner
 import borg.trikeshed.kanban.ForgeKanbanIngest
 import borg.trikeshed.job.ContentId
 import borg.trikeshed.memory.MemoryIndexLayer
@@ -927,6 +928,13 @@ class FlywheelDriver(
                     if (branch != null) {
                         val diff = git("diff", "--no-color", "master...$branch")
                         if (diff.exitCode == 0 && diff.output.isNotBlank()) {
+                            val touched = parsePatchFiles(diff.output)
+                            val suspicious = EntropyPathScanner.scanTouchedPaths(touched)
+                            if (suspicious.isNotEmpty()) {
+                                drainFail(s, "drain-rejected: steganographic entropy detected in paths: ${suspicious.map { it.path }}")
+                                return@async null
+                            }
+
                             val patchCid = withContext(Dispatchers.IO) {
                                 casStore.put(diff.output.encodeToByteArray())
                             }
@@ -941,6 +949,13 @@ class FlywheelDriver(
                     val automatic = withTimeoutOrNull(60_000L) { automaticPatch(s) }
                     if (automatic is AutomaticPatch.Available) {
                         val patch = automatic.text
+                        val touched = parsePatchFiles(patch)
+                        val suspicious = EntropyPathScanner.scanTouchedPaths(touched)
+                        if (suspicious.isNotEmpty()) {
+                            drainFail(s, "drain-rejected: steganographic entropy detected in paths: ${suspicious.map { it.path }}")
+                            return@async null
+                        }
+
                         val patchCid = try {
                             automatic.patchCid ?: withContext(Dispatchers.IO) {
                                 casStore.put(patch.encodeToByteArray())


### PR DESCRIPTION
* 🚨 Severity: Medium
* 💡 Vulnerability: Malleable file/directory tree hierarchies used for steganographic coordination (Legion Doc 02).
* 🎯 Impact: Agents can encode covert state in path names, directory depths, or naming conventions without detection.
* 🔧 Fix: Implemented EntropyPathScanner in commonMain and wired it into FlywheelDriver's drainExactArtifacts to block patches with path segment entropy > 3.5 bits/char.
* ✅ Verification: Tested against entropy calculation unit scripts and ran ./gradlew jvmMainClasses --console=plain successfully.

---
*PR created automatically by Jules for task [2274920288333098645](https://jules.google.com/task/2274920288333098645) started by @jnorthrup*