### PR TITLE
🎨 Palette: Add accessible labels to board new card buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,6 @@
 ## 2025-01-22 - Reducing screen reader noise for decorative elements
 **Learning:** Dynamically created DOM elements used purely for visual styling or as decorative markers (such as tree toggles '▾' / '▸', tree icons '▤', bullet markers '•', or slash menu icons) can create significant noise for screen reader users if left unannotated. Screen readers may read out the literal characters (e.g., "black right-pointing small triangle") which interrupts the flow and doesn't add semantic value when the adjacent text already describes the item.
 **Action:** When dynamically generating decorative icon or marker elements via JavaScript (e.g., `document.createElement('span')`), explicitly set `aria-hidden="true"` via `setAttribute('aria-hidden', 'true')` to silence them for assistive technologies, allowing the screen reader to focus on the meaningful sibling content.
+## 2024-08-17 - Context for identical buttons
+**Learning:** Identical buttons like "+ New" across multiple columns in a kanban board lack context for screen reader users. The screen reader would just say "button, + New" multiple times, without indicating which column it belongs to.
+**Action:** When adding identical action buttons to lists or columns, always add an `aria-label` that includes the parent context, e.g. `aria-label="Add new card to ' + col.name"`.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -547,6 +547,7 @@
       const addBtn = document.createElement('button');
       addBtn.className = 'board-add-card';
       addBtn.textContent = '+ New';
+      addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);
       addBtn.addEventListener('click', () => {
         mutate((s) => { s.board.cards.push({ id: uid(), title: '', column: col.id, meta: '' }); });
         renderBoard();


### PR DESCRIPTION
💡 What: Added an `aria-label` to the `+ New` button inside Kanban board columns.
🎯 Why: Multiple identical `+ New` buttons without contextual names cause screen readers to announce them exactly the same way without indicating which column the button will add the card to.
📸 Before/After: Visuals are unchanged. The screen reader experience goes from hearing "button, + New" to "button, Add new card to [column name]".
♿ Accessibility: Ensures that screen reader users can uniquely identify buttons by providing a descriptive accessible name using `aria-label`.

---
*PR created automatically by Jules for task [17487099305667126994](https://jules.google.com/task/17487099305667126994) started by @jnorthrup*