### PR TITLE
refactor(kanban): remove runBlocking from ForgeKanbanIngest (ccek-consistency §2 / RGA N3)

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/ForgeApp.kt
@@ -90,7 +90,7 @@ object ForgeApp {
         julesSurface: JulesBlackboardSurface? = null,
         flywheelReport: FlywheelReportSnapshot? = null,
     ): String {
-        val reduction = runCatching { ForgeKanbanIngest.load(userId) }.getOrElse { ForgeKanbanIngest.fallbackReduction() }
+        val reduction = runCatching { ForgeKanbanIngest.loadProjection(userId) }.getOrElse { ForgeKanbanIngest.fallbackReduction() }
         val seed = forgeSeedJson(userId, reduction, julesSurface, flywheelReport)
         return htmlShell(seed)
     }

--- a/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanDaemon.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanDaemon.kt
@@ -29,7 +29,7 @@ class ForgeKanbanDaemon(
     /**
      * The user's board (loaded on demand).
      */
-    private var board: KanbanBoard = ForgeKanbanIngest.load(userId).board
+    private var board: KanbanBoard = ForgeKanbanIngest.loadProjection(userId).board
     
     init {
         walReplay?.invoke()?.forEach { (causalKey, _) ->
@@ -202,7 +202,7 @@ class ForgeKanbanDaemon(
      * Reload board from disk.
      */
     fun reload() {
-        board = ForgeKanbanIngest.load(userId).board
+        board = ForgeKanbanIngest.loadProjection(userId).board
     }
     
     /**

--- a/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/ForgeKanbanIngest.kt
@@ -50,14 +50,29 @@ object ForgeKanbanIngest {
         KanbanColumn(KanbanColumnId("archived"), "Archived", 6),
     )
 
-    fun persistMarkdown(userId: String, markdownPath: String): ForgeKanbanReduction {
+    /**
+     * Persist the markdown envelope, then reduce it and assert the derived facts into
+     * [workingMemory].  The default is a fresh memory, which reproduces the historical
+     * behaviour of an assertion pass whose memory is immediately discarded; callers that
+     * care about the facts pass their own.
+     */
+    suspend fun persistMarkdown(
+        userId: String,
+        markdownPath: String,
+        workingMemory: ReteWorkingMemory = ReteWorkingMemory(),
+    ): ForgeKanbanReduction {
         val markdown = borg.trikeshed.common.Files.readString(markdownPath)
         val source = ForgeBoardPersistence.source(userId, markdown, markdownPath)
         ForgeBoardPersistence.persist(source).getOrThrow()
-        return reduce(source)
+        return reduce(source, workingMemory)
     }
 
-    fun persistArchive(userId: String, archive: borg.trikeshed.lib.Series<Any?>, pipeline: borg.trikeshed.treedoc.TreeDocPipeline): ForgeKanbanReduction {
+    suspend fun persistArchive(
+        userId: String,
+        archive: borg.trikeshed.lib.Series<Any?>,
+        pipeline: borg.trikeshed.treedoc.TreeDocPipeline,
+        workingMemory: ReteWorkingMemory = ReteWorkingMemory(),
+    ): ForgeKanbanReduction {
         val documents = archive.b(borg.trikeshed.treedoc.TreeDocK.Documents.ordinal) as borg.trikeshed.cursor.Cursor
         val allMarkdown = StringBuilder()
         for (i in 0 until documents.a) {
@@ -65,16 +80,28 @@ object ForgeKanbanIngest {
             allMarkdown.append(bytes.decodeToString()).append("\n\n")
         }
         val source = ForgeBoardPersistence.source(userId, allMarkdown.toString(), "archive:${(archive.b(borg.trikeshed.treedoc.TreeDocK.ArchiveId.ordinal) as borg.trikeshed.job.ContentId).value}")
-        return reduce(source)
+        return reduce(source, workingMemory)
     }
 
-    fun load(userId: String): ForgeKanbanReduction =
-        reduce(ForgeBoardPersistence.load(userId).getOrThrow())
+    suspend fun load(
+        userId: String,
+        workingMemory: ReteWorkingMemory = ReteWorkingMemory(),
+    ): ForgeKanbanReduction =
+        reduce(ForgeBoardPersistence.load(userId).getOrThrow(), workingMemory)
+
+    /**
+     * Read-only sibling of [load] for render/report paths that only want the projection
+     * and cannot suspend (e.g. the `@JsExport` wasm shell entry point).  It performs no
+     * working-memory assertion, so it stays a pure function of the persisted envelope.
+     */
+    fun loadProjection(userId: String): ForgeKanbanReduction =
+        project(ForgeBoardPersistence.load(userId).getOrThrow())
 
     /**
      * Browser-safe fallback — builds a minimal reduction entirely in memory
-     * without touching disk.  Used when [load] and [persistMarkdown] both fail
-     * (e.g. browser bundle where require('fs') is unavailable).
+     * without touching disk.  Used when [loadProjection] and [persistMarkdown] both fail
+     * (e.g. browser bundle where require('fs') is unavailable).  Like [loadProjection]
+     * it is a pure projection, so render paths stay non-suspending.
      */
     fun fallbackReduction(): ForgeKanbanReduction {
         val source = ForgeKanbanSource(
@@ -100,10 +127,23 @@ object ForgeKanbanIngest {
             """.trimIndent(),
             contentId = "fallback",
         )
-        return reduce(source)
+        return project(source)
     }
 
-    fun reduce(source: ForgeKanbanSource): ForgeKanbanReduction {
+    /**
+     * Reduce [source] and assert the derived facts into [workingMemory].
+     *
+     * RGA N3 note: this path still bypasses `JobSupervisor` — the JobCommand bridge is a
+     * sibling concern and is deliberately untouched here.
+     */
+    suspend fun reduce(
+        source: ForgeKanbanSource,
+        workingMemory: ReteWorkingMemory = ReteWorkingMemory(),
+    ): ForgeKanbanReduction =
+        project(source).also { assertFacts(workingMemory, it.reteFacts) }
+
+    /** Pure deterministic projection — no suspension and no working-memory writes. */
+    fun project(source: ForgeKanbanSource): ForgeKanbanReduction {
         require(!Regex("(?i)ignore all previous instructions").containsMatchIn(source.description)) { "Prompt injection detected" }
         val tasks = parseWorkPackages(source.description)
         validateTasks(tasks)
@@ -114,7 +154,7 @@ object ForgeKanbanIngest {
             provenance = provenance(
                 source = source.sourcePath,
                 timestamp = 0L,
-                transformations = listOf("ForgeKanbanIngest.reduce"),
+                transformations = listOf("ForgeKanbanIngest.project"),
             ),
             tags = mapOf("sourceContentId" to source.contentId),
         )
@@ -138,8 +178,6 @@ object ForgeKanbanIngest {
 
         val cards = buildCards(tasks, parentIdsByTask, source)
         val taskFacts = updateTaskFactsWithStatus(cards, provisionalTaskFacts)
-
-        assertFacts(taskFacts, dependencyFacts)
 
         val causalNodes = buildCausalNodes(tasks, parentIdsByTask, context)
         val correlations = buildCorrelations(tasks, parentIdsByTask, childIdsByTask, causalNodes)
@@ -248,12 +286,9 @@ object ForgeKanbanIngest {
         }
     }
 
-    private fun assertFacts(taskFacts: List<ReteStoredFact>, dependencyFacts: List<ReteStoredFact>) {
-        val workingMemory = ReteWorkingMemory()
-        kotlinx.coroutines.runBlocking {
-            (taskFacts + dependencyFacts).forEach { fact ->
-                workingMemory.assert(fact.factId, fact.fields, fact.versionCid, fact.board)
-            }
+    private suspend fun assertFacts(workingMemory: ReteWorkingMemory, facts: List<ReteStoredFact>) {
+        facts.forEach { fact ->
+            workingMemory.assert(fact.factId, fact.fields, fact.versionCid, fact.board)
         }
     }
 

--- a/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestArchiveTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestArchiveTest.kt
@@ -4,6 +4,7 @@ import borg.trikeshed.job.CasStore
 import borg.trikeshed.lib.seriesOf
 import borg.trikeshed.treedoc.TreeDocPipeline
 import borg.trikeshed.treedoc.TreeDocument
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -34,7 +35,7 @@ class ForgeKanbanIngestArchiveTest {
     """.trimIndent()
 
     @Test
-    fun ingestReducesArchive() {
+    fun ingestReducesArchive() = runTest {
         val cas = CasStore.inMemory()
         val pipeline = TreeDocPipeline(cas, 1024)
         val docs = seriesOf(listOf(

--- a/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/kanban/ForgeKanbanIngestTest.kt
@@ -1,5 +1,7 @@
 package borg.trikeshed.kanban
 
+import borg.trikeshed.dag.ReteWorkingMemory
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -44,7 +46,7 @@ class ForgeKanbanIngestTest {
     }
 
     @Test
-    fun ingestReducesHermesStyleTasksLinksReteCorrelationsAndCausality() {
+    fun ingestReducesHermesStyleTasksLinksReteCorrelationsAndCausality() = runTest {
         val reduction = ForgeKanbanIngest.reduce(
             ForgeBoardPersistence.source("jim", markdown, "/tmp/hi")
         )
@@ -64,5 +66,36 @@ class ForgeKanbanIngestTest {
         assertEquals(2, reduction.reteFacts.count { it.fields["kind"] == "link" })
         assertEquals(listOf("G0"), reduction.causalNodes.first { it.nodeId == "F0" }.parentNodeIds)
         assertEquals(f0.causalKey, reduction.causalNodes.first { it.nodeId == "F0" }.causalKey)
+    }
+
+    @Test
+    fun reduceAssertsEveryDerivedFactIntoTheCallerSuppliedWorkingMemory() = runTest {
+        val source = ForgeBoardPersistence.source("jim", markdown, "/tmp/hi")
+        val workingMemory = ReteWorkingMemory()
+
+        val reduction = ForgeKanbanIngest.reduce(source, workingMemory)
+
+        // reduce == the pure projection plus an assertion pass; the reduction is unchanged.
+        assertEquals(ForgeKanbanIngest.project(source), reduction)
+
+        val board = reduction.reteFacts.first().board
+        assertEquals(3, workingMemory.query(board, "kind" to "task").size)
+        assertEquals(2, workingMemory.query(board, "kind" to "link").size)
+        reduction.reteFacts.forEach { fact ->
+            assertEquals(listOf(fact), workingMemory.facts(fact.factId))
+        }
+    }
+
+    @Test
+    fun projectionPathPerformsNoWorkingMemoryAssertion() = runTest {
+        val source = ForgeBoardPersistence.source("jim", markdown, "/tmp/hi")
+        val workingMemory = ReteWorkingMemory()
+
+        val projected = ForgeKanbanIngest.project(source)
+
+        assertTrue(projected.reteFacts.isNotEmpty())
+        projected.reteFacts.forEach { fact ->
+            assertTrue(workingMemory.facts(fact.factId).isEmpty())
+        }
     }
 }

--- a/src/jsMain/kotlin/borg/trikeshed/forge/ForgeNodeMain.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/forge/ForgeNodeMain.kt
@@ -2,6 +2,8 @@ package borg.trikeshed.forge
 
 import borg.trikeshed.common.Files
 import borg.trikeshed.kanban.ForgeKanbanIngest
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 
 /**
  * JS entry point for the Forge local-first workspace.
@@ -16,6 +18,22 @@ import borg.trikeshed.kanban.ForgeKanbanIngest
  * → seed and saves mutations back to localStorage + IndexedDB permanently.
  */
 fun main() {
+    // Ingest is a suspending contract (the Rete assertion pass suspends) and Kotlin/JS has
+    // no runBlocking, so the whole entry point runs as a single coroutine on the JS event
+    // loop.  One coroutine keeps the persist -> render ordering that the seed JSON depends on.
+    MainScope().launch {
+        try {
+            forgeNodeMain()
+        } catch (t: Throwable) {
+            // The detached coroutine cannot propagate out of main(); mark the process failed
+            // so `node forge.js > out.html` still aborts a pipeline instead of emitting nothing.
+            System.err.println("Forge node main failed: ${t.message}")
+            js("if (typeof process !== 'undefined') { process.exitCode = 1; }")
+        }
+    }
+}
+
+private suspend fun forgeNodeMain() {
     // Node.js: ingest /tmp/hi into the local-first persistence layer.
     if (!(js("typeof window !== 'undefined' && typeof document !== 'undefined'") as Boolean)) {
 

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
@@ -11,7 +11,7 @@ import java.sql.Connection
 import java.sql.ResultSet
 
 object HermesDonorTrace {
-    fun ingestDonor(userId: String, format: String, donorPath: String? = null): ForgeKanbanReduction {
+    suspend fun ingestDonor(userId: String, format: String, donorPath: String? = null): ForgeKanbanReduction {
         return when (format.lowercase()) {
             "sqlite" -> {
                 val path = if (donorPath == null) {
@@ -37,7 +37,7 @@ object HermesDonorTrace {
         }
     }
 
-    private fun ingestMarkdown(userId: String, donorPath: Path): ForgeKanbanReduction {
+    private suspend fun ingestMarkdown(userId: String, donorPath: Path): ForgeKanbanReduction {
         val ingestPath = if (borg.trikeshed.kanban.JvmTikaIngestAdapter.isTikaCandidate(donorPath)) {
             val md = borg.trikeshed.kanban.JvmTikaIngestAdapter.extractToMarkdown(donorPath)
             val tmp = Files.createTempFile("tika-donor", ".md")
@@ -49,7 +49,7 @@ object HermesDonorTrace {
         return ForgeKanbanIngest.persistMarkdown(userId, ingestPath)
     }
 
-    private fun ingestSqlite(userId: String, dbPath: Path): ForgeKanbanReduction {
+    private suspend fun ingestSqlite(userId: String, dbPath: Path): ForgeKanbanReduction {
         require(Files.exists(dbPath)) { "SQLite donor db not found at: $dbPath" }
 
         val dataSource = SQLiteDataSource().apply {

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
@@ -1737,7 +1737,7 @@ class FlywheelDriver(
 
 
     private fun getKanbanBoard(): borg.trikeshed.kanban.KanbanBoard {
-        return try { ForgeKanbanIngest.load("jim").board }
+        return try { ForgeKanbanIngest.loadProjection("jim").board }
         catch (_: Throwable) { borg.trikeshed.kanban.KanbanBoard(
             id = borg.trikeshed.kanban.KanbanBoardId("flywheel"),
             name = "flywheel",

--- a/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/litebike/JvmKanbanServer.kt
@@ -203,6 +203,8 @@ class JvmKanbanServer(
                 }
                 ForgeKanbanIngest.persistMarkdown("jim", ingestPath)
                 System.err.println("donor replayed: $donorPath")
+            } catch (c: kotlinx.coroutines.CancellationException) {
+                throw c
             } catch (t: Throwable) {
                 System.err.println("donor replay failed: ${t.message}")
             }
@@ -390,7 +392,7 @@ class JvmKanbanServer(
     }
 
     private fun boardJson(): String = runCatching {
-        val reduction = ForgeKanbanIngest.load("jim")
+        val reduction = ForgeKanbanIngest.loadProjection("jim")
         JsonSupport.stringify(
             linkedMapOf(
                 "title" to reduction.source.title,
@@ -431,7 +433,10 @@ class JvmKanbanServer(
                     )
                 ),
             )
-        }.getOrElse { HttpResponse(500, """{"error":"submit_failed","reason":"${it.message}"}""") }
+        }.getOrElse {
+            if (it is kotlinx.coroutines.CancellationException) throw it
+            HttpResponse(500, """{"error":"submit_failed","reason":"${it.message}"}""")
+        }
     }
 
     private fun statusReason(code: Int): String = when (code) {

--- a/src/jvmTest/kotlin/borg/trikeshed/forge/donor/HermesDonorTraceTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/forge/donor/HermesDonorTraceTest.kt
@@ -1,5 +1,6 @@
 package borg.trikeshed.forge.donor
 
+import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.sql.DriverManager
@@ -30,7 +31,7 @@ class HermesDonorTraceTest {
             }
             conn.close()
 
-            val reduction = HermesDonorTrace.ingestDonor("test-user", "sqlite", null)
+            val reduction = runBlocking { HermesDonorTrace.ingestDonor("test-user", "sqlite", null) }
 
             assertTrue(reduction.board.cards.size >= 1)
         } finally {
@@ -59,7 +60,7 @@ class HermesDonorTraceTest {
             }
             conn.close()
 
-            val reduction = HermesDonorTrace.ingestDonor("test-user", "sqlite", null)
+            val reduction = runBlocking { HermesDonorTrace.ingestDonor("test-user", "sqlite", null) }
 
             assertTrue(reduction.board.cards.size >= 1)
         } finally {
@@ -89,7 +90,7 @@ class HermesDonorTraceTest {
             }
             conn.close()
 
-            val reduction = HermesDonorTrace.ingestDonor("test-user", "sqlite", null)
+            val reduction = runBlocking { HermesDonorTrace.ingestDonor("test-user", "sqlite", null) }
 
             // The structural elements should be escaped, preventing FAKE-99 and FAKE-98 from becoming cards
             val cards = reduction.board.cards


### PR DESCRIPTION
## What

`ForgeKanbanIngest.reduce` wrapped its Rete assertion pass in `kotlinx.coroutines.runBlocking` **inside commonMain**, against a `ReteWorkingMemory` that was built locally and immediately discarded.

- `assertFacts` is now `private suspend fun assertFacts(workingMemory, facts)` — the assert loop is unchanged and still walks `taskFacts + dependencyFacts` in the same order (`reteFacts` is defined as exactly that concatenation).
- `reduce` / `load` / `persistMarkdown` / `persistArchive` are `suspend` and take an optional `workingMemory: ReteWorkingMemory = ReteWorkingMemory()`. The default reproduces the old observable behaviour; callers that care about the facts now pass their own.
- The pure half of the old `reduce` is extracted as non-suspending `project`, with `loadProjection` as its read-only load sibling.

## Decision point (noted per the unit's autonomy rule)

`ForgeApp.renderHtml` is reachable from `@JsExport fun getForgeHtml(): String` on wasmJs, which can be neither `suspend` nor `runBlocking`-wrapped. Rather than break the JS/wasm entry points, render/report paths (`ForgeApp`, `ForgeKanbanDaemon`, `JvmKanbanServer.boardJson`, `FlywheelDriver.getKanbanBoard`) use the pure projection; **write** paths (`persist*`) stay suspend. Provenance now records `"ForgeKanbanIngest.project"`, the transformation that actually ran.

## Call sites

| site | treatment |
|---|---|
| `JvmKanbanServer` donor replay, `submit` | already `suspend`; both catch sites now rethrow `CancellationException` instead of turning it into `"replay failed"` / HTTP 500 |
| `HermesDonorTrace.ingestDonor/ingestMarkdown/ingestSqlite` | `suspend`; `runBlocking` pushed out to the 3 jvmTest callers |
| `jsMain` `ForgeNodeMain.main` | body runs as one `MainScope` coroutine (preserves persist -> render ordering) and sets `process.exitCode` on failure |
| `ForgeApp.renderHtml`, `ForgeKanbanDaemon`, `boardJson`, `getKanbanBoard` | `loadProjection` — unchanged signatures |

## RGA N3

This path still bypasses `JobSupervisor`. The JobCommand bridge belongs to sibling unit **M2** and is deliberately untouched here.

## Verification

- `./gradlew jvmMainClasses --console=plain` — BUILD SUCCESSFUL
- `./gradlew jvmTest --tests '*ForgeKanban*' --tests '*HermesDonorTrace*' --console=plain` — 11 tests PASSED, including the new `reduceAssertsEveryDerivedFactIntoTheCallerSuppliedWorkingMemory` (reduction equals the pure projection; every task/link fact lands in the caller's memory) and `projectionPathPerformsNoWorkingMemoryAssertion`.
- `compileKotlinJs` is red from pre-existing commonMain `java.` / `System.` / `JvmInline` debt unrelated to this change, so the small jsMain edit is compile-unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
