### PR TITLE
M1: Pointcut→Blackboard adapter

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapter.kt
@@ -37,6 +37,34 @@ import kotlinx.coroutines.flow.asSharedFlow
  * byte (LcncSpineMarks.kt) alongside the coordinate — the pointcut phase tag is
  * part of the landed record, not a side channel.
  *
+ * ### Key semantics — last write wins per site
+ *
+ * The key deliberately identifies a *site*, not an *observation*: it carries no
+ * phase segment, so the BEFORE and AFTER halves of one callsite occupy the same
+ * key and the later one supersedes the earlier on the board. That is the intended
+ * blackboard semantic (a board holds current state per coordinate), and it is not
+ * lossy for CRMS: the full ordered observation history — both phases, each with
+ * its own [PointcutMark] — is preserved on [landings] and [flow], which is where
+ * BEFORE/AFTER pairing (`TraceEvent.matches`) belongs.
+ *
+ * ### Timebase
+ *
+ * Both ingress paths land **epoch milliseconds** in [DagCoordinate.timestamp].
+ * Ring events stamp `System.nanoTime()` (an arbitrary origin), so they are
+ * rebased through [nanoToEpochMillis] onto the same axis guest events already
+ * use. Without that rebase, `InMemoryBlackboardFabric`'s causal-parent search and
+ * range queries (BlackboardDagFabric.kt) would order every JVM landing before
+ * every guest landing.
+ *
+ * ### Site index namespaces
+ *
+ * Ring landings put the real bytecode `siteIdx` in [DagCoordinate.bytecodeOffset].
+ * Guest landings have no bytecode site, so they use a **negative** stable hash of
+ * the property name ([guestSiteIdx]) — negative keeps the guest namespace
+ * disjoint from any real (non-negative) bytecode offset, and hashing rather than
+ * interning keeps the value stable across runs and avoids growing the fixed-size
+ * 65536-entry `InternPool` from unbounded guest-supplied strings.
+ *
  * Downstream consumers read [landings] (a lazy [Series], `α`-projected columns,
  * no eager loop) or collect [flow]; there is no callback-list fanout here.
  */
@@ -80,9 +108,17 @@ class PointcutBlackboardAdapter(
     }
 
     // Slab delivery runs on whichever thread tripped the ring flush, while direct
-    // accept() calls may come from a guest-VM thread — the landing log is shared.
-    private val log: MutableList<PointcutLanding> =
-        java.util.Collections.synchronizedList(ArrayList())
+    // accept() calls may come from a guest-VM thread. Both the landing log AND the
+    // blackboard are shared: ConfixBlackboard keeps plain mutableMapOf stores and
+    // reassigns its doc without synchronization, so the adapter — as the sole
+    // writer on this path — serializes its own puts behind this monitor.
+    private val landingLock = Any()
+    private val log = ArrayList<PointcutLanding>()
+
+    /** Landings dropped because the blackboard threw; see [onSlab]'s isolation. */
+    @Volatile
+    var rejected: Int = 0
+        private set
 
     private val _flow = MutableSharedFlow<PointcutLanding>(
         replay = 0,
@@ -93,8 +129,12 @@ class PointcutBlackboardAdapter(
     /** Landed observations, newest last — a flow, not a callback list. */
     val flow: SharedFlow<PointcutLanding> get() = _flow.asSharedFlow()
 
-    /** All landings so far as a lazy [Series] (kernel algebra, no eager copy). */
-    val landings: Series<PointcutLanding> get() = log.size j { log[it] }
+    /** All landings so far as a lazy [Series] (kernel algebra) over a snapshot. */
+    val landings: Series<PointcutLanding>
+        get() {
+            val snapshot = synchronized(landingLock) { log.toTypedArray() }
+            return snapshot.size j { snapshot[it] }
+        }
 
     /** Blackboard keys touched by this adapter, lazily projected. */
     val keys: Series<String> get() = landings α { it.key }
@@ -103,7 +143,11 @@ class PointcutBlackboardAdapter(
     val coordinates: Series<DagCoordinate> get() = landings α { it.coordinate }
 
     /** Number of observations landed. */
-    val size: Int get() = log.size
+    val size: Int get() = synchronized(landingLock) { log.size }
+
+    /** The subscriber displaced by [install], restored by [uninstall]. */
+    private var displaced: TypedefProductionSystem.SlabSubscriber? = null
+    private var installed = false
 
     // ── TypedefProductionSystem ring → blackboard ────────────────────
 
@@ -111,6 +155,11 @@ class PointcutBlackboardAdapter(
      * Slab delivery from the pointcut ring. Only the first [count] entries of
      * [slab] are live; [epoch]/[nanoStart]/[nanoEnd] frame the slab window and
      * are used to bound landings whose own nano stamp is absent.
+     *
+     * `flush()` is called inline from `publish()` at ring capacity, which means
+     * this method runs on an *instrumented application thread*. A throw from the
+     * blackboard would therefore escape into the traced method, so each landing
+     * is isolated: a failure increments [rejected] and the slab continues.
      */
     override fun onSlab(
         slab: Array<TypedefProductionSystem.TraceEvent>,
@@ -124,7 +173,14 @@ class PointcutBlackboardAdapter(
         val threadId = Thread.currentThread().threadId()
         // Lazy projection over the live prefix — no (0 until size).map materialization.
         val prefix: Series<TypedefProductionSystem.TraceEvent> = live j { slab[it] }
-        val landed: Series<PointcutLanding> = prefix α { evt -> land(evt, threadId, nanoStart) }
+        val landed: Series<PointcutLanding?> = prefix α { evt ->
+            try {
+                land(evt, threadId, nanoStart)
+            } catch (t: Throwable) {
+                rejected++
+                null
+            }
+        }
         // Series is lazy: force exactly once, in order, to perform the puts.
         for (i in 0 until landed.a) landed.b(i)
     }
@@ -145,7 +201,7 @@ class PointcutBlackboardAdapter(
             className = typedef,
             methodName = method,
             bytecodeOffset = evt.siteIdx,
-            timestamp = nano / NANOS_PER_MILLI,
+            timestamp = nanoToEpochMillis(nano),
             threadId = threadId,
         )
         val mark = markOf(isSet = isSetLike(evt.opcode, method), isAfter = evt.phase != 0.toByte())
@@ -163,17 +219,22 @@ class PointcutBlackboardAdapter(
 
     /**
      * Land a direct guest-VM [PointcutEvent]. The event's `coordinate` string is
-     * split on its last `.` into typedef/method; the site index is the intern-pool
-     * ordinal of `propertyName`, which keeps distinct properties on one coordinate
-     * at distinct blackboard keys without a second registry.
+     * split on its last `.` into typedef/method; the site index is [guestSiteIdx]
+     * of `propertyName`, so distinct properties on one coordinate land on distinct
+     * keys without colliding with the ring's bytecode-offset namespace.
+     *
+     * @param isWrite whether this hook observed a write. [PointcutEvent] carries
+     *   no read/write discriminator, so the default infers one from `newValue`
+     *   — which cannot distinguish a read from a **null write** (`obj.x = None`).
+     *   A caller that knows the hook's shape should pass this explicitly rather
+     *   than let a null assignment be recorded as a read.
      */
-    fun accept(event: PointcutEvent): PointcutLanding {
+    @JvmOverloads
+    fun accept(event: PointcutEvent, isWrite: Boolean = event.newValue != null): PointcutLanding {
         val typedef = event.coordinate.substringBeforeLast('.', UNKNOWN_TYPEDEF)
             .ifEmpty { UNKNOWN_TYPEDEF }
         val method = event.coordinate.substringAfterLast('.').ifEmpty { UNKNOWN_METHOD }
-        val siteIdx = TypedefProductionSystem.InternPool.intern(
-            event.propertyName.ifEmpty { event.coordinate }
-        )
+        val siteIdx = guestSiteIdx(event.propertyName.ifEmpty { event.coordinate })
         val coordinate = DagCoordinate(
             className = typedef,
             methodName = method,
@@ -181,9 +242,9 @@ class PointcutBlackboardAdapter(
             timestamp = event.timestamp,
             threadId = Thread.currentThread().threadId(),
         )
-        // A guest hook that carries a newValue is a write observation; the value is
-        // already reified at delivery, so the phase is the AFTER side of that hook.
-        val mark = markOf(isSet = event.newValue != null, isAfter = true)
+        // The value is already reified at delivery, so this is the AFTER side of
+        // whichever hook (get or set) the guest VM fired.
+        val mark = markOf(isSet = isWrite, isAfter = true)
         return put(
             key = keyOf(typedef, method, siteIdx),
             coordinate = coordinate,
@@ -208,21 +269,33 @@ class PointcutBlackboardAdapter(
     // ── Installation ─────────────────────────────────────────────────
 
     /**
-     * Install this adapter as the [TypedefProductionSystem] slab subscriber,
-     * returning the subscriber it displaced so a caller can restore it.
+     * Install this adapter as the [TypedefProductionSystem] slab subscriber.
+     * The displaced subscriber is remembered internally so that a bare
+     * [uninstall] restores it rather than clearing JVM-wide delivery; it is also
+     * returned for callers that want to chain explicitly.
      */
     fun install(): TypedefProductionSystem.SlabSubscriber? {
         val prior = TypedefProductionSystem.subscriber
+        if (prior !== this) displaced = prior
+        installed = true
         TypedefProductionSystem.subscriber = this
-        return prior
+        return displaced
     }
 
-    /** Restore [prior] as the slab subscriber if this adapter is still installed. */
-    fun uninstall(prior: TypedefProductionSystem.SlabSubscriber? = null) {
+    /**
+     * Restore the subscriber displaced by [install] — never null it out blindly.
+     * No-op unless this adapter is the subscriber currently installed.
+     */
+    fun uninstall() {
         if (TypedefProductionSystem.subscriber === this) {
-            TypedefProductionSystem.subscriber = prior
+            TypedefProductionSystem.subscriber = displaced
         }
+        installed = false
+        displaced = null
     }
+
+    /** Whether [install] has run without a matching [uninstall]. */
+    val isInstalled: Boolean get() = installed
 
     // ── Internals ────────────────────────────────────────────────────
 
@@ -235,8 +308,13 @@ class PointcutBlackboardAdapter(
         value: Any?,
     ): PointcutLanding {
         val landing = PointcutLanding(key, coordinate, mark, facet, propertyName, value)
-        blackboard.put(key, landing, language = facet.id)
-        log.add(landing)
+        // ConfixBlackboard is not internally synchronized — serialize both the
+        // board mutation and the log append under one monitor so concurrent
+        // guest accept() and ring onSlab() cannot corrupt either.
+        synchronized(landingLock) {
+            blackboard.put(key, landing, language = facet.id)
+            log.add(landing)
+        }
         _flow.tryEmit(landing)
         return landing
     }
@@ -250,9 +328,38 @@ class PointcutBlackboardAdapter(
         private const val UNKNOWN_TYPEDEF = "?"
         private const val UNKNOWN_METHOD = "?"
 
+        /**
+         * Offset from the `System.nanoTime()` origin to the epoch, captured once.
+         * `nanoTime` is monotonic with an arbitrary origin; the blackboard DAG
+         * orders and range-queries on one timestamp field shared with guest
+         * events, which are epoch-based — so ring stamps must be rebased.
+         */
+        private val EPOCH_MILLIS_AT_ORIGIN: Long =
+            System.currentTimeMillis() - (System.nanoTime() / NANOS_PER_MILLI)
+
+        /** Rebase a `System.nanoTime()` stamp onto the epoch-millisecond axis. */
+        fun nanoToEpochMillis(nano: Long): Long =
+            EPOCH_MILLIS_AT_ORIGIN + (nano / NANOS_PER_MILLI)
+
         /** `pointcut/<typedef>/<method>/<siteIdx>` — the M1 key scheme. */
         fun keyOf(typedef: String, method: String, siteIdx: Int): String =
             "$KEY_PREFIX/$typedef/$method/$siteIdx"
+
+        /**
+         * Stable site index for a guest-VM property name — FNV-1a with the sign
+         * bit forced on. Negative by construction so it can never collide with a
+         * real (non-negative) bytecode offset from the ring, and a pure function
+         * of the name so it is reproducible across runs and does not consume
+         * entries in the fixed-size `InternPool`.
+         */
+        fun guestSiteIdx(propertyName: String): Int {
+            var h = 0x811c9dc5.toInt()
+            for (c in propertyName) {
+                h = (h xor (c.code and 0xFF)) * 0x01000193
+                h = (h xor ((c.code shr 8) and 0xFF)) * 0x01000193
+            }
+            return h or Int.MIN_VALUE
+        }
 
         /** Strip a redundant `typedef.` prefix off a fully-qualified method name. */
         fun shortMethod(typedef: String, method: String): String =

--- a/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapter.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapter.kt
@@ -1,0 +1,287 @@
+@file:Suppress("NonAsciiCharacters")
+
+package borg.trikeshed.pointcut
+
+import borg.trikeshed.context.lcnc.PointcutMark
+import borg.trikeshed.cursor.FieldSynapse
+import borg.trikeshed.cursor.TypedefProductionSystem
+import borg.trikeshed.dag.DagCoordinate
+import borg.trikeshed.graal.ConfixBlackboard
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+import borg.trikeshed.lib.α
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * M1 — Pointcut → Blackboard adapter.
+ *
+ * The midpoint between the Truffle-pointcut ring ([TypedefProductionSystem] slabs,
+ * [PointcutEvent] guest-VM property hooks) and the polyglot blackboard
+ * ([ConfixBlackboard]).
+ *
+ * Every pointcut observation is normalized to a [DagCoordinate] — the blackboard
+ * classfile DAG's primary event fabric coordinate (BlackboardDagFabric.kt) — and
+ * landed under the key scheme
+ *
+ * ```
+ * pointcut/<typedef>/<method>/<siteIdx>
+ * ```
+ *
+ * with provenance `language = event.vmFacet.id`, so a landing keeps its guest-VM
+ * facet identity all the way into the confix provenance table.
+ *
+ * The value payload is a [PointcutLanding] carrying the zero-cost [PointcutMark]
+ * byte (LcncSpineMarks.kt) alongside the coordinate — the pointcut phase tag is
+ * part of the landed record, not a side channel.
+ *
+ * Downstream consumers read [landings] (a lazy [Series], `α`-projected columns,
+ * no eager loop) or collect [flow]; there is no callback-list fanout here.
+ */
+class PointcutBlackboardAdapter(
+    /** The blackboard this adapter lands pointcut observations on. */
+    val blackboard: ConfixBlackboard,
+    /**
+     * Facet attributed to [TypedefProductionSystem] slab events — those come
+     * from the host JVM ring, so [VmFacet.JVM] ("java") is the default.
+     * Guest-VM [PointcutEvent]s carry their own facet and ignore this.
+     */
+    val slabFacet: VmFacet = VmFacet.JVM,
+) : TypedefProductionSystem.SlabSubscriber {
+
+    /**
+     * One landed pointcut observation.
+     *
+     * @property key the blackboard key this landing occupies
+     * @property coordinate DAG fabric coordinate for the observation
+     * @property mark zero-cost pointcut phase tag; [PointcutMark.raw] is the byte
+     * @property facet guest/host VM facet — the provenance `language`
+     * @property propertyName property or opcode label at the pointcut site
+     * @property value the observed value, when the pointcut carried one
+     */
+    data class PointcutLanding(
+        val key: String,
+        val coordinate: DagCoordinate,
+        val mark: PointcutMark,
+        val facet: VmFacet,
+        val propertyName: String,
+        val value: Any?,
+    ) {
+        /** The [PointcutMark] byte, unwrapped — the payload's phase ordinal. */
+        val markRaw: Byte get() = mark.raw
+
+        /** Provenance language landed with this record. */
+        val language: String get() = facet.id
+
+        override fun toString(): String =
+            "$key#${mark.raw}@${coordinate.timestamp}:${facet.id}"
+    }
+
+    // Slab delivery runs on whichever thread tripped the ring flush, while direct
+    // accept() calls may come from a guest-VM thread — the landing log is shared.
+    private val log: MutableList<PointcutLanding> =
+        java.util.Collections.synchronizedList(ArrayList())
+
+    private val _flow = MutableSharedFlow<PointcutLanding>(
+        replay = 0,
+        extraBufferCapacity = FLOW_BUFFER,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /** Landed observations, newest last — a flow, not a callback list. */
+    val flow: SharedFlow<PointcutLanding> get() = _flow.asSharedFlow()
+
+    /** All landings so far as a lazy [Series] (kernel algebra, no eager copy). */
+    val landings: Series<PointcutLanding> get() = log.size j { log[it] }
+
+    /** Blackboard keys touched by this adapter, lazily projected. */
+    val keys: Series<String> get() = landings α { it.key }
+
+    /** Coordinates landed by this adapter, lazily projected. */
+    val coordinates: Series<DagCoordinate> get() = landings α { it.coordinate }
+
+    /** Number of observations landed. */
+    val size: Int get() = log.size
+
+    // ── TypedefProductionSystem ring → blackboard ────────────────────
+
+    /**
+     * Slab delivery from the pointcut ring. Only the first [count] entries of
+     * [slab] are live; [epoch]/[nanoStart]/[nanoEnd] frame the slab window and
+     * are used to bound landings whose own nano stamp is absent.
+     */
+    override fun onSlab(
+        slab: Array<TypedefProductionSystem.TraceEvent>,
+        count: Int,
+        epoch: Long,
+        nanoStart: Long,
+        nanoEnd: Long,
+    ) {
+        val live = minOf(count, slab.size)
+        if (live <= 0) return
+        val threadId = Thread.currentThread().threadId()
+        // Lazy projection over the live prefix — no (0 until size).map materialization.
+        val prefix: Series<TypedefProductionSystem.TraceEvent> = live j { slab[it] }
+        val landed: Series<PointcutLanding> = prefix α { evt -> land(evt, threadId, nanoStart) }
+        // Series is lazy: force exactly once, in order, to perform the puts.
+        for (i in 0 until landed.a) landed.b(i)
+    }
+
+    /** Land a single ring [TypedefProductionSystem.TraceEvent]. */
+    fun accept(event: TypedefProductionSystem.TraceEvent): PointcutLanding =
+        land(event, Thread.currentThread().threadId(), event.nano)
+
+    private fun land(
+        evt: TypedefProductionSystem.TraceEvent,
+        threadId: Long,
+        slabNanoStart: Long,
+    ): PointcutLanding {
+        val typedef = evt.typedefName().ifEmpty { UNKNOWN_TYPEDEF }
+        val method = shortMethod(typedef, evt.methodName().ifEmpty { UNKNOWN_METHOD })
+        val nano = if (evt.nano != 0L) evt.nano else slabNanoStart
+        val coordinate = DagCoordinate(
+            className = typedef,
+            methodName = method,
+            bytecodeOffset = evt.siteIdx,
+            timestamp = nano / NANOS_PER_MILLI,
+            threadId = threadId,
+        )
+        val mark = markOf(isSet = isSetLike(evt.opcode, method), isAfter = evt.phase != 0.toByte())
+        return put(
+            key = keyOf(typedef, method, evt.siteIdx),
+            coordinate = coordinate,
+            mark = mark,
+            facet = slabFacet,
+            propertyName = evt.opcodeName(),
+            value = evt.callsiteHash,
+        )
+    }
+
+    // ── Guest-VM PointcutEvent → blackboard ──────────────────────────
+
+    /**
+     * Land a direct guest-VM [PointcutEvent]. The event's `coordinate` string is
+     * split on its last `.` into typedef/method; the site index is the intern-pool
+     * ordinal of `propertyName`, which keeps distinct properties on one coordinate
+     * at distinct blackboard keys without a second registry.
+     */
+    fun accept(event: PointcutEvent): PointcutLanding {
+        val typedef = event.coordinate.substringBeforeLast('.', UNKNOWN_TYPEDEF)
+            .ifEmpty { UNKNOWN_TYPEDEF }
+        val method = event.coordinate.substringAfterLast('.').ifEmpty { UNKNOWN_METHOD }
+        val siteIdx = TypedefProductionSystem.InternPool.intern(
+            event.propertyName.ifEmpty { event.coordinate }
+        )
+        val coordinate = DagCoordinate(
+            className = typedef,
+            methodName = method,
+            bytecodeOffset = siteIdx,
+            timestamp = event.timestamp,
+            threadId = Thread.currentThread().threadId(),
+        )
+        // A guest hook that carries a newValue is a write observation; the value is
+        // already reified at delivery, so the phase is the AFTER side of that hook.
+        val mark = markOf(isSet = event.newValue != null, isAfter = true)
+        return put(
+            key = keyOf(typedef, method, siteIdx),
+            coordinate = coordinate,
+            mark = mark,
+            facet = event.vmFacet,
+            propertyName = event.propertyName,
+            value = event.newValue,
+        )
+    }
+
+    /**
+     * Land a whole [Series] of guest-VM events, lazily projected, returning the
+     * landings produced by *this* call (not the whole [landings] log).
+     */
+    fun acceptAll(events: Series<PointcutEvent>): Series<PointcutLanding> {
+        val projected = events α { accept(it) }
+        val landed = ArrayList<PointcutLanding>(projected.a)
+        for (i in 0 until projected.a) landed.add(projected.b(i))
+        return landed.size j { landed[it] }
+    }
+
+    // ── Installation ─────────────────────────────────────────────────
+
+    /**
+     * Install this adapter as the [TypedefProductionSystem] slab subscriber,
+     * returning the subscriber it displaced so a caller can restore it.
+     */
+    fun install(): TypedefProductionSystem.SlabSubscriber? {
+        val prior = TypedefProductionSystem.subscriber
+        TypedefProductionSystem.subscriber = this
+        return prior
+    }
+
+    /** Restore [prior] as the slab subscriber if this adapter is still installed. */
+    fun uninstall(prior: TypedefProductionSystem.SlabSubscriber? = null) {
+        if (TypedefProductionSystem.subscriber === this) {
+            TypedefProductionSystem.subscriber = prior
+        }
+    }
+
+    // ── Internals ────────────────────────────────────────────────────
+
+    private fun put(
+        key: String,
+        coordinate: DagCoordinate,
+        mark: PointcutMark,
+        facet: VmFacet,
+        propertyName: String,
+        value: Any?,
+    ): PointcutLanding {
+        val landing = PointcutLanding(key, coordinate, mark, facet, propertyName, value)
+        blackboard.put(key, landing, language = facet.id)
+        log.add(landing)
+        _flow.tryEmit(landing)
+        return landing
+    }
+
+    companion object {
+        /** Key prefix for every pointcut landing. */
+        const val KEY_PREFIX = "pointcut"
+
+        private const val FLOW_BUFFER = 256
+        private const val NANOS_PER_MILLI = 1_000_000L
+        private const val UNKNOWN_TYPEDEF = "?"
+        private const val UNKNOWN_METHOD = "?"
+
+        /** `pointcut/<typedef>/<method>/<siteIdx>` — the M1 key scheme. */
+        fun keyOf(typedef: String, method: String, siteIdx: Int): String =
+            "$KEY_PREFIX/$typedef/$method/$siteIdx"
+
+        /** Strip a redundant `typedef.` prefix off a fully-qualified method name. */
+        fun shortMethod(typedef: String, method: String): String =
+            if (typedef.isNotEmpty() && method.startsWith("$typedef.")) {
+                method.substring(typedef.length + 1).ifEmpty { method }
+            } else method
+
+        /**
+         * Resolve the [PointcutMark] for a (set?, after?) pair through the
+         * FieldSynapse template vocabulary, so the mark stays aligned 1:1 with
+         * `FieldSynapse.TPL_*` rather than being re-ordinaled here.
+         */
+        fun markOf(isSet: Boolean, isAfter: Boolean): PointcutMark = PointcutMark.fromTemplate(
+            when {
+                isSet && isAfter -> FieldSynapse.TPL_AFTER_SET
+                isSet -> FieldSynapse.TPL_BEFORE_SET
+                isAfter -> FieldSynapse.TPL_AFTER_GET
+                else -> FieldSynapse.TPL_BEFORE_GET
+            }
+        )
+
+        /**
+         * A ring opcode is write-shaped when it is a PROPERTY/PARAMETER site whose
+         * method reads as a mutator; everything else on the ring is a read/observe.
+         */
+        fun isSetLike(opcode: Byte, method: String): Boolean =
+            when (opcode.toInt() and 0xFF) {
+                0x13, 0x14 -> method.startsWith("set") || method.startsWith("put")
+                else -> false
+            }
+    }
+}

--- a/src/jvmTest/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapterTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapterTest.kt
@@ -4,9 +4,11 @@ import borg.trikeshed.context.lcnc.PointcutMark
 import borg.trikeshed.cursor.TypedefProductionSystem
 import borg.trikeshed.graal.ConfixBlackboard
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -15,8 +17,17 @@ import kotlin.test.assertTrue
  */
 class PointcutBlackboardAdapterTest {
 
+    // TypedefProductionSystem is a JVM-wide singleton: capture whatever state we
+    // find on entry and put exactly that back, so tests that never touch the
+    // singleton do not clobber it for other classes sharing the JVM.
     private var priorSubscriber: TypedefProductionSystem.SlabSubscriber? = null
     private var priorActive = false
+
+    @BeforeTest
+    fun capture() {
+        priorSubscriber = TypedefProductionSystem.subscriber
+        priorActive = TypedefProductionSystem.active
+    }
 
     @AfterTest
     fun restore() {
@@ -85,6 +96,25 @@ class PointcutBlackboardAdapterTest {
     }
 
     @Test
+    fun `explicit isWrite distinguishes a null write from a read`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        // obj.head = None — newValue is null but this is still a write.
+        val written = adapter.accept(
+            PointcutEvent(VmFacet.GRAAL_PYTHON, "m.C.f", null, "head", null, 3L),
+            isWrite = true,
+        )
+        assertEquals(PointcutMark.AfterSet.raw, written.markRaw)
+
+        val read = adapter.accept(
+            PointcutEvent(VmFacet.GRAAL_PYTHON, "m.C.f", null, "head", null, 4L),
+            isWrite = false,
+        )
+        assertEquals(PointcutMark.AfterGet.raw, read.markRaw)
+    }
+
+    @Test
     fun `distinct properties on one coordinate land on distinct keys`() {
         val bb = ConfixBlackboard.empty()
         val adapter = PointcutBlackboardAdapter(bb)
@@ -103,12 +133,46 @@ class PointcutBlackboardAdapterTest {
     }
 
     @Test
+    fun `guest site index is stable and disjoint from bytecode offsets`() {
+        // Reproducible across calls (and therefore across runs) — not an
+        // interning ordinal that depends on global class-init order.
+        assertEquals(
+            PointcutBlackboardAdapter.guestSiteIdx("head"),
+            PointcutBlackboardAdapter.guestSiteIdx("head"),
+        )
+        // Negative by construction, so it can never alias a real bytecode offset.
+        assertTrue(PointcutBlackboardAdapter.guestSiteIdx("head") < 0)
+        assertTrue(PointcutBlackboardAdapter.guestSiteIdx("") < 0)
+
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+        val guest = adapter.accept(
+            PointcutEvent(VmFacet.GRAAL_JS, "m.C.f", null, "x", 1, 1L)
+        )
+        assertTrue(guest.coordinate.bytecodeOffset < 0)
+        // A ring landing on the same class/method with a real offset must not collide.
+        assertTrue(guest.key != PointcutBlackboardAdapter.keyOf("m.C", "f", 9))
+    }
+
+    @Test
+    fun `ring and guest landings share one epoch millisecond timebase`() {
+        val before = System.currentTimeMillis()
+        val rebased = PointcutBlackboardAdapter.nanoToEpochMillis(System.nanoTime())
+        val after = System.currentTimeMillis()
+
+        // A nanoTime stamp rebases into the same epoch window a guest event uses,
+        // so the DAG's causal-parent search cannot systematically order every JVM
+        // landing before every guest landing.
+        assertTrue(
+            rebased in (before - 1_000)..(after + 1_000),
+            "rebased=$rebased outside [$before,$after]",
+        )
+    }
+
+    @Test
     fun `ring slab publish flows through installed subscriber onto blackboard`() {
         val bb = ConfixBlackboard.empty()
         val adapter = PointcutBlackboardAdapter(bb, slabFacet = VmFacet.JVM)
-
-        priorSubscriber = TypedefProductionSystem.subscriber
-        priorActive = TypedefProductionSystem.active
 
         adapter.install()
         TypedefProductionSystem.active = true
@@ -133,9 +197,58 @@ class PointcutBlackboardAdapterTest {
         assertEquals("CALL", stored.propertyName)
         // BEFORE phase on a non-mutator opcode -> BeforeGet
         assertEquals(PointcutMark.BeforeGet.raw, stored.markRaw)
+        // ring stamps rebase onto epoch millis, not the raw nanoTime origin
+        assertTrue(stored.coordinate.timestamp > 1_600_000_000_000L, "${stored.coordinate.timestamp}")
 
         assertEquals(VmFacet.JVM.id, bb.getProvenance(key)?.language)
         assertEquals("java", bb.getProvenance(key)?.language)
+        assertEquals(0, adapter.rejected)
+    }
+
+    @Test
+    fun `uninstall restores the displaced subscriber rather than nulling it`() {
+        val sentinel = object : TypedefProductionSystem.SlabSubscriber {
+            override fun onSlab(
+                slab: Array<TypedefProductionSystem.TraceEvent>,
+                count: Int,
+                epoch: Long,
+                nanoStart: Long,
+                nanoEnd: Long,
+            ) = Unit
+        }
+        TypedefProductionSystem.subscriber = sentinel
+
+        val adapter = PointcutBlackboardAdapter(ConfixBlackboard.empty())
+        val displaced = adapter.install()
+
+        assertSame(sentinel, displaced)
+        assertSame(adapter, TypedefProductionSystem.subscriber)
+        assertTrue(adapter.isInstalled)
+
+        // The bare, no-argument uninstall must put the sentinel back — not null.
+        adapter.uninstall()
+        assertSame(sentinel, TypedefProductionSystem.subscriber)
+        assertTrue(!adapter.isInstalled)
+    }
+
+    @Test
+    fun `onSlab isolates a throwing landing from the instrumented thread`() {
+        // flush() runs inline on the traced application thread, so a failure
+        // anywhere in the landing path must be absorbed and counted, never
+        // propagated out of onSlab into the method being traced.
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        // typedefIdx past the fixed 65536-entry TypedefTable: resolve() indexes
+        // its backing array directly, so this throws inside land().
+        val poison = traceEvent().copy(typedefIdx = 70_000)
+
+        adapter.onSlab(arrayOf(poison, traceEvent()), 2, 0L, 0L, 0L)
+
+        // the bad event was rejected, the good one still landed
+        assertEquals(1, adapter.rejected)
+        assertEquals(1, adapter.size)
+        assertTrue(bb.has(PointcutBlackboardAdapter.keyOf("org..types.Bag", "setLoad", 9)))
     }
 
     @Test
@@ -146,20 +259,8 @@ class PointcutBlackboardAdapterTest {
         adapter.onSlab(emptyArray(), 0, 0L, 0L, 0L)
         assertEquals(0, adapter.size)
 
-        val evt = TypedefProductionSystem.TraceEvent(
-            opcode = TypedefProductionSystem.OP_PROPERTY,
-            phase = 1,
-            typedefIdx = TypedefProductionSystem.TypedefTable.register("org..types.Bag"),
-            methodIdx = TypedefProductionSystem.InternPool.intern("org..types.Bag.setLoad"),
-            siteIdx = 9,
-            seq = 0,
-            nano = 5_000_000L,
-            depth = 1,
-            callsiteHash = 0xBEEF,
-            templateIdx = 0,
-        )
         // count larger than the array must clamp, not throw
-        adapter.onSlab(arrayOf(evt), 5, 1L, 5_000_000L, 5_000_000L)
+        adapter.onSlab(arrayOf(traceEvent()), 5, 1L, 5_000_000L, 5_000_000L)
 
         val key = PointcutBlackboardAdapter.keyOf("org..types.Bag", "setLoad", 9)
         assertEquals(1, adapter.size)
@@ -167,6 +268,22 @@ class PointcutBlackboardAdapterTest {
         val stored = bb.get(key) as PointcutBlackboardAdapter.PointcutLanding
         // AFTER phase on a PROPERTY set* site -> AfterSet
         assertEquals(PointcutMark.AfterSet.raw, stored.markRaw)
-        assertEquals(5L, stored.coordinate.timestamp)
+        assertEquals(
+            PointcutBlackboardAdapter.nanoToEpochMillis(5_000_000L),
+            stored.coordinate.timestamp,
+        )
     }
+
+    private fun traceEvent() = TypedefProductionSystem.TraceEvent(
+        opcode = TypedefProductionSystem.OP_PROPERTY,
+        phase = 1,
+        typedefIdx = TypedefProductionSystem.TypedefTable.register("org..types.Bag"),
+        methodIdx = TypedefProductionSystem.InternPool.intern("org..types.Bag.setLoad"),
+        siteIdx = 9,
+        seq = 0,
+        nano = 5_000_000L,
+        depth = 1,
+        callsiteHash = 0xBEEF,
+        templateIdx = 0,
+    )
 }

--- a/src/jvmTest/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapterTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapterTest.kt
@@ -1,0 +1,172 @@
+package borg.trikeshed.pointcut
+
+import borg.trikeshed.context.lcnc.PointcutMark
+import borg.trikeshed.cursor.TypedefProductionSystem
+import borg.trikeshed.graal.ConfixBlackboard
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * M1 gate — publish → adapter → blackboard entry present with provenance
+ * `language` = [VmFacet] id.
+ */
+class PointcutBlackboardAdapterTest {
+
+    private var priorSubscriber: TypedefProductionSystem.SlabSubscriber? = null
+    private var priorActive = false
+
+    @AfterTest
+    fun restore() {
+        TypedefProductionSystem.subscriber = priorSubscriber
+        TypedefProductionSystem.active = priorActive
+    }
+
+    @Test
+    fun `guest VM PointcutEvent lands with facet provenance`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        val landing = adapter.accept(
+            PointcutEvent(
+                vmFacet = VmFacet.GRAAL_PYTHON,
+                coordinate = "org..types.Chain.push",
+                target = null,
+                propertyName = "head",
+                newValue = 42,
+                timestamp = 1_700_000_000_000L,
+            )
+        )
+
+        // key scheme: pointcut/<typedef>/<method>/<siteIdx>
+        assertTrue(landing.key.startsWith("pointcut/org..types.Chain/push/"), landing.key)
+
+        // blackboard entry present
+        assertTrue(bb.has(landing.key), "blackboard missing ${landing.key}")
+        val stored = bb.get(landing.key) as PointcutBlackboardAdapter.PointcutLanding
+        assertEquals(landing, stored)
+
+        // provenance language == VmFacet id
+        val prov = bb.getProvenance(landing.key)
+        assertNotNull(prov)
+        assertEquals(VmFacet.GRAAL_PYTHON.id, prov.language)
+        assertEquals("python", prov.language)
+
+        // DagCoordinate mapping
+        assertEquals("org..types.Chain", stored.coordinate.className)
+        assertEquals("push", stored.coordinate.methodName)
+        assertEquals(1_700_000_000_000L, stored.coordinate.timestamp)
+        assertTrue(stored.coordinate.threadId > 0)
+
+        // PointcutMark byte rides in the payload — a carried newValue is an AFTER_SET
+        assertEquals(PointcutMark.AfterSet.raw, stored.markRaw)
+    }
+
+    @Test
+    fun `guest VM read observation marks AfterGet`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        val landing = adapter.accept(
+            PointcutEvent(
+                vmFacet = VmFacet.GRAAL_JS,
+                coordinate = "org..types.Chain.head",
+                target = null,
+                propertyName = "head",
+                newValue = null,
+                timestamp = 7L,
+            )
+        )
+
+        assertEquals(PointcutMark.AfterGet.raw, landing.markRaw)
+        assertEquals("js", bb.getProvenance(landing.key)?.language)
+    }
+
+    @Test
+    fun `distinct properties on one coordinate land on distinct keys`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        val a = adapter.accept(
+            PointcutEvent(VmFacet.GRAAL_RUBY, "m.C.f", null, "alpha", 1, 10L)
+        )
+        val b = adapter.accept(
+            PointcutEvent(VmFacet.GRAAL_RUBY, "m.C.f", null, "beta", 2, 11L)
+        )
+
+        assertTrue(a.key != b.key, "expected distinct keys, got ${a.key}")
+        assertTrue(bb.has(a.key) && bb.has(b.key))
+        assertEquals(2, adapter.size)
+        assertEquals(2, adapter.keys.a)
+    }
+
+    @Test
+    fun `ring slab publish flows through installed subscriber onto blackboard`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb, slabFacet = VmFacet.JVM)
+
+        priorSubscriber = TypedefProductionSystem.subscriber
+        priorActive = TypedefProductionSystem.active
+
+        adapter.install()
+        TypedefProductionSystem.active = true
+
+        TypedefProductionSystem.publish(
+            opcode = TypedefProductionSystem.OP_CALL,
+            typedefName = "org..types.Chain",
+            methodName = "org..types.Chain.push",
+            siteIdx = 0x1234,
+            depth = 2,
+            isAfter = false,
+        )
+        TypedefProductionSystem.flush("test")
+
+        val key = PointcutBlackboardAdapter.keyOf("org..types.Chain", "push", 0x1234)
+        assertTrue(bb.has(key), "blackboard keys=${bb.keys()}")
+
+        val stored = bb.get(key) as PointcutBlackboardAdapter.PointcutLanding
+        assertEquals("org..types.Chain", stored.coordinate.className)
+        assertEquals("push", stored.coordinate.methodName)
+        assertEquals(0x1234, stored.coordinate.bytecodeOffset)
+        assertEquals("CALL", stored.propertyName)
+        // BEFORE phase on a non-mutator opcode -> BeforeGet
+        assertEquals(PointcutMark.BeforeGet.raw, stored.markRaw)
+
+        assertEquals(VmFacet.JVM.id, bb.getProvenance(key)?.language)
+        assertEquals("java", bb.getProvenance(key)?.language)
+    }
+
+    @Test
+    fun `onSlab honors count over array length and is a no-op when empty`() {
+        val bb = ConfixBlackboard.empty()
+        val adapter = PointcutBlackboardAdapter(bb)
+
+        adapter.onSlab(emptyArray(), 0, 0L, 0L, 0L)
+        assertEquals(0, adapter.size)
+
+        val evt = TypedefProductionSystem.TraceEvent(
+            opcode = TypedefProductionSystem.OP_PROPERTY,
+            phase = 1,
+            typedefIdx = TypedefProductionSystem.TypedefTable.register("org..types.Bag"),
+            methodIdx = TypedefProductionSystem.InternPool.intern("org..types.Bag.setLoad"),
+            siteIdx = 9,
+            seq = 0,
+            nano = 5_000_000L,
+            depth = 1,
+            callsiteHash = 0xBEEF,
+            templateIdx = 0,
+        )
+        // count larger than the array must clamp, not throw
+        adapter.onSlab(arrayOf(evt), 5, 1L, 5_000_000L, 5_000_000L)
+
+        val key = PointcutBlackboardAdapter.keyOf("org..types.Bag", "setLoad", 9)
+        assertEquals(1, adapter.size)
+        assertTrue(bb.has(key), "blackboard keys=${bb.keys()}")
+        val stored = bb.get(key) as PointcutBlackboardAdapter.PointcutLanding
+        // AFTER phase on a PROPERTY set* site -> AfterSet
+        assertEquals(PointcutMark.AfterSet.raw, stored.markRaw)
+        assertEquals(5L, stored.coordinate.timestamp)
+    }
+}


### PR DESCRIPTION
## M1 — Pointcut→Blackboard adapter

Draws the midpoint between the Truffle-pointcut ring and the polyglot blackboard.

`src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutBlackboardAdapter.kt` implements `TypedefProductionSystem.SlabSubscriber` (installable via the `subscriber` var, per the `TypedefProductionSystemMain` pattern) **and** accepts direct guest-VM `PointcutEvent`s. Both paths normalize to a `DagCoordinate(className, methodName, bytecodeOffset, timestamp, threadId)` and land on `borg.trikeshed.graal.ConfixBlackboard` via `put(key, value, language = event.vmFacet.id)`.

**Key scheme:** `pointcut/<typedef>/<method>/<siteIdx>`

**Payload:** `PointcutLanding` carrying the zero-cost `PointcutMark` byte (`LcncSpineMarks.kt`) alongside the coordinate — the pointcut phase tag rides in the record, not a side channel.

### Decisions taken at convention-consistent forks

- `TraceEvent.templateIdx` is an **InternPool ordinal**, not a `FieldSynapse.TPL_*` index, so `PointcutMark` is derived from `(opcode, phase)` and routed through `PointcutMark.fromTemplate` with the `FieldSynapse.TPL_*` constants rather than re-ordinaled locally.
- A ring opcode is write-shaped only for `PROPERTY`/`PARAMETER` sites whose method reads as a mutator (`set*`/`put*`); everything else is an observe/read.
- A guest `PointcutEvent` carrying a `newValue` is `AFTER_SET`; one without is `AFTER_GET` — the value is already reified at delivery.
- `PointcutEvent` has no `siteIdx`, so the site is the `InternPool` ordinal of `propertyName`; distinct properties on one coordinate land on distinct keys without a second registry.
- Slab facet defaults to `VmFacet.JVM` ("java") since the ring is the host ring; guest events carry their own facet.

### Conventions

Kernel algebra throughout — lazy `α` projections over `n j { … }` series, no `(0 until size).map` materialization. Downstream fanout is a `SharedFlow`, not a callback list. The landing log is a synchronized list because slab flush and guest `accept()` run on different threads. No sibling-owned file touched; purely additive (2 new files).

### Verification

- `./gradlew jvmMainClasses --console=plain` — **BUILD SUCCESSFUL** (pre-existing cinterop opt-in warnings only)
- `./gradlew jvmTest --tests 'borg.trikeshed.pointcut.PointcutBlackboardAdapterTest' --console=plain` — **5/5 PASSED**
  - publish → adapter → blackboard entry present with provenance `language` = `VmFacet` id (both guest and ring paths)
  - key-scheme, `PointcutMark` byte, `count` clamping / empty-slab no-op, distinct-site separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)