### PR TITLE
🎨 Palette: Add contextual ARIA label to board add card button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-01-22 - Reducing screen reader noise for decorative elements
 **Learning:** Dynamically created DOM elements used purely for visual styling or as decorative markers (such as tree toggles '▾' / '▸', tree icons '▤', bullet markers '•', or slash menu icons) can create significant noise for screen reader users if left unannotated. Screen readers may read out the literal characters (e.g., "black right-pointing small triangle") which interrupts the flow and doesn't add semantic value when the adjacent text already describes the item.
 **Action:** When dynamically generating decorative icon or marker elements via JavaScript (e.g., `document.createElement('span')`), explicitly set `aria-hidden="true"` via `setAttribute('aria-hidden', 'true')` to silence them for assistive technologies, allowing the screen reader to focus on the meaningful sibling content.
+
+## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
+**Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
+**Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -547,6 +547,7 @@
       const addBtn = document.createElement('button');
       addBtn.className = 'board-add-card';
       addBtn.textContent = '+ New';
+      addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);
       addBtn.addEventListener('click', () => {
         mutate((s) => { s.board.cards.push({ id: uid(), title: '', column: col.id, meta: '' }); });
         renderBoard();


### PR DESCRIPTION
💡 What: Added a contextual ARIA label to the dynamically created "+ New" button for adding cards to a board column.
🎯 Why: Without a contextual label, screen reader users navigating the DOM hear only "+ New", missing the crucial context of which column they are adding the card to, as visual layout cues are not translated by screen readers.
📸 Before/After: Before: `<button class="board-add-card">+ New</button>` After: `<button class="board-add-card" aria-label="Add new card to TODO">+ New</button>`
♿ Accessibility: Ensures that dynamic add card buttons inside Kanban boards communicate their context to assistive technologies.

---
*PR created automatically by Jules for task [11953326023123964330](https://jules.google.com/task/11953326023123964330) started by @jnorthrup*