### PR TITLE
🎨 Palette: Add contextual ARIA labels to DatabaseView buttons

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/editor/DatabaseView.kt
@@ -74,8 +74,8 @@ class DatabaseView(var database: LcncDatabase, val ingestState: IngestStateEleme
             for (prop in schema.properties.values) {
                 text("<th>")
                 text("<button class=\"lcnc-database-sort\" data-column=\"${prop.id}\" onclick=\"window.lcncSortColumn('${database.id}', '${prop.id}')\" aria-label=\"Sort by ${prop.name}\" title=\"Sort by ${prop.name}\">${prop.name}</button>")
-                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\" aria-label=\"Delete column\" title=\"Delete column\"><span aria-hidden=\"true\">x</span></button>")
-                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\" aria-label=\"Rename column\" title=\"Rename column\"><span aria-hidden=\"true\">✎</span></button>")
+                text("<button class=\"lcnc-col-delete\" onclick=\"window.lcncDeleteColumn('${database.id}', '${prop.id}')\" aria-label=\"Delete column ${prop.name}\" title=\"Delete column\"><span aria-hidden=\"true\">x</span></button>")
+                text("<button class=\"lcnc-col-rename\" onclick=\"window.lcncRenameColumn('${database.id}', '${prop.id}')\" aria-label=\"Rename column ${prop.name}\" title=\"Rename column\"><span aria-hidden=\"true\">✎</span></button>")
                 text("</th>")
             }
             text("<th>Actions</th>")
@@ -134,8 +134,8 @@ class DatabaseView(var database: LcncDatabase, val ingestState: IngestStateEleme
                 }
                 
                 text("<td>")
-                text("<button onclick=\"window.lcncDuplicateRow('${database.id}', '${page.id}')\" aria-label=\"Copy row\" title=\"Copy row\">Copy</button>")
-                text("<button onclick=\"window.lcncDeleteRow('${database.id}', '${page.id}')\" aria-label=\"Delete row\" title=\"Delete row\">Delete</button>")
+                text("<button onclick=\"window.lcncDuplicateRow('${database.id}', '${page.id}')\" aria-label=\"Copy row ${page.title}\" title=\"Copy row\">Copy</button>")
+                text("<button onclick=\"window.lcncDeleteRow('${database.id}', '${page.id}')\" aria-label=\"Delete row ${page.title}\" title=\"Delete row\">Delete</button>")
                 text("</td>")
                 text("</tr>")
             }


### PR DESCRIPTION
* 💡 What: Added dynamic context variables (`${prop.name}` and `${page.title}`) to the `aria-label` attributes of generic action buttons in `DatabaseView.kt`.
* 🎯 Why: Screen reader users navigating through tables or grouped layouts lose visual context. When all row delete buttons say "Delete row", it is impossible to know which row is being acted upon without context.
* 📸 Before/After: Before, multiple buttons read exactly the same. After, they provide specific context (e.g., "Delete row My Page Title").
* ♿ Accessibility: Fixes a major usability issue for non-visual navigation of repeating interactive elements.

---
*PR created automatically by Jules for task [8547782669032802142](https://jules.google.com/task/8547782669032802142) started by @jnorthrup*