### PR TITLE
⚡ Bolt: Avoid intermediate List allocations in filterIsInstance chains

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
@@ -460,7 +460,15 @@ class FlywheelDriver(
 
         // Legion Doc 04 Layer 5: Audit behavioral graphs across sessions
         for (card in conductor.cards.values) {
-            val observed = card.causes.filterIsInstance<JulesCause.PatchSnapshotObserved>().maxByOrNull { it.causalOrdinal }
+            // Bolt: Avoid intermediate List allocations from filterIsInstance<T>().maxByOrNull { ... }
+            var observed: JulesCause.PatchSnapshotObserved? = null
+            for (cause in card.causes) {
+                if (cause is JulesCause.PatchSnapshotObserved) {
+                    if (observed == null || cause.causalOrdinal > observed.causalOrdinal) {
+                        observed = cause
+                    }
+                }
+            }
             if (observed != null) {
                 for (file in observed.touchedFiles) {
                     behavioralAuditor.recordFileAccess(card.snapshot.sessionId, file)
@@ -509,8 +517,15 @@ class FlywheelDriver(
             var activeScopeUnknown = false
             for (card in conductor.cards.values) {
                 if (card.snapshot.state !in TERMINAL_STATES) {
-                    val observed = card.causes.filterIsInstance<JulesCause.PatchSnapshotObserved>()
-                        .maxByOrNull { it.causalOrdinal }
+                    // Bolt: Avoid intermediate List allocations from filterIsInstance<T>().maxByOrNull { ... }
+                    var observed: JulesCause.PatchSnapshotObserved? = null
+                    for (cause in card.causes) {
+                        if (cause is JulesCause.PatchSnapshotObserved) {
+                            if (observed == null || cause.causalOrdinal > observed.causalOrdinal) {
+                                observed = cause
+                            }
+                        }
+                    }
                     if (card.snapshot.patchBytes > 0 && observed == null) activeScopeUnknown = true
                     if (observed != null) inflightFiles += observed.touchedFiles
                 }
@@ -1544,10 +1559,10 @@ class FlywheelDriver(
                     val receipt = entry?.receipt
                     if (receipt != null && isImmutableReceipt(receipt)) {
                         val identity = entry.workId.let { wid ->
+                            // Bolt: Avoid intermediate List allocations from filterIsInstance<T>().lastOrNull()
                             withContext(Dispatchers.IO) { store.replayCauses(wid) }
-                                .filterIsInstance<JulesCause.WorkIdentitySynthesized>()
-                                .lastOrNull()?.identity
-                        }
+                                .lastOrNull { it is JulesCause.WorkIdentitySynthesized } as? JulesCause.WorkIdentitySynthesized
+                        }?.identity
                         sendMergeReceipt(
                             sessionId = sessionId,
                             commitSha = receipt.revision,


### PR DESCRIPTION
💡 **What**: Avoid intermediate `ArrayList` allocations when filtering type instances in `FlywheelDriver.kt`. Replaced chains of `.filterIsInstance<T>().maxByOrNull { ... }` with zero-allocation manual loops, and replaced `.filterIsInstance<T>().lastOrNull()` with `.lastOrNull { it is T } as? T`.

🎯 **Why**: When chaining `.filterIsInstance<T>()` before terminal short-circuiting operations like `any`, `firstOrNull`, `lastOrNull`, or aggregation operations like `maxByOrNull`, Kotlin generates a redundant, full intermediate `ArrayList`. This causes unnecessary GC pressure, especially in performance-sensitive reactor loops. This optimization directly applies the learnings documented in `.jules/bolt.md`.

📊 **Impact**: Eliminates `O(N)` memory allocation spikes during session behavioral audits, active scope tracking, and identity synthesis in the Flywheel daemon.

🔬 **Measurement**: Verified by successfully running `./gradlew :jvmTest --tests "*Jules*"` and `./gradlew :jvmTest --tests "*Flywheel*"`.

---
*PR created automatically by Jules for task [10235737572719682445](https://jules.google.com/task/10235737572719682445) started by @jnorthrup*