### PR TITLE
⚡ Bolt: Replace ByteArray .toList() comparison with zero-allocation .contentEquals()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -81,3 +81,7 @@
 ## 2026-08-18 - Avoid O(F*S) scaling in nested dispatch loops
 **Learning:** While replacing `.filterIsInstance<T>()` with `.forEach { if (it is T) }` prevents intermediate List allocations, applying this blindly inside a nested dispatch loop (e.g. iterating `frames` then iterating `subscribers`) causes an `O(F*S)` performance regression because the `is T` type check is evaluated for every subscriber for every frame.
 **Action:** When optimizing nested dispatch loops that broadcast items to matching subscribers, fast-path check the presence of matching subscribers outside the frame loop using `.any { it is T }`. This safely skips the inner broadcast loop when there are no listeners, while avoiding intermediate list allocations and preserving event delivery order.
+
+## 2024-12-10 - Avoid O(N) boxing allocation when comparing ByteArray
+**Learning:** Comparing ByteArray objects using .toList() == other.toList() causes an O(N) memory allocation because each Byte gets boxed into an object within a new ArrayList. This can introduce unexpected GC pressure, especially when frequently hashing or comparing proofs.
+**Action:** Replace a.toList() == b.toList() on ByteArray with a.contentEquals(b) for a fast, zero-allocation byte-level comparison.

--- a/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
@@ -246,18 +246,19 @@ class ViewServer {
         reducer: ReducerIdentity = reducerIdentity(viewDef),
     ): Boolean {
         if (reducer != reducerIdentity(viewDef)) return false
-        if (receipt.viewDefinition.canonicalBytes.toList() != definitionBytes(viewDef).toList()) return false
+        // Bolt: Prevent O(N) boxing allocation by using contentEquals instead of toList()
+        if (!receipt.viewDefinition.canonicalBytes.contentEquals(definitionBytes(viewDef))) return false
         if (receipt.reducer != reducer) return false
         val replayBytes = resultBytes(execute(viewDef, documents))
-        if (replayBytes.toList() != receipt.outputBytes.toList()) return false
-        if (resultBytes(result).toList() != receipt.outputBytes.toList()) return false
+        if (!replayBytes.contentEquals(receipt.outputBytes)) return false
+        if (!resultBytes(result).contentEquals(receipt.outputBytes)) return false
         val reminted = MapReduceProofReceipt.mint(
             ViewDefinitionIdentity(definitionBytes(viewDef)),
             documents.map { ContentId.of(documentBytes(it)) },
             reducer,
             replayBytes,
         )
-        return reminted.contentId == receipt.contentId && reminted.canonicalBytes.toList() == receipt.canonicalBytes.toList()
+        return reminted.contentId == receipt.contentId && reminted.canonicalBytes.contentEquals(receipt.canonicalBytes)
     }
 
     /**


### PR DESCRIPTION
💡 **What**:
Replaced `.toList() == other.toList()` with `.contentEquals(other)` for `ByteArray` comparisons in `ViewServer.verifyReplay`.

🎯 **Why**:
Calling `.toList()` on a primitive `ByteArray` boxes every single byte and allocates a new `ArrayList`. When verifying map/reduce proof receipts, checking the canonical bytes (which can be sizable) using `.toList()` introduces significant, unnecessary Garbage Collection pressure and O(N) overhead. `contentEquals` iterates over the native arrays directly without allocating objects.

📊 **Impact**:
Eliminates O(N) object allocations (where N is the length of the canonical bytes/output bytes) per verification call in `ViewServer`. Prevents boxing overhead and reduces GC pressure in CouchDB-style proof receipt evaluation.

🔬 **Measurement**:
Validated correctness via `./gradlew :jvmTest --tests "*ViewServerTest*"`. Zero-allocation behavior of `contentEquals` is statically known compared to standard library `.toList()` on arrays.

---
*PR created automatically by Jules for task [7626105149330086396](https://jules.google.com/task/7626105149330086396) started by @jnorthrup*