### PR TITLE
⚡ Bolt: Replace .toList() == with .contentEquals() for byte array comparisons

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -81,3 +81,6 @@
 ## 2026-08-18 - Avoid O(F*S) scaling in nested dispatch loops
 **Learning:** While replacing `.filterIsInstance<T>()` with `.forEach { if (it is T) }` prevents intermediate List allocations, applying this blindly inside a nested dispatch loop (e.g. iterating `frames` then iterating `subscribers`) causes an `O(F*S)` performance regression because the `is T` type check is evaluated for every subscriber for every frame.
 **Action:** When optimizing nested dispatch loops that broadcast items to matching subscribers, fast-path check the presence of matching subscribers outside the frame loop using `.any { it is T }`. This safely skips the inner broadcast loop when there are no listeners, while avoiding intermediate list allocations and preserving event delivery order.
+## 2025-02-22 - ByteArray Comparison Optimization
+**Learning:** In Kotlin, replacing `.toList() == .toList()` on `ByteArray` with `.contentEquals()` removes unnecessary boxing/allocation. However, `.contentEquals()` requires exactly matching typed arrays. Using it generically (e.g., trying to use `UIntArray.contentEquals(Sequence<UInt>)`) causes compiler errors due to receiver type mismatches.
+**Action:** When optimizing byte/primitive array comparisons, explicitly use `.contentEquals()` for identical array types, but do not blindly apply it across mismatched sequence or collection bounds.

--- a/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/couch/ViewServer.kt
@@ -246,18 +246,18 @@ class ViewServer {
         reducer: ReducerIdentity = reducerIdentity(viewDef),
     ): Boolean {
         if (reducer != reducerIdentity(viewDef)) return false
-        if (receipt.viewDefinition.canonicalBytes.toList() != definitionBytes(viewDef).toList()) return false
+        if (!receipt.viewDefinition.canonicalBytes.contentEquals(definitionBytes(viewDef))) return false
         if (receipt.reducer != reducer) return false
         val replayBytes = resultBytes(execute(viewDef, documents))
-        if (replayBytes.toList() != receipt.outputBytes.toList()) return false
-        if (resultBytes(result).toList() != receipt.outputBytes.toList()) return false
+        if (!replayBytes.contentEquals(receipt.outputBytes)) return false
+        if (!resultBytes(result).contentEquals(receipt.outputBytes)) return false
         val reminted = MapReduceProofReceipt.mint(
             ViewDefinitionIdentity(definitionBytes(viewDef)),
             documents.map { ContentId.of(documentBytes(it)) },
             reducer,
             replayBytes,
         )
-        return reminted.contentId == receipt.contentId && reminted.canonicalBytes.toList() == receipt.canonicalBytes.toList()
+        return reminted.contentId == receipt.contentId && reminted.canonicalBytes.contentEquals(receipt.canonicalBytes)
     }
 
     /**

--- a/src/commonTest/kotlin/borg/trikeshed/viewserver/MapReduceProofReceiptTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/viewserver/MapReduceProofReceiptTest.kt
@@ -46,7 +46,7 @@ class MapReduceProofReceiptTest {
             output = byteArrayOf(),
         )
 
-        assertNotEquals(left.canonicalBytes.toList(), right.canonicalBytes.toList())
+        kotlin.test.assertFalse(left.canonicalBytes.contentEquals(right.canonicalBytes))
         assertNotEquals(left.contentId, right.contentId)
     }
 


### PR DESCRIPTION
💡 What: Replaced `.toList() ==` and `.toList() !=` comparisons on `ByteArray` objects with `.contentEquals()` in `ViewServer.kt` and `MapReduceProofReceiptTest.kt`.
🎯 Why: Calling `.toList()` on primitive arrays eagerly boxes all items and allocates O(N) memory, causing GC churn on hot paths (like receipt validation).
📊 Impact: Zero-allocation primitive byte comparisons avoid intermediate `ArrayList` and `Byte` boxing object allocations.
🔬 Measurement: Verify changes compile correctly via `./gradlew :jvmMainClasses --no-daemon` and pass unit tests via `./gradlew :jvmTest --no-daemon`.

---
*PR created automatically by Jules for task [6308402139956135430](https://jules.google.com/task/6308402139956135430) started by @jnorthrup*