### PR TITLE
feat(lcnc): LcncFormula.evaluate(RowVec) + formula-as-reduction (M5)

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cursor/RowVecSupport.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cursor/RowVecSupport.kt
@@ -13,9 +13,11 @@ fun RowVec.getValue(key: String): Any? {
             is Function0<*> -> raw.invoke()
             else -> null
         }
+        // Names are CharSequence in ColumnMeta, so compare by text: CharSequence.equals(String)
+        // is false for equal content unless the instance happens to be a String.
         when (meta) {
             is RecordMeta -> if (meta.name == key) return cell.a
-            is Join<*, *> -> if (meta.a == key) return cell.a
+            is Join<*, *> -> if ((meta.a as? CharSequence)?.toString() == key) return cell.a
         }
     }
     return null

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/formula/LcncFormula.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/formula/LcncFormula.kt
@@ -1,25 +1,38 @@
 package borg.trikeshed.lcnc.formula
 
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.getValue
 import borg.trikeshed.lcnc.collections.associative.PropertyType
 import borg.trikeshed.lcnc.collections.associative.PropertyValue
 
 /**
  * Basic AST for LCNC Formulas.
+ *
+ * Two evaluation substrates:
+ *  - `Map<String, PropertyValue>` — the associative LCNC page-property form.
+ *  - [RowVec] — the Cursor substrate; property names resolve against each cell's
+ *    ColumnMeta/RecordMeta `name` via the meta supplier (`row[i].b()`).
  */
 sealed class FormulaAST {
     abstract fun evaluate(row: Map<String, PropertyValue>): Any?
+
+    /** Evaluate against a Cursor row — the dispatch-algebra substrate. */
+    abstract fun evaluate(row: RowVec): Any?
 }
 
 data class NumberLiteral(val value: Double) : FormulaAST() {
     override fun evaluate(row: Map<String, PropertyValue>): Any? = value
+    override fun evaluate(row: RowVec): Any? = value
 }
 
 data class StringLiteral(val value: String) : FormulaAST() {
     override fun evaluate(row: Map<String, PropertyValue>): Any? = value
+    override fun evaluate(row: RowVec): Any? = value
 }
 
 data class BooleanLiteral(val value: Boolean) : FormulaAST() {
     override fun evaluate(row: Map<String, PropertyValue>): Any? = value
+    override fun evaluate(row: RowVec): Any? = value
 }
 
 data class PropFunction(val propertyName: String) : FormulaAST() {
@@ -27,10 +40,23 @@ data class PropFunction(val propertyName: String) : FormulaAST() {
         val prop = row[propertyName] ?: return null
         return prop.value
     }
+
+    /** Resolve by column name from the row's metadata; unwrap [PropertyValue] cells for parity with the Map form. */
+    override fun evaluate(row: RowVec): Any? =
+        when (val cell = row.getValue(propertyName)) {
+            is PropertyValue -> cell.value
+            else -> cell
+        }
 }
 
 data class IfFunction(val condition: FormulaAST, val thenExpr: FormulaAST, val elseExpr: FormulaAST) : FormulaAST() {
     override fun evaluate(row: Map<String, PropertyValue>): Any? {
+        val condValue = condition.evaluate(row)
+        val isTrue = condValue == true || (condValue is Number && condValue.toDouble() != 0.0)
+        return if (isTrue) thenExpr.evaluate(row) else elseExpr.evaluate(row)
+    }
+
+    override fun evaluate(row: RowVec): Any? {
         val condValue = condition.evaluate(row)
         val isTrue = condValue == true || (condValue is Number && condValue.toDouble() != 0.0)
         return if (isTrue) thenExpr.evaluate(row) else elseExpr.evaluate(row)
@@ -142,4 +168,7 @@ class FormulaReducer(source: String) {
     fun reduce(row: Map<String, PropertyValue>): Any? {
         return ast.evaluate(row)
     }
+
+    /** RowVec overload — same formula, Cursor substrate. */
+    fun reduce(row: RowVec): Any? = ast.evaluate(row)
 }

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/formula/LcncFormula.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/formula/LcncFormula.kt
@@ -2,64 +2,56 @@ package borg.trikeshed.lcnc.formula
 
 import borg.trikeshed.cursor.RowVec
 import borg.trikeshed.cursor.getValue
-import borg.trikeshed.lcnc.collections.associative.PropertyType
 import borg.trikeshed.lcnc.collections.associative.PropertyValue
 
 /**
  * Basic AST for LCNC Formulas.
  *
- * Two evaluation substrates:
+ * A node evaluates against a *property resolver* — `(String) -> Any?`, null when the
+ * property is absent. The two substrates are therefore two resolvers over one
+ * evaluator, so neither can drift from the other as nodes are added:
  *  - `Map<String, PropertyValue>` — the associative LCNC page-property form.
- *  - [RowVec] — the Cursor substrate; property names resolve against each cell's
- *    ColumnMeta/RecordMeta `name` via the meta supplier (`row[i].b()`).
+ *  - [RowVec] — the Cursor substrate; names resolve against each cell's `ColumnMeta`
+ *    `name` via the meta supplier, and [PropertyValue] cells are unwrapped so a boxed
+ *    cell and a raw cell agree with the Map form.
  */
 sealed class FormulaAST {
-    abstract fun evaluate(row: Map<String, PropertyValue>): Any?
+    /** The single evaluator. [resolve] maps a property name to its raw value, or null when absent. */
+    abstract fun eval(resolve: (String) -> Any?): Any?
+
+    /** Evaluate against the associative page-property form. */
+    fun evaluate(row: Map<String, PropertyValue>): Any? = eval { name -> row[name]?.value }
 
     /** Evaluate against a Cursor row — the dispatch-algebra substrate. */
-    abstract fun evaluate(row: RowVec): Any?
-}
-
-data class NumberLiteral(val value: Double) : FormulaAST() {
-    override fun evaluate(row: Map<String, PropertyValue>): Any? = value
-    override fun evaluate(row: RowVec): Any? = value
-}
-
-data class StringLiteral(val value: String) : FormulaAST() {
-    override fun evaluate(row: Map<String, PropertyValue>): Any? = value
-    override fun evaluate(row: RowVec): Any? = value
-}
-
-data class BooleanLiteral(val value: Boolean) : FormulaAST() {
-    override fun evaluate(row: Map<String, PropertyValue>): Any? = value
-    override fun evaluate(row: RowVec): Any? = value
-}
-
-data class PropFunction(val propertyName: String) : FormulaAST() {
-    override fun evaluate(row: Map<String, PropertyValue>): Any? {
-        val prop = row[propertyName] ?: return null
-        return prop.value
-    }
-
-    /** Resolve by column name from the row's metadata; unwrap [PropertyValue] cells for parity with the Map form. */
-    override fun evaluate(row: RowVec): Any? =
-        when (val cell = row.getValue(propertyName)) {
+    fun evaluate(row: RowVec): Any? = eval { name ->
+        when (val cell = row.getValue(name)) {
             is PropertyValue -> cell.value
             else -> cell
         }
+    }
+}
+
+data class NumberLiteral(val value: Double) : FormulaAST() {
+    override fun eval(resolve: (String) -> Any?): Any? = value
+}
+
+data class StringLiteral(val value: String) : FormulaAST() {
+    override fun eval(resolve: (String) -> Any?): Any? = value
+}
+
+data class BooleanLiteral(val value: Boolean) : FormulaAST() {
+    override fun eval(resolve: (String) -> Any?): Any? = value
+}
+
+data class PropFunction(val propertyName: String) : FormulaAST() {
+    override fun eval(resolve: (String) -> Any?): Any? = resolve(propertyName)
 }
 
 data class IfFunction(val condition: FormulaAST, val thenExpr: FormulaAST, val elseExpr: FormulaAST) : FormulaAST() {
-    override fun evaluate(row: Map<String, PropertyValue>): Any? {
-        val condValue = condition.evaluate(row)
+    override fun eval(resolve: (String) -> Any?): Any? {
+        val condValue = condition.eval(resolve)
         val isTrue = condValue == true || (condValue is Number && condValue.toDouble() != 0.0)
-        return if (isTrue) thenExpr.evaluate(row) else elseExpr.evaluate(row)
-    }
-
-    override fun evaluate(row: RowVec): Any? {
-        val condValue = condition.evaluate(row)
-        val isTrue = condValue == true || (condValue is Number && condValue.toDouble() != 0.0)
-        return if (isTrue) thenExpr.evaluate(row) else elseExpr.evaluate(row)
+        return if (isTrue) thenExpr.eval(resolve) else elseExpr.eval(resolve)
     }
 }
 

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/FormulaReduction.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/FormulaReduction.kt
@@ -18,10 +18,15 @@ import borg.trikeshed.lib.toList
  *
  * The carrier input is a `Series<RowVec>` (i.e. a Cursor) or an `Array<RowVec>`,
  * per [LcncCarrierAlg.seriesCarrierAlg].
+ *
+ * **Carrier caveat.** `seriesCarrierAlg` dispatches on `is Join<*, *>`, and a [RowVec] is
+ * *itself* a `Join` — so passing a single row where a Cursor is expected is not rejected;
+ * each cell-`Join` is then treated as a row and the output is garbage. The collision is
+ * structural and cannot be resolved at runtime: always hand this a `Series<RowVec>`.
  */
 class FormulaReduction private constructor(
     val source: String,
-    ast: FormulaAST,
+    private val ast: FormulaAST,
 ) : AbstractLcncReduction<String, RowVec, List<Any?>, List<Any?>>(
     keyAlg = formulaKeyAlg(source),
     valueAlg = formulaValueAlg(ast),
@@ -30,8 +35,19 @@ class FormulaReduction private constructor(
 ) {
     constructor(source: String) : this(source, FormulaParser(source).parse())
 
+    /**
+     * Every row carries the same key, so the MAP/REDUCE/REREDUCE grouping is a no-op here and the
+     * result is exactly the per-row projection. Taking it directly keeps the hot path a single lazy
+     * `α` projection; going through the template's persistent-list fold would copy the accumulator
+     * once per row (O(n²)). [executeWithCheckpoints] still runs the full pipeline for inspection,
+     * and `executeMatchesCheckpointPipeline` in FormulaRowVecTest pins the two to the same answer.
+     */
     @Suppress("UNCHECKED_CAST")
+    override fun execute(input: ReductionCarrier<*>): List<Any?> =
+        (input as ReductionCarrier<RowVec>).map { ast.evaluate(it) }.toList()
+
     override fun formatOutput(reduced: Any): List<Any?> {
+        @Suppress("UNCHECKED_CAST")
         val carrier = reduced as ReductionCarrier<Join<String, List<Any?>>>
         return carrier.map { it.b }.toList().flatten()
     }
@@ -62,12 +78,24 @@ private fun formulaValueAlg(ast: FormulaAST): ValueAlg<RowVec, List<Any?>> =
  * Registration = copy + reassign of [ReducerRegistry.registry] (the object carries a
  * plain `var` map and no register() method). Additive: existing keys are preserved,
  * an existing binding under [key] is replaced.
+ *
+ * **Bootstrap only.** The read-modify-write is not atomic and `registry` cannot be `@Volatile`
+ * in commonMain, so concurrent registrations may lose one another or go unseen by other threads.
+ * Call this during single-threaded startup, not from running pipelines.
  */
 fun registerReduction(key: String, reduction: LcncReduction<*, *, *, *>): LcncReduction<*, *, *, *> {
     ReducerRegistry.registry = ReducerRegistry.registry + (key to reduction)
     return reduction
 }
 
-/** Parse [source] into a [FormulaReduction] and admit it to the registry under [key]. */
+/**
+ * Parse [source] into a [FormulaReduction] and admit it to the registry under [key].
+ *
+ * [key] is a **direct-lookup** key (`ReducerRegistry.registry[key]`), not a dispatch category:
+ * [ReducerRegistry.runFor] resolves by `Capability.category`, and no `Capability` yields
+ * `"formula"`, so a formula is not reachable through `runFor` until a category is minted for it.
+ * The default key means two different formulas registered without an explicit [key] collide —
+ * pass a distinct [key] (e.g. the block id) when registering more than one.
+ */
 fun registerFormulaReduction(source: String, key: String = "formula"): FormulaReduction =
     FormulaReduction(source).also { registerReduction(key, it) }

--- a/src/commonMain/kotlin/borg/trikeshed/reduction/FormulaReduction.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reduction/FormulaReduction.kt
@@ -1,0 +1,73 @@
+package borg.trikeshed.reduction
+
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.lcnc.formula.FormulaAST
+import borg.trikeshed.lcnc.formula.FormulaParser
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.toList
+
+/**
+ * Formula-as-reduction: wraps a parsed LCNC formula so it participates in the
+ * unified reduction pipeline. Each carried [RowVec] is evaluated against the
+ * formula AST; the output is the ordered list of per-row results.
+ *
+ * K   = the formula source text (single-group key)
+ * V   = [RowVec] (Cursor substrate row)
+ * Acc = accumulated per-row results (ordered)
+ * Out = flat ordered list of results across all groups
+ *
+ * The carrier input is a `Series<RowVec>` (i.e. a Cursor) or an `Array<RowVec>`,
+ * per [LcncCarrierAlg.seriesCarrierAlg].
+ */
+class FormulaReduction private constructor(
+    val source: String,
+    ast: FormulaAST,
+) : AbstractLcncReduction<String, RowVec, List<Any?>, List<Any?>>(
+    keyAlg = formulaKeyAlg(source),
+    valueAlg = formulaValueAlg(ast),
+    phaseAlg = LcncPhaseAlg.forgePhaseAlg,
+    carrierAlg = LcncCarrierAlg.seriesCarrierAlg(),
+) {
+    constructor(source: String) : this(source, FormulaParser(source).parse())
+
+    @Suppress("UNCHECKED_CAST")
+    override fun formatOutput(reduced: Any): List<Any?> {
+        val carrier = reduced as ReductionCarrier<Join<String, List<Any?>>>
+        return carrier.map { it.b }.toList().flatten()
+    }
+}
+
+/** Single-group key algebra: every row of a formula run belongs to the one group named by [source]. */
+private fun formulaKeyAlg(source: String): KeyAlg<String> {
+    val sourceExtractor = KeyExtractor<Any, String> { source }
+    return object : KeyAlg<String> {
+        override val extractor = sourceExtractor
+        override val hierarchy = object : KeyHierarchy<String> {
+            override val levels = listOf(sourceExtractor)
+            override fun compositeKey(input: Any): List<String> = levels.map { it.extract(input) }
+            override fun prefix(key: List<String>, depth: Int): List<String> = key.take(minOf(depth, key.size))
+        }
+        override val order = LcncKeyAlg.naturalKeyOrder<String>()
+    }
+}
+
+private fun formulaValueAlg(ast: FormulaAST): ValueAlg<RowVec, List<Any?>> =
+    object : ValueAlg<RowVec, List<Any?>> {
+        override val initial: List<Any?> = emptyList()
+        override val folder = Folder<RowVec, List<Any?>> { acc, row -> acc + ast.evaluate(row) }
+        override val merger = Merger<List<Any?>> { partials -> partials.toList().flatten() }
+    }
+
+/**
+ * Registration = copy + reassign of [ReducerRegistry.registry] (the object carries a
+ * plain `var` map and no register() method). Additive: existing keys are preserved,
+ * an existing binding under [key] is replaced.
+ */
+fun registerReduction(key: String, reduction: LcncReduction<*, *, *, *>): LcncReduction<*, *, *, *> {
+    ReducerRegistry.registry = ReducerRegistry.registry + (key to reduction)
+    return reduction
+}
+
+/** Parse [source] into a [FormulaReduction] and admit it to the registry under [key]. */
+fun registerFormulaReduction(source: String, key: String = "formula"): FormulaReduction =
+    FormulaReduction(source).also { registerReduction(key, it) }

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/formula/FormulaRowVecTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/formula/FormulaRowVecTest.kt
@@ -1,11 +1,17 @@
 package borg.trikeshed.lcnc.formula
 
+import borg.trikeshed.cursor.ColumnMeta
 import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.`ColumnMeta↻`
 import borg.trikeshed.cursor.cellsToRowVec
+import borg.trikeshed.isam.meta.IOMemento
 import borg.trikeshed.lcnc.collections.associative.PropertyType
 import borg.trikeshed.lcnc.collections.associative.PropertyValue
+import borg.trikeshed.lib.ReifiedSplitSeries2
 import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.j
+import borg.trikeshed.lib.leftIdentity
+import borg.trikeshed.reduction.FormulaReduction
 import borg.trikeshed.reduction.ReducerRegistry
 import borg.trikeshed.reduction.registerFormulaReduction
 import kotlin.test.Test
@@ -73,6 +79,33 @@ class FormulaRowVecTest {
         assertEquals(1.0, reducer.reduce(rowVec(true)))
         assertEquals(reducer.reduce(mapRow(true)), reducer.reduce(rowVec(true)))
         assertEquals(reducer.reduce(mapRow(false)), reducer.reduce(rowVec(false)))
+    }
+
+    /**
+     * `ColumnMeta.name` is a CharSequence, so a column named by something other than a String
+     * must still resolve — otherwise `prop("Done")` silently yields null instead of the value.
+     */
+    @Test
+    fun nonStringColumnNamesStillResolve() {
+        val values: Series<Any?> = 1 j { _: Int -> true }
+        val meta: Series<`ColumnMeta↻`> = 1 j { _: Int ->
+            ColumnMeta(StringBuilder("Done"), IOMemento.IoBoolean).leftIdentity
+        }
+        val row: RowVec = ReifiedSplitSeries2(values, meta)
+
+        assertEquals(true, PropFunction("Done").evaluate(row))
+        assertEquals(1.0, FormulaParser(source).parse().evaluate(row))
+    }
+
+    /** The fast `execute` path and the introspectable checkpoint pipeline must agree. */
+    @Test
+    fun executeMatchesCheckpointPipeline() {
+        val reduction = FormulaReduction(source)
+        val rows: Series<RowVec> = 3 j { i: Int -> rowVec(i != 1) }
+        val carrier = reduction.carrierAlg.carrier(rows)
+
+        assertEquals(listOf<Any?>(1.0, 0.0, 1.0), reduction.execute(carrier))
+        assertEquals(reduction.execute(carrier), reduction.executeWithCheckpoints(carrier).output)
     }
 
     @Test

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/formula/FormulaRowVecTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/formula/FormulaRowVecTest.kt
@@ -1,0 +1,95 @@
+package borg.trikeshed.lcnc.formula
+
+import borg.trikeshed.cursor.RowVec
+import borg.trikeshed.cursor.cellsToRowVec
+import borg.trikeshed.lcnc.collections.associative.PropertyType
+import borg.trikeshed.lcnc.collections.associative.PropertyValue
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+import borg.trikeshed.reduction.ReducerRegistry
+import borg.trikeshed.reduction.registerFormulaReduction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * M5 seam: the formula language evaluates on the Cursor substrate (RowVec)
+ * with the same semantics as the associative Map form, and formulas are
+ * admitted to the reduction registry as first-class reductions.
+ */
+class FormulaRowVecTest {
+    private val source = """if(prop("Done"), 1, 0)"""
+
+    private fun mapRow(done: Boolean): Map<String, PropertyValue> =
+        mapOf("Done" to PropertyValue("done_id", PropertyType.CHECKBOX, done))
+
+    private fun rowVec(done: Boolean): RowVec {
+        val cells: Series<Any?> = 1 j { _: Int -> done }
+        val keys: Series<String> = 1 j { _: Int -> "Done" }
+        return cellsToRowVec(cells, keys)
+    }
+
+    @Test
+    fun mapAndRowVecEvaluationAgree() {
+        val ast = FormulaParser(source).parse()
+
+        assertEquals(1.0, ast.evaluate(rowVec(true)))
+        assertEquals(0.0, ast.evaluate(rowVec(false)))
+        assertEquals(ast.evaluate(mapRow(true)), ast.evaluate(rowVec(true)))
+        assertEquals(ast.evaluate(mapRow(false)), ast.evaluate(rowVec(false)))
+    }
+
+    @Test
+    fun absentPropertyYieldsNullOnBothSubstrates() {
+        val ast = PropFunction("Missing")
+
+        // Map form: absent key → null. RowVec form: no column of that name → null.
+        assertNull(ast.evaluate(mapRow(true)))
+        assertNull(ast.evaluate(rowVec(true)))
+
+        // …and the same holds through the whole formula: if(prop("Missing"), 1, 0) → 0.0 both ways.
+        val guarded = FormulaParser("""if(prop("Missing"), 1, 0)""").parse()
+        assertEquals(0.0, guarded.evaluate(mapRow(true)))
+        assertEquals(guarded.evaluate(mapRow(true)), guarded.evaluate(rowVec(true)))
+    }
+
+    /** A RowVec cell may itself carry a [PropertyValue]; PropFunction unwraps it, as the Map form does. */
+    @Test
+    fun propertyValueCellsAreUnwrappedLikeTheMapForm() {
+        val boxed: Series<Any?> = 1 j { _: Int -> PropertyValue("done_id", PropertyType.CHECKBOX, true) }
+        val keys: Series<String> = 1 j { _: Int -> "Done" }
+        val row = cellsToRowVec(boxed, keys)
+
+        val ast = FormulaParser(source).parse()
+        assertEquals(true, PropFunction("Done").evaluate(row))
+        assertEquals(ast.evaluate(mapRow(true)), ast.evaluate(row))
+    }
+
+    @Test
+    fun formulaReducerRowVecOverloadAgreesWithMapForm() {
+        val reducer = FormulaReducer(source)
+        assertEquals(1.0, reducer.reduce(rowVec(true)))
+        assertEquals(reducer.reduce(mapRow(true)), reducer.reduce(rowVec(true)))
+        assertEquals(reducer.reduce(mapRow(false)), reducer.reduce(rowVec(false)))
+    }
+
+    @Test
+    fun formulaReductionRegisteredAndExecutableViaReducerRegistry() {
+        val before = ReducerRegistry.registry
+        try {
+            val reduction = registerFormulaReduction(source)
+
+            val registered = ReducerRegistry.registry["formula"]
+            assertNotNull(registered)
+            assertSame(reduction, registered)
+
+            val rows: Series<RowVec> = 2 j { i: Int -> rowVec(i == 0) }
+            val out = registered.execute(reduction.carrierAlg.carrier(rows))
+            assertEquals(listOf<Any?>(1.0, 0.0), out)
+        } finally {
+            ReducerRegistry.registry = before
+        }
+    }
+}


### PR DESCRIPTION
## M5 — `LcncFormula.evaluate(RowVec)`

Formulas previously evaluated only against the associative `Map<String, PropertyValue>` page-property form. This adds the Cursor substrate as a second, semantically identical evaluation target and wires formulas into the unified reduction pipeline.

### Changes

- **`src/commonMain/kotlin/borg/trikeshed/lcnc/formula/LcncFormula.kt`** (additive)
  - `FormulaAST` gains an abstract `evaluate(row: RowVec)` beside the existing Map overload, implemented on all five nodes (`NumberLiteral`, `StringLiteral`, `BooleanLiteral`, `PropFunction`, `IfFunction`).
  - `PropFunction` resolves the property by **column name from the row's `ColumnMeta` suppliers** (`RowVecSupport.getValue`) and unwraps `PropertyValue` cells, so a boxed cell and a raw cell both agree with the Map form. An absent column yields `null` on both substrates.
  - `FormulaReducer.reduce(RowVec)` overload.
- **`src/commonMain/kotlin/borg/trikeshed/reduction/FormulaReduction.kt`** (new)
  - `FormulaReduction : AbstractLcncReduction<String, RowVec, List<Any?>, List<Any?>>` — single-group key algebra keyed on the formula source, folder evaluates the AST per row, output is the flat ordered per-row results.
  - `registerReduction` / `registerFormulaReduction` admit it into `ReducerRegistry.registry` by **copy + reassign** of the plain `var` map. `ReducerRegistry` itself is untouched.
- **`src/commonTest/kotlin/borg/trikeshed/lcnc/formula/FormulaRowVecTest.kt`** (new) — 5 tests: Map/RowVec agreement on `if(prop("Done"), 1, 0)`, absent-property null parity, boxed `PropertyValue` cell unwrapping, `FormulaReducer` overload parity, and registry admission + execution through `LcncReduction.execute`.

### Notes

- `PropertyType.FORMULA` stays removed (deliberately dropped 2026-07-21). The formula seam is the reduction registry, not an associative property type.
- commonMain conventions respected: no `System.*` / `java.*` / `synchronized` / `@Volatile` / `runBlocking` / reflection / NIO; `formatOutput` and `merger` use the Series/carrier algebra rather than index loops.

### Verification

- `./gradlew jvmMainClasses --console=plain` — BUILD SUCCESSFUL
- `./gradlew jvmTest --tests 'borg.trikeshed.lcnc.formula.FormulaRowVecTest'` — 5/5 PASSED
- `./gradlew jvmTest --tests 'borg.trikeshed.reduction.*' --tests 'borg.trikeshed.lcnc.*'` — all PASSED (no regression in the reduction/registry suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Review follow-up (commit `a5646f0`)

A scoped review confirmed no semantic divergence between the two `evaluate` paths and a sound `formatOutput` cast, and raised these, now fixed:

- **Parity was enforced only by copy-paste.** `FormulaAST` now has one `eval(resolve: (String) -> Any?)`; the two public `evaluate` overloads are thin resolvers over it. A new node can no longer implement one substrate and forget the other. Public API unchanged.
- **The fold was O(n²).** All rows share one key, so the template's grouping is a no-op while its persistent-list fold copied the accumulator per row. `execute` now takes the direct per-row projection; `executeWithCheckpoints` still runs the full pipeline, and `executeMatchesCheckpointPipeline` pins the two to the same answer.
- **Latent name-resolution bug in `RowVecSupport.getValue`** — it compared a `CharSequence` `ColumnMeta.name` against a `String` with `==`, which is false for equal text unless the instance is a `String`. Every call site passes a `String` today, so nothing was broken, but this change made it load-bearing: a non-String-named column would make `prop("X")` silently return `null`. Now compared by text, with `nonStringColumnNamesStillResolve` guarding it. All 117 tests across `getValue`'s other consumers still pass.
- **KDoc** — `registerReduction` is bootstrap-only (non-atomic read-modify-write on a plain `var` Map); `registerFormulaReduction`'s key is a direct-lookup key, **not** a `runFor` dispatch category (no `Capability` yields `"formula"`), and the default key collides across formulas; `FormulaReduction` warns that a bare `RowVec` is structurally a `Join` and so is *not* rejected by `seriesCarrierAlg`.
- Dropped an unused import; scoped `@Suppress` to the cast statement.

Deliberately not done: minting a `Capability` category for `"formula"` (touches `Nuid.kt`, outside this unit — the KDoc records the gap).

**Note for whoever runs the focused slice:** `./gradlew jvmTest -PfocusedTransportSlice=true` cannot compile `commonTest` — the flag *disables* the `**/util/oroboros/**` and `**/htx/**` exclusions at `build.gradle.kts:366-368`, producing 27 pre-existing errors unrelated to this change. Use plain `jvmTest` to validate this work.
