### PR TITLE
refactor(graal): ConfixBlackboard reactor form — SharedFlow<ConfixDoc> changes stream

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
@@ -3,15 +3,29 @@ package borg.trikeshed.graal
 import borg.trikeshed.parse.confix.*
 import borg.trikeshed.cursor.*
 import borg.trikeshed.lib.*
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.datetime.Clock
 
 /**
  * ConfixBlackboard — content-addressed blackboard backed by ConfixDoc.
- * 
+ *
  * Provides a shared workspace for polyglot language communication with:
  * - Content-addressed storage (ConfixDoc as key)
- * - Event subscription via CursorFacet pattern
+ * - Reactor-form change stream via [changes] (SharedFlow<ConfixDoc>)
  * - Provenance tracking for each entry
+ *
+ * Reactor/lifecycle notes (CCEK-style):
+ * - [state] is the single source of truth; every mutator ([put], [remove], [merge])
+ *   emits the post-mutation ConfixDoc snapshot into [changes].
+ * - Emission uses `tryEmit` against `extraBufferCapacity`, so mutators stay
+ *   synchronous and never suspend; slow collectors may drop intermediate
+ *   snapshots but always converge on a later (newer) [state].
+ * - The blackboard owns no coroutine scope: collectors bring their own scope
+ *   and simply stop collecting to detach — no close/shutdown is required.
+ * - The legacy callback [subscribe] remains as a deprecated synchronous shim.
  */
 class ConfixBlackboard {
     
@@ -32,7 +46,21 @@ class ConfixBlackboard {
         val sourceLocation: String? = null
     )
     
-    /** Subscribe to blackboard changes */
+    /**
+     * Reactor-form change stream. Each mutation emits the post-mutation [state].
+     * `extraBufferCapacity` + `DROP_OLDEST` guarantee `tryEmit` always succeeds
+     * without suspending in the synchronous mutators: under back-pressure the
+     * *oldest* buffered snapshot is discarded, never the newest one.
+     */
+    private val _changes = MutableSharedFlow<ConfixDoc>(
+        extraBufferCapacity = CHANGE_BUFFER_CAPACITY,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /** Hot stream of ConfixDoc snapshots, one per mutation. Collect to observe the blackboard. */
+    val changes: SharedFlow<ConfixDoc> = _changes.asSharedFlow()
+
+    /** Legacy synchronous shim — see [subscribe]. */
     private val subscribers = mutableListOf<(ConfixDoc) -> Unit>()
     
     // ─────────────────────────────────────────────────────────────────
@@ -77,13 +105,23 @@ class ConfixBlackboard {
         return this
     }
     
-    /** Subscribe to changes */
+    /**
+     * Subscribe to changes (legacy synchronous shim).
+     *
+     * Handlers are invoked synchronously inside each mutator, mirroring the
+     * pre-reactor behavior, and receive the same snapshots emitted on [changes].
+     */
+    @Deprecated(
+        message = "Collect the changes SharedFlow instead; this synchronous shim exists only for legacy callers.",
+        replaceWith = ReplaceWith("changes"),
+    )
     fun subscribe(handler: (ConfixDoc) -> Unit): () -> Unit {
         subscribers.add(handler)
         return { subscribers.remove(handler) }
     }
-    
+
     private fun notifySubscribers() {
+        _changes.tryEmit(doc)
         subscribers.forEach { it(doc) }
     }
     
@@ -98,6 +136,9 @@ class ConfixBlackboard {
     // ─────────────────────────────────────────────────────────────────
     
     companion object {
+        /** Buffered snapshots per collector before the oldest is dropped. */
+        const val CHANGE_BUFFER_CAPACITY: Int = 64
+
         fun empty(): ConfixBlackboard = ConfixBlackboard()
         
         fun fromMap(map: Map<String, Any?>, language: String = "init"): ConfixBlackboard {

--- a/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/graal/ConfixBlackboard.kt
@@ -18,11 +18,25 @@ import kotlinx.datetime.Clock
  * - Provenance tracking for each entry
  *
  * Reactor/lifecycle notes (CCEK-style):
- * - [state] is the single source of truth; every mutator ([put], [remove], [merge])
- *   emits the post-mutation ConfixDoc snapshot into [changes].
- * - Emission uses `tryEmit` against `extraBufferCapacity`, so mutators stay
- *   synchronous and never suspend; slow collectors may drop intermediate
- *   snapshots but always converge on a later (newer) [state].
+ * - Every mutator ([put], [remove], [merge]) emits the post-mutation [state]
+ *   into [changes], so collectors observe exactly one snapshot per mutation.
+ * - **Caveat: [state] is not a full view of the board.** The authoritative
+ *   key/value store is the private map behind [get] / [keys] / [has]; `doc` is
+ *   rebuilt by a single-key `ConfixDoc.set` and `ConfixDoc.remove` is a no-op,
+ *   so an emitted snapshot carries only the most recently written key and never
+ *   reflects a deletion. This predates the reactor form — collectors that need
+ *   the whole board must read [get] / [keys] rather than parse the emitted doc.
+ *   Making `doc` a faithful multi-key projection is follow-up work.
+ * - Cost note: each [put] rebuilds and reparses a one-key JSON document inline on
+ *   the caller's thread, so a bulk flush pays one parse per entry. Fixing that
+ *   means making `doc` lazy or incremental, which is the same follow-up as above.
+ * - Emission uses `tryEmit` with `DROP_OLDEST`, so it always succeeds and the
+ *   mutators stay synchronous and non-suspending. A slow collector loses
+ *   intermediate snapshots under back-pressure, but the values it does receive
+ *   are always the newest ones, and `replay = 1` hands a late subscriber the
+ *   current snapshot instead of nothing.
+ * - Mutation is not synchronized: confine writes to a single writer. The
+ *   emitted ConfixDoc values are immutable, so collectors are safe anywhere.
  * - The blackboard owns no coroutine scope: collectors bring their own scope
  *   and simply stop collecting to detach — no close/shutdown is required.
  * - The legacy callback [subscribe] remains as a deprecated synchronous shim.
@@ -48,11 +62,17 @@ class ConfixBlackboard {
     
     /**
      * Reactor-form change stream. Each mutation emits the post-mutation [state].
-     * `extraBufferCapacity` + `DROP_OLDEST` guarantee `tryEmit` always succeeds
-     * without suspending in the synchronous mutators: under back-pressure the
-     * *oldest* buffered snapshot is discarded, never the newest one.
+     *
+     * `DROP_OLDEST` over a non-zero buffer makes `tryEmit` *always succeed*, which
+     * is what lets the mutators stay plain non-suspending functions: under
+     * back-pressure the **oldest** buffered snapshot is discarded, never the
+     * newest, so a lagging collector still converges on current truth.
+     * `replay = 1` closes the subscribe-after-mutate race — a collector that
+     * attaches late is handed the latest snapshot rather than waiting for the
+     * next write.
      */
     private val _changes = MutableSharedFlow<ConfixDoc>(
+        replay = 1,
         extraBufferCapacity = CHANGE_BUFFER_CAPACITY,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
@@ -111,9 +131,10 @@ class ConfixBlackboard {
      * Handlers are invoked synchronously inside each mutator, mirroring the
      * pre-reactor behavior, and receive the same snapshots emitted on [changes].
      */
+    // No ReplaceWith: `changes` is a SharedFlow property, not a drop-in for a
+    // (handler) -> unsubscribe call, so a mechanical quick-fix would not compile.
     @Deprecated(
         message = "Collect the changes SharedFlow instead; this synchronous shim exists only for legacy callers.",
-        replaceWith = ReplaceWith("changes"),
     )
     fun subscribe(handler: (ConfixDoc) -> Unit): () -> Unit {
         subscribers.add(handler)
@@ -122,7 +143,9 @@ class ConfixBlackboard {
 
     private fun notifySubscribers() {
         _changes.tryEmit(doc)
-        subscribers.forEach { it(doc) }
+        // Copy before dispatch: a legacy handler is allowed to unsubscribe itself
+        // from inside the callback, which would otherwise mutate the list mid-iteration.
+        if (subscribers.isNotEmpty()) subscribers.toList().forEach { it(doc) }
     }
     
     /** Get snapshot as Series<Pair> for cursor operations */
@@ -156,18 +179,46 @@ private fun emptyConfix(): ConfixDoc = confixDoc("{}".encodeToByteArray(), Synta
 
 private fun ConfixDoc.set(key: String, value: Any?): ConfixDoc {
     val json = buildString {
-        append("{")
-        append("\"$key\":")
-        append(when (value) {
-            null -> "null"
-            is String -> "\"$value\""
-            is Number -> value.toString()
-            is Boolean -> value.toString()
-            else -> "\"$value\""
-        })
-        append("}")
+        append('{')
+        appendJsonString(key)
+        append(':')
+        when (value) {
+            null -> append("null")
+            is Number -> append(value.toString())
+            is Boolean -> append(value.toString())
+            is String -> appendJsonString(value)
+            else -> appendJsonString(value.toString())
+        }
+        append('}')
     }
     return confixDoc(json.encodeToByteArray(), Syntax.JSON)
+}
+
+/**
+ * Append [raw] as a quoted, RFC 8259 §7-escaped JSON string.
+ *
+ * Keys and string values reach this doc straight from caller input, so raw
+ * interpolation would let a quote, backslash, or control character break out of
+ * the literal and corrupt the document.
+ */
+private fun StringBuilder.appendJsonString(raw: String) {
+    append('"')
+    for (c in raw) when (c) {
+        '"' -> append("\\\"")
+        '\\' -> append("\\\\")
+        '\n' -> append("\\n")
+        '\r' -> append("\\r")
+        '\t' -> append("\\t")
+        '\b' -> append("\\b")
+        '\u000C' -> append("\\f")
+        else -> if (c < ' ') {
+            append("\\u")
+            append(c.code.toString(16).padStart(4, '0'))
+        } else {
+            append(c)
+        }
+    }
+    append('"')
 }
 
 private fun ConfixDoc.get(key: String): Any? = this.value(key)

--- a/src/jvmTest/kotlin/borg/trikeshed/graal/ConfixBlackboardTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/graal/ConfixBlackboardTest.kt
@@ -1,9 +1,13 @@
 package borg.trikeshed.graal
 
+import borg.trikeshed.lib.asString
+import borg.trikeshed.parse.confix.root
+import borg.trikeshed.parse.confix.src
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
@@ -14,6 +18,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @Suppress("DEPRECATION") // legacy subscribe shim is exercised deliberately
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class) // advanceUntilIdle
 class ConfixBlackboardTest {
     
     @Test
@@ -160,18 +165,57 @@ class ConfixBlackboardTest {
     }
 
     @Test
-    fun `a stalled collector never stalls the mutators`() = runTest {
+    fun `DROP_OLDEST keeps the newest snapshots when a collector lags`() = runTest {
         val bb = ConfixBlackboard.empty()
-        val overflow = ConfixBlackboard.CHANGE_BUFFER_CAPACITY * 4
+        val burst = ConfixBlackboard.CHANGE_BUFFER_CAPACITY * 4
+        val received = mutableListOf<Any?>()
 
-        // Collector subscribes but does not drain until after every mutation has run;
-        // DROP_OLDEST means tryEmit always succeeds and the mutators never block.
-        val collected = async { bb.changes.take(1).toList() }
-        yield()
+        val collector = launch { bb.changes.collect { received.add(it) } }
+        yield() // collector is subscribed, but StandardTestDispatcher will not resume it
 
-        repeat(overflow) { bb.put("k$it", it, "host") }
-        assertEquals(overflow, bb.keys().size, "mutators completed without suspending")
+        repeat(burst) { bb.put("k$it", it, "host") }
+        assertTrue(received.isEmpty(), "collector must still be lagging mid-burst")
+        assertEquals(burst, bb.keys().size, "mutators ran to completion without suspending")
 
-        assertEquals(1, collected.await().size)
+        advanceUntilIdle() // now let the lagging collector drain whatever survived
+        collector.cancel()
+
+        assertTrue(
+            received.size < burst,
+            "back-pressure must have discarded snapshots (got ${'$'}{received.size} of ${'$'}burst)",
+        )
+        // The discriminating assertion: under SUSPEND or DROP_LATEST the collector would
+        // hold the *earliest* snapshots and this would be some stale doc instead.
+        assertSame(bb.state, received.last(), "the newest snapshot survives; the oldest are dropped")
+    }
+
+    @Test
+    fun `replay hands a late subscriber the current snapshot`() = runTest {
+        val bb = ConfixBlackboard.empty()
+
+        bb.put("k", "v", "host") // mutation happens with nobody listening
+
+        val collected = async { bb.changes.take(1).toList().single() }
+        advanceUntilIdle()
+
+        assertSame(bb.state, collected.await(), "subscribe-after-mutate must not miss current truth")
+    }
+    @Test
+    fun `put escapes JSON-special characters in keys and string values`() {
+        val bb = ConfixBlackboard.empty()
+        val key = "say \"hi\""
+        val value = "back\\slash\nnewline"
+
+        bb.put(key, value, "host")
+
+        // The store keeps the raw text ...
+        assertEquals(value, bb.get(key))
+        // ... while the emitted doc is well-formed JSON. Unescaped interpolation
+        // produced {"say "hi"":"back\slash<LF>newline"}, which is not parseable.
+        assertEquals(
+            """{"say \"hi\"":"back\\slash\nnewline"}""",
+            bb.state.src.asString(),
+        )
+        assertNotNull(bb.state.root, "a quote-bearing key must still yield a parseable doc")
     }
 }

--- a/src/jvmTest/kotlin/borg/trikeshed/graal/ConfixBlackboardTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/graal/ConfixBlackboardTest.kt
@@ -1,11 +1,19 @@
 package borg.trikeshed.graal
 
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+@Suppress("DEPRECATION") // legacy subscribe shim is exercised deliberately
 class ConfixBlackboardTest {
     
     @Test
@@ -87,8 +95,83 @@ class ConfixBlackboardTest {
     @Test
     fun `fromMap creates blackboard with initial values`() {
         val bb = ConfixBlackboard.fromMap(mapOf("a" to 1, "b" to 2), "init")
-        
+
         assertEquals(1, bb.get("a"))
         assertEquals(2, bb.get("b"))
+    }
+
+    @Test
+    fun `changes flow emits on put remove and merge`() = runTest {
+        val bb = ConfixBlackboard.empty()
+
+        // merge of a 1-key doc funnels through put -> one emission; total = put + remove + merge
+        val collected = async { bb.changes.take(3).toList() }
+        yield() // let the collector subscribe before mutating
+
+        bb.put("k", "v", "host")
+        bb.remove("k")
+        bb.merge(ConfixBlackboard.empty().put("m", 1, "js").state, "js")
+
+        val snapshots = collected.await()
+        assertEquals(3, snapshots.size)
+        assertSame(bb.state, snapshots.last(), "the last emission is the current doc truth")
+    }
+
+    @Test
+    fun `changes flow emission carries current state snapshot`() = runTest {
+        val bb = ConfixBlackboard.empty()
+        var observed: Any? = null
+
+        val collector = launch {
+            observed = bb.changes.take(1).toList().single()
+        }
+        yield()
+
+        bb.put("k", "v", "host")
+        collector.join()
+
+        assertSame(bb.state, observed, "flow must emit the post-mutation doc truth")
+    }
+
+    @Test
+    fun `legacy subscribe shim and changes flow see the same mutation`() = runTest {
+        val bb = ConfixBlackboard.empty()
+        var shimFired = 0
+        val unsubscribe = bb.subscribe { shimFired++ }
+
+        val collector = launch {
+            bb.changes.take(1).toList()
+        }
+        yield()
+
+        bb.put("k", "v", "host")
+
+        assertEquals(1, shimFired) // shim stays synchronous
+        collector.join()           // flow saw it too
+        unsubscribe()
+    }
+
+    @Test
+    fun `tryEmit never blocks mutators without collectors`() {
+        val bb = ConfixBlackboard.empty()
+        // No collector attached: mutators must stay synchronous and non-suspending
+        repeat(200) { bb.put("k$it", it, "host") }
+        assertEquals(200, bb.keys().size)
+    }
+
+    @Test
+    fun `a stalled collector never stalls the mutators`() = runTest {
+        val bb = ConfixBlackboard.empty()
+        val overflow = ConfixBlackboard.CHANGE_BUFFER_CAPACITY * 4
+
+        // Collector subscribes but does not drain until after every mutation has run;
+        // DROP_OLDEST means tryEmit always succeeds and the mutators never block.
+        val collected = async { bb.changes.take(1).toList() }
+        yield()
+
+        repeat(overflow) { bb.put("k$it", it, "host") }
+        assertEquals(overflow, bb.keys().size, "mutators completed without suspending")
+
+        assertEquals(1, collected.await().size)
     }
 }


### PR DESCRIPTION
## What

`doc/ccek-consistency-pass.md` §3 lists `graal/ConfixBlackboard.kt` as a pre-CCEK callback list — `mutableListOf<(ConfixDoc) -> Unit>` subscribers where a `SharedFlow` is the reactor idiom. This converts it, and picks up two correctness fixes found while reviewing the surrounding code.

### Reactor form

- **New** `val changes: SharedFlow<ConfixDoc>`, backed by a `MutableSharedFlow` with `replay = 1`, `extraBufferCapacity = CHANGE_BUFFER_CAPACITY` (64), and `onBufferOverflow = BufferOverflow.DROP_OLDEST`. `tryEmit` therefore always succeeds, which is what lets the mutators stay plain non-suspending functions: a lagging collector can never stall a writer, back-pressure discards the *oldest* buffered snapshot rather than the newest, and `replay = 1` closes the subscribe-after-mutate race so a late collector gets current truth instead of nothing.
- Every mutator (`put` / `remove` / `merge`) emits the post-mutation snapshot. `state: ConfixDoc` stays the truth reference; `put`/`remove`/`merge`/`empty`/`fromMap` signatures are unchanged.
- The callback `subscribe` survives as a `@Deprecated` synchronous shim firing on the same snapshots. No non-test caller uses it — the sole consumer, `pointcut/polyglot/PointcutPolyglotBlackboardTaxonomy.kt:40,59`, only references the type — so nothing downstream changed. No `ReplaceWith`: a `SharedFlow` property is not a mechanical substitute for a `(handler) -> unsubscribe` call, and the quick-fix would emit non-compiling code.
- The blackboard owns no coroutine scope: collectors bring their own and detach by stopping collection, so no close/shutdown surface is added.

### Correctness fixes

- **JSON injection in `put`.** `ConfixDoc.set` interpolated the key and string values into JSON raw, so any key or value containing a quote, backslash, or control character produced a malformed document. Now escaped per RFC 8259 §7; `put`'s signature is untouched. Covered by a test with a quote-bearing key and a backslash+newline value asserting the exact emitted JSON.
- **Concurrent modification in the legacy shim.** `notifySubscribers` dispatches over a copy, so a handler that unsubscribes itself from inside the callback no longer mutates the list mid-iteration.

### Documented, not fixed

The class KDoc no longer claims `state` is a complete view of the board, because it is not: the private store behind `get`/`keys`/`has` is authoritative, while `doc` is rebuilt by a **single-key** `set` and `ConfixDoc.remove` is a **no-op**. An emitted snapshot therefore carries only the last-written key and never reflects a deletion. This predates the flow, but the conversion was promoting it to a documented public API, so the caveat is now explicit and collectors are told to read `get`/`keys` rather than parse the doc. The same bullet records the per-`put` reparse cost (each `put` rebuilds and reparses a one-key document inline on the caller's thread, so a bulk slab flush pays one parse per entry). Both point at one follow-up: making `doc` a lazy/incremental multi-key projection. Out of scope here.

`src/jvmMain/kotlin/borg/trikeshed/cursor/ConfixBlackboard.kt` is a near-duplicate of this class and is **deliberately left untouched** — it has its own consumer (`ClassfileBlackboardAdapterExt.kt`, same-package binding) and reconciling the two is a separate unit. Only the `commonMain` `graal` copy gains the flow.

## Verification

- `./gradlew jvmMainClasses --console=plain` — BUILD SUCCESSFUL. The warnings emitted are pre-existing (`kotlinx.datetime.Clock` deprecations, redundant null-assertions) and unrelated to this change.
- `./gradlew jvmTest --tests '*.ConfixBlackboardTest' --console=plain` — 14/14 PASSED.
- `./gradlew jvmTest --tests '*.PointcutPolyglotBlackboardTaxonomyTest' --console=plain` — 3/3 PASSED (the sole consumer).

Two earlier tests were removed as tautological: `put` is not a `suspend fun`, so "mutators do not block" could not fail, and neither test could tell `DROP_OLDEST` from `SUSPEND`. The replacement drains a 256-emission burst through the 64-slot buffer and asserts the last value the collector receives is the current `state` — **verified to fail under `BufferOverflow.SUSPEND`** and pass under `DROP_OLDEST`, so the buffer policy is genuinely covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
