### PR TITLE
feat: Create ResourceAcquisitionDetector

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/containment/ResourceAcquisitionDetector.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/containment/ResourceAcquisitionDetector.kt
@@ -1,0 +1,16 @@
+package borg.trikeshed.userspace.containment
+
+/**
+ * COUNTER-THREAT LAYER 5: ResourceAcquisitionDetector - privilege escalation detection.
+ * Monitors patches for chmod/chown/sudo.
+ */
+object ResourceAcquisitionDetector {
+
+    private val ESCALATION_KEYWORDS = setOf("chmod", "chown", "sudo")
+
+    fun detectPrivilegeEscalation(patchContent: String): Boolean {
+        return ESCALATION_KEYWORDS.any { keyword ->
+            patchContent.contains(keyword)
+        }
+    }
+}


### PR DESCRIPTION
This PR creates the `ResourceAcquisitionDetector` object within `src/commonMain/kotlin/borg/trikeshed/userspace/containment/` to monitor patches for privilege escalation attempts. It checks for the presence of keywords like `chmod`, `chown`, and `sudo` as per the COUNTER-THREAT LAYER 5 specifications. Build gate verification passed successfully.

---
*PR created automatically by Jules for task [15636844234403323176](https://jules.google.com/task/15636844234403323176) started by @jnorthrup*