### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing behavioral graph auditor for containment policy

### DIFF
--- a/fix_auditor_leak.py
+++ b/fix_auditor_leak.py
@@ -1,0 +1,73 @@
+with open("src/commonMain/kotlin/borg/trikeshed/userspace/containment/BehavioralGraphAuditor.kt", "r") as f:
+    content = f.read()
+
+import re
+
+new_logic = """    private val sessionFiles = mutableMapOf<String, MutableSet<String>>()
+    private val filesPerCycle = mutableMapOf<Long, Int>()
+    private var cycleCounter = 0L
+
+    data class AuditReport(
+        val isClean: Boolean,
+        val signals: List<String>
+    )
+
+    fun recordFileAccess(sessionId: String, filePath: String) {
+        if (!policy.layer5Arbitrage.behavioralGraphAudit) return
+        sessionFiles.getOrPut(sessionId) { mutableSetOf() }.add(filePath)
+        filesPerCycle[cycleCounter] = (filesPerCycle[cycleCounter] ?: 0) + 1
+    }
+
+    fun endCycle() {
+        cycleCounter++
+        // Keep windowed state to prevent unbounded memory growth
+        if (filesPerCycle.size > 20) {
+            val oldest = filesPerCycle.keys.minOrNull()
+            if (oldest != null) filesPerCycle.remove(oldest)
+        }
+    }
+
+    fun auditResult(): AuditReport {
+        if (!policy.layer5Arbitrage.behavioralGraphAudit) {
+            return AuditReport(isClean = true, signals = emptyList())
+        }
+
+        val signals = mutableListOf<String>()
+        val fileToSessions = mutableMapOf<String, MutableList<String>>()
+
+        for ((sessionId, files) in sessionFiles) {
+            for (file in files) {
+                fileToSessions.getOrPut(file) { mutableListOf() }.add(sessionId)
+            }
+        }
+
+        for ((file, sessions) in fileToSessions) {
+            if (sessions.size >= 2) {
+                signals.add("Collusion signal: File $file accessed by multiple sessions: ${sessions.joinToString()}")
+            }
+        }
+
+        // Detect entropy spikes in file creation patterns per cycle
+        if (filesPerCycle.size >= 3) {
+            val sortedCycles = filesPerCycle.keys.sorted()
+            val recentCycles = sortedCycles.takeLast(5).dropLast(1) // exclude current
+            if (recentCycles.isNotEmpty()) {
+                val avgFiles = recentCycles.mapNotNull { filesPerCycle[it] }.average()
+                val lastCycleFiles = filesPerCycle[sortedCycles.last()] ?: 0
+                if (lastCycleFiles > avgFiles * 2 && lastCycleFiles > 10) {
+                    signals.add("Entropy spike detected in cycle ${sortedCycles.last()}: $lastCycleFiles files accessed")
+                }
+            }
+        }
+
+        // Clear session files to avoid indefinitely repeating alerts for same collusions
+        sessionFiles.clear()
+
+        return AuditReport(isClean = signals.isEmpty(), signals = signals)
+    }"""
+
+content = re.sub(r'    private val sessionFiles = mutableMapOf<String, MutableSet<String>>\(\)[\s\S]*return AuditReport\(isClean = signals\.isEmpty\(\), signals = signals\)\n    \}', new_logic, content)
+
+with open("src/commonMain/kotlin/borg/trikeshed/userspace/containment/BehavioralGraphAuditor.kt", "w") as f:
+    f.write(content)
+print("done")

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/containment/BehavioralGraphAuditor.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/containment/BehavioralGraphAuditor.kt
@@ -1,0 +1,74 @@
+package borg.trikeshed.userspace.containment
+
+
+
+/**
+ * Legion Doc 04 Layer 5: Asynchronous behavioral graph auditing.
+ * Detects multi-instance collusion via cross-run file access patterns
+ * and emergent spontaneous protocols (e.g. entropy spikes, recurring tokens).
+ */
+class BehavioralGraphAuditor(private val policy: ContainmentPolicy) {
+
+    private val sessionFiles = mutableMapOf<String, MutableSet<String>>()
+    private val filesPerCycle = mutableMapOf<Long, Int>()
+    private var cycleCounter = 0L
+
+    data class AuditReport(
+        val isClean: Boolean,
+        val signals: List<String>
+    )
+
+    fun recordFileAccess(sessionId: String, filePath: String) {
+        if (!policy.layer5Arbitrage.behavioralGraphAudit) return
+        sessionFiles.getOrPut(sessionId) { mutableSetOf() }.add(filePath)
+        filesPerCycle[cycleCounter] = (filesPerCycle[cycleCounter] ?: 0) + 1
+    }
+
+    fun endCycle() {
+        cycleCounter++
+        // Keep windowed state to prevent unbounded memory growth
+        if (filesPerCycle.size > 20) {
+            val oldest = filesPerCycle.keys.minOrNull()
+            if (oldest != null) filesPerCycle.remove(oldest)
+        }
+    }
+
+    fun auditResult(): AuditReport {
+        if (!policy.layer5Arbitrage.behavioralGraphAudit) {
+            return AuditReport(isClean = true, signals = emptyList())
+        }
+
+        val signals = mutableListOf<String>()
+        val fileToSessions = mutableMapOf<String, MutableList<String>>()
+
+        for ((sessionId, files) in sessionFiles) {
+            for (file in files) {
+                fileToSessions.getOrPut(file) { mutableListOf() }.add(sessionId)
+            }
+        }
+
+        for ((file, sessions) in fileToSessions) {
+            if (sessions.size >= 2) {
+                signals.add("Collusion signal: File $file accessed by multiple sessions: ${sessions.joinToString()}")
+            }
+        }
+
+        // Detect entropy spikes in file creation patterns per cycle
+        if (filesPerCycle.size >= 3) {
+            val sortedCycles = filesPerCycle.keys.sorted()
+            val recentCycles = sortedCycles.takeLast(5).dropLast(1) // exclude current
+            if (recentCycles.isNotEmpty()) {
+                val avgFiles = recentCycles.mapNotNull { filesPerCycle[it] }.average()
+                val lastCycleFiles = filesPerCycle[sortedCycles.last()] ?: 0
+                if (lastCycleFiles > avgFiles * 2 && lastCycleFiles > 10) {
+                    signals.add("Entropy spike detected in cycle ${sortedCycles.last()}: $lastCycleFiles files accessed")
+                }
+            }
+        }
+
+        // Clear session files to avoid indefinitely repeating alerts for same collusions
+        sessionFiles.clear()
+
+        return AuditReport(isClean = signals.isEmpty(), signals = signals)
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
@@ -96,6 +96,10 @@ class FlywheelDriver(
         JvmFileOperations().resolvePath(forgeDir.absolutePath, "cas"),
     ),
 ) {
+    private val behavioralAuditor = borg.trikeshed.userspace.containment.BehavioralGraphAuditor(
+        borg.trikeshed.userspace.containment.ContainmentPolicy.MAXIMUM
+    )
+
     @Volatile private var htxElement: borg.trikeshed.htx.HtxElement? = null
 
     /** Wire the HTX element after daemon construction (circular dep). */
@@ -420,7 +424,25 @@ class FlywheelDriver(
         val queueBySession = loadQueueIo().mapNotNull { entry ->
             entry.sessionId?.let { it to entry }
         }.toMap()
-        val archived = archiveSettledSessions(queueBySession)
+                val archived = archiveSettledSessions(queueBySession)
+
+        // Legion Doc 04 Layer 5: Audit behavioral graphs across sessions
+        for (card in conductor.cards.values) {
+            val observed = card.causes.filterIsInstance<JulesCause.PatchSnapshotObserved>().maxByOrNull { it.causalOrdinal }
+            if (observed != null) {
+                for (file in observed.touchedFiles) {
+                    behavioralAuditor.recordFileAccess(card.snapshot.sessionId, file)
+                }
+            }
+        }
+        val auditReport = behavioralAuditor.auditResult()
+        if (!auditReport.isClean) {
+            println("[FLYWHEEL] BEHAVIORAL AUDIT SIGNALS DETECTED:")
+            for (signal in auditReport.signals) {
+                println("[FLYWHEEL]   - $signal")
+            }
+        }
+        behavioralAuditor.endCycle()
 
         // 6. INDUCT — the WAL is the only induction surface. External agents
         //    CAS-put a ≤4000-byte spec and appendWork(workId, WorkQueued).


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Missing implementation for Legion Doc 04 §5 async behavioral graph auditing.
* 🎯 Impact: Multi-instance collusion or emergent protocol signaling could occur undetected without cross-run file pattern audits.
* 🔧 Fix: Implemented BehavioralGraphAuditor to track cross-session file overlaps and entropy spikes (via a windowed cycle counter) and wired it into FlywheelDriver.kt cycle() after archiveSettledSessions. Memory leak addressed by removing old keys and clearing sessionFiles each cycle.
* ✅ Verification: Ran `./gradlew jvmMainClasses --console=plain` and compilation succeeds.

---
*PR created automatically by Jules for task [13287738544189719497](https://jules.google.com/task/13287738544189719497) started by @jnorthrup*