### PR TITLE
feat(modelmux): real provider-blind routing strategies + first ModelSelected emission

### DIFF
--- a/src/commonMain/kotlin/modelmux/ModelMux.kt
+++ b/src/commonMain/kotlin/modelmux/ModelMux.kt
@@ -111,6 +111,35 @@ class ModelMux internal constructor(
     private val models: Series<ModelEntry> get() = core.a
     private val router: ModelRouter get() = core.b
 
+    /**
+     * Observer sink for [ModelSelectionEvent]. Null by default. Single-writer: set once, before
+     * routing. The sink is called inline on the routing path but is isolated from it — a sink
+     * that throws must not fail the route it is merely observing.
+     */
+    var selectionObserver: ((ModelSelectionEvent) -> Unit)? = null
+
+    /**
+     * The most recent [ModelSelectionEvent.ModelSelected] this mux emitted, or null before the
+     * first non-empty route. Recorded because [route] does not return the event's `requestId`
+     * — a caller that wants to reconcile a downstream [ModelResponseReceipt] against the
+     * selection that produced it reads the id from here.
+     */
+    var lastSelection: ModelSelectionEvent.ModelSelected? = null
+        private set
+
+    /**
+     * Label naming the ranking discipline behind a selection; stamped onto
+     * [ModelSelectionEvent.ModelSelected.strategy].
+     *
+     * This is a declaration, not a derivation: nothing verifies it. It defaults to
+     * `"capability"`, which is what [CapabilityRouter] — the router [ModelMuxBuilder] installs
+     * — actually does, namely filter by capability and preserve catalog order. An owner that
+     * ranks the route result through a [RoutingStrategy] should set this to that strategy's
+     * [RoutingStrategy.strategyName]; setting it to a discipline that did not run makes the
+     * event stream lie.
+     */
+    var strategyName: String = "capability"
+
     companion object {
         operator fun invoke(keyMux: KeyMux, block: ModelMuxBuilder.() -> Unit): ModelMux =
             ModelMuxBuilder(keyMux).apply(block).build()
@@ -133,9 +162,43 @@ class ModelMux internal constructor(
         return Result.success(session)
     }
 
-    /** Route to the best model for a given action + capabilities */
-    fun route(action: AcpAction, vararg requiredCaps: String): RouteResult =
-        router.route(models, action, requiredCaps.toList().toSeries())
+    /**
+     * Route to the best model for a given action + capabilities.
+     *
+     * This is the selection point. The result is a ranked candidate list, and its head is the
+     * selection this mux is reporting: on a non-empty route a [ModelSelectionEvent.ModelSelected]
+     * naming `result.a[0]` is recorded as [lastSelection] and handed to [selectionObserver].
+     * An empty route selects nothing and emits nothing.
+     *
+     * A caller free to ignore the ranking and call [chat] with some other candidate will find
+     * the event stream disagreeing with what it did; the event describes the head of the
+     * ranking, which is the only selection this method makes.
+     */
+    fun route(action: AcpAction, vararg requiredCaps: String): RouteResult {
+        val result = router.route(models, action, requiredCaps.toList().toSeries())
+        if (result.a.size > 0) {
+            val chosen = result.a[0]
+            val event = ModelSelectionEvent.ModelSelected(
+                // A card carries one identity; provider and model coincide until cards split them.
+                provider = chosen.b.id,
+                model = chosen.a,
+                strategy = strategyName,
+                requestId = defaultSecureIdGenerator.generateHexId("req", 8),
+                at = kotlinx.datetime.Clock.System.now().toEpochMilliseconds(),
+            )
+            lastSelection = event
+            val observer = selectionObserver
+            if (observer != null) {
+                // An observability hook must never fail the operation it observes: a closed
+                // appender or a full queue costs the event, not the route.
+                try {
+                    observer(event)
+                } catch (_: Throwable) {
+                }
+            }
+        }
+        return result
+    }
 
     /** Non-streaming chat completion */
     suspend fun chat(

--- a/src/commonMain/kotlin/modelmux/RoutingStrategy.kt
+++ b/src/commonMain/kotlin/modelmux/RoutingStrategy.kt
@@ -6,33 +6,209 @@ import borg.trikeshed.lib.*
  * A routing strategy is a pure ranking function over candidates.
  * It reads candidates and contextual health/latency inputs, and returns
  * a ranked Series of candidates.
+ *
+ * ## Provider-blind invariant
+ * No strategy in this file may read [ModelCatalogEntry.provider] (or [ModelCatalogEntry.model])
+ * to decide an ordering. Rankings are computed strictly from the neutral facts —
+ * `freeTier`, `quotaRemaining`, `latencyEstimateMs` — plus the candidate's input position.
+ * A ranking that consults provider identity would privilege a vendor and is forbidden.
+ *
+ * ## Laziness
+ * Every ranking returns a [Series] whose index permutation is computed on first access and
+ * whose elements are still pulled from the source Series. Candidates are never demoted to a
+ * `List` and never copied.
  */
 sealed interface RoutingStrategy<C, H> {
+    /**
+     * Stable label naming this ranking discipline. Stamped onto
+     * [ModelSelectionEvent.ModelSelected.strategy] at the selection point.
+     */
+    val strategyName: String
+
     operator fun invoke(candidates: Series<C>, context: H): Series<C>
 }
+
+/**
+ * How a candidate `C` exposes the neutral catalog facts a ranking reads.
+ *
+ * Strategies stay generic in `C` (the interface is unchanged); a lens supplies the typed
+ * view onto [ModelCatalogEntry] without the strategy knowing what `C` actually is. When
+ * `C` *is* [ModelCatalogEntry], use the entry-typed factories at the foot of this file.
+ */
+typealias EntryLens<C> = (C) -> ModelCatalogEntry
+
+/**
+ * Lazily reorder this Series by a permutation of its own indices, decorate-sort-undecorate.
+ *
+ * Each candidate is pulled from the source and projected to a sort key **exactly once** — the
+ * source's index oracle may be arbitrarily expensive (a cursor, a lazily mapped view), so a
+ * comparator that re-read it per comparison would cost `2·n·log n` reads instead of `n`.
+ *
+ * What is materialized is a `List<Int>` of *indices* and an array of keys; the candidates
+ * themselves are never demoted out of Series form. The permutation is computed on first
+ * element access and then cached, under [LazyThreadSafetyMode.PUBLICATION] — a ranked result
+ * is a value handed to callers and this is a coroutine-heavy codebase, so two dispatcher
+ * threads reading one result must not race on a half-published permutation. PUBLICATION costs
+ * nothing on the uncontended path.
+ *
+ * `sortedWith` is a stable sort, so candidates whose keys compare equal keep their input
+ * order. That is what makes "stable input order" the universal final tiebreak of every
+ * strategy here, and it is why no strategy ever needs a provider-name tiebreak.
+ */
+private fun <C, K> Series<C>.rankedBy(key: (C) -> K, cmp: Comparator<K>): Series<C> {
+    val src = this
+    val n = src.size
+    val order: List<Int> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        val keys = arrayOfNulls<Any?>(n)
+        var i = 0
+        while (i < n) { keys[i] = key(src[i]); i++ }
+        @Suppress("UNCHECKED_CAST")
+        (0 until n).sortedWith(Comparator { x: Int, y: Int -> cmp.compare(keys[x] as K, keys[y] as K) })
+    }
+    return n j { i: Int -> src[order[i]] }
+}
+
+/**
+ * Cheapest-first ordering over the neutral catalog facts, shared by [CostOptimizedStrategy]
+ * and [AutoStrategy].
+ *
+ * 1. **Usable before exhausted.** A candidate with no quota left cannot serve the request, so
+ *    it sinks below every candidate that can — otherwise a free tier at `quotaRemaining == 0`
+ *    would head the ranking and the selection would be a guaranteed failure.
+ * 2. **Free tier before paid.** Free costs nothing; the catalog carries no cost field, so this
+ *    is the only cost signal that exists.
+ * 3. **More remaining quota first.** Quota is budget already paid for.
+ *
+ * `tiebreak` refines what is left — [CostOptimizedStrategy] passes none and falls through to
+ * stable input order, [AutoStrategy] passes latency.
+ */
+private fun costComparator(tiebreak: Comparator<ModelCatalogEntry>?): Comparator<ModelCatalogEntry> =
+    Comparator { x: ModelCatalogEntry, y: ModelCatalogEntry ->
+        val byUsable = (y.quotaRemaining > 0).compareTo(x.quotaRemaining > 0)
+        if (byUsable != 0) return@Comparator byUsable
+        val byTier = y.freeTier.compareTo(x.freeTier)
+        if (byTier != 0) return@Comparator byTier
+        val byQuota = y.quotaRemaining.compareTo(x.quotaRemaining)
+        if (byQuota != 0) byQuota else tiebreak?.compare(x, y) ?: 0
+    }
 
 // ═══════════════════════════════════════════
 // Core Strategy Hierarchy
 // ═══════════════════════════════════════════
 
+/**
+ * Rank by **stable input order** — the caller's own precedence list wins, untouched.
+ *
+ * This is a true identity on the candidate Series and is deliberately so: the catalog (or an
+ * upstream filter) has already expressed a preference by ordering, and `PriorityStrategy`
+ * honours it rather than second-guessing it. It is the strategy to pick when priority is
+ * configuration, not measurement.
+ */
 class PriorityStrategy<C, H> : RoutingStrategy<C, H> {
+    override val strategyName: String get() = "priority"
     override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
 }
 
-class WeightedStrategy<C, H> : RoutingStrategy<C, H> {
-    override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
+/**
+ * Rank by a quota-weighted score with a latency penalty, best first.
+ *
+ * `score = quotaRemaining / (1 + latencyEstimateMs / 1000)`
+ *
+ * Headroom is the numerator, so a candidate with more quota outranks a starved one; latency
+ * divides it, so a second of extra round trip halves the value of that headroom. Ties fall
+ * back to input order.
+ */
+class WeightedStrategy<C, H>(private val lens: EntryLens<C>) : RoutingStrategy<C, H> {
+    override val strategyName: String get() = "weighted"
+
+    override fun invoke(candidates: Series<C>, context: H): Series<C> =
+        candidates.rankedBy(::score, Comparator { x: Double, y: Double -> y.compareTo(x) })
+
+    /** Quota is the numerator, so an exhausted candidate scores zero and sinks on its own. */
+    private fun score(c: C): Double = lens(c).let { e ->
+        e.quotaRemaining.toDouble() / (1.0 + e.latencyEstimateMs / 1000.0)
+    }
 }
 
-class CostOptimizedStrategy<C, H> : RoutingStrategy<C, H> {
-    override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
+/**
+ * Rank cheapest first — usable before exhausted, then free tier before paid, then most
+ * remaining quota first. See [costComparator]. Ties fall back to input order.
+ *
+ * [ModelCatalogEntry] carries no cost field, so "cheap" is expressed by the facts that do
+ * exist: a free tier costs nothing, and remaining quota is budget already paid for.
+ */
+class CostOptimizedStrategy<C, H>(private val lens: EntryLens<C>) : RoutingStrategy<C, H> {
+    override val strategyName: String get() = "cost-optimized"
+
+    override fun invoke(candidates: Series<C>, context: H): Series<C> =
+        candidates.rankedBy(lens, costComparator(null))
 }
 
+/**
+ * Rotate the candidate list by one position per invocation, spreading load evenly.
+ *
+ * Invocation *n* starts the ranking at input index *n mod size* and wraps; relative order is
+ * otherwise preserved. Rotation is the whole ranking — no candidate fact is consulted, which
+ * makes this the most provider-blind strategy of the five.
+ *
+ * The counter is kept **un-normalized** and reduced modulo the candidate count only at the
+ * moment of use. Normalizing it in place would reset the spread whenever the candidate count
+ * changed — and it changes constantly, since callers filter by capability before ranking. A
+ * counter clamped by a two-candidate call would restart a six-candidate call at index 0 every
+ * time, picking the same head twice in a row and starving indices 1..5, which is precisely the
+ * even spread this strategy exists to provide.
+ *
+ * **Single-writer assumption.** The counter is plain instance state, deliberately not guarded
+ * (commonMain has no `synchronized`/`@Volatile`, and a lock here would be worse than the drift
+ * it prevents). One router owns one instance; concurrent callers must each hold their own, or
+ * accept that a raced counter merely skews the spread, never corrupts a result.
+ *
+ * The counter advances at invoke time, not at element-access time, so the Series a caller
+ * receives keeps the offset it was issued.
+ */
 class RoundRobinStrategy<C, H> : RoutingStrategy<C, H> {
-    override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
+    override val strategyName: String get() = "round-robin"
+
+    /** Un-normalized invocation counter; the start index is this reduced by the candidate count. */
+    private var cursor: Int = 0
+
+    /** Invocations served so far — the start index for `n` candidates is `invocations % n`. */
+    val invocations: Int get() = cursor
+
+    override fun invoke(candidates: Series<C>, context: H): Series<C> {
+        val n = candidates.size
+        if (n == 0) return candidates
+        val start = cursor % n
+        // wrap short of overflow rather than going negative; any multiple of a plausible
+        // candidate count would do, and 2^30 is one.
+        cursor = if (cursor == MAX_CURSOR) 0 else cursor + 1
+        return n j { i: Int -> candidates[(start + i) % n] }
+    }
+
+    private companion object {
+        const val MAX_CURSOR = 1 shl 30
+    }
 }
 
-class AutoStrategy<C, H> : RoutingStrategy<C, H> {
-    override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
+/**
+ * The default: cost first, latency as the tiebreak.
+ *
+ * The primary ordering is exactly [CostOptimizedStrategy]'s ([costComparator]); where that
+ * leaves candidates equal, the faster one wins. Expressed as one comparator rather than
+ * `CostOptimized j latencySort` because a second stable sort on latency alone would overwrite
+ * the cost ordering instead of refining it; this is the composition's *intent*, correctly spelled.
+ */
+class AutoStrategy<C, H>(private val lens: EntryLens<C>) : RoutingStrategy<C, H> {
+    override val strategyName: String get() = "auto"
+
+    override fun invoke(candidates: Series<C>, context: H): Series<C> =
+        candidates.rankedBy(lens, costComparator(byLatency))
+
+    private companion object {
+        val byLatency = Comparator { x: ModelCatalogEntry, y: ModelCatalogEntry ->
+            x.latencyEstimateMs.compareTo(y.latencyEstimateMs)
+        }
+    }
 }
 
 // ═══════════════════════════════════════════
@@ -43,6 +219,7 @@ class AutoStrategy<C, H> : RoutingStrategy<C, H> {
  * PassThroughStrategy is the identity element. It returns the candidates unchanged.
  */
 class PassThroughStrategy<C, H> : RoutingStrategy<C, H> {
+    override val strategyName: String get() = "pass-through"
     override fun invoke(candidates: Series<C>, context: H): Series<C> = candidates
 }
 
@@ -54,6 +231,8 @@ class ComposedStrategy<C, H>(
     override val a: RoutingStrategy<C, H>,
     override val b: RoutingStrategy<C, H>
 ) : RoutingStrategy<C, H>, Join<RoutingStrategy<C, H>, RoutingStrategy<C, H>> {
+    override val strategyName: String get() = "${a.strategyName} j ${b.strategyName}"
+
     override fun invoke(candidates: Series<C>, context: H): Series<C> {
         val resultA = a.invoke(candidates, context)
         return b.invoke(resultA, context)
@@ -63,5 +242,22 @@ class ComposedStrategy<C, H>(
 /**
  * Infix operator to compose any two strategies dynamically while remaining in the RoutingStrategy domain
  */
-infix fun <C, H> RoutingStrategy<C, H>.j(other: RoutingStrategy<C, H>): RoutingStrategy<C, H> = 
+infix fun <C, H> RoutingStrategy<C, H>.j(other: RoutingStrategy<C, H>): RoutingStrategy<C, H> =
     ComposedStrategy(this, other)
+
+// ═══════════════════════════════════════════
+// Entry-typed factories
+// ═══════════════════════════════════════════
+//
+// The common case: candidates already *are* ModelCatalogEntry, so the lens is identity.
+// These exist so callers never write `{ it }` and never reach for an unchecked cast.
+
+fun <H> priorityOf(): PriorityStrategy<ModelCatalogEntry, H> = PriorityStrategy()
+
+fun <H> weightedOf(): WeightedStrategy<ModelCatalogEntry, H> = WeightedStrategy { it }
+
+fun <H> costOptimizedOf(): CostOptimizedStrategy<ModelCatalogEntry, H> = CostOptimizedStrategy { it }
+
+fun <H> roundRobinOf(): RoundRobinStrategy<ModelCatalogEntry, H> = RoundRobinStrategy()
+
+fun <H> autoOf(): AutoStrategy<ModelCatalogEntry, H> = AutoStrategy { it }

--- a/src/commonTest/kotlin/modelmux/RoutingStrategyTest.kt
+++ b/src/commonTest/kotlin/modelmux/RoutingStrategyTest.kt
@@ -1,0 +1,217 @@
+package modelmux
+
+import borg.trikeshed.lib.*
+import keymux.KeyMux
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RoutingStrategyTest {
+
+    // Deliberately unordered on every axis so no two strategies can agree by accident.
+    // Names are opaque labels: no strategy may read them, and no assertion below asserts
+    // on a provider *because* of its identity — only on the neutral facts' ordering.
+    private val alpha = ModelCatalogEntry("alpha", "a-1", freeTier = false, quotaRemaining = 900, latencyEstimateMs = 100)
+    private val bravo = ModelCatalogEntry("bravo", "b-1", freeTier = true, quotaRemaining = 50, latencyEstimateMs = 4000)
+    private val charlie = ModelCatalogEntry("charlie", "c-1", freeTier = true, quotaRemaining = 500, latencyEstimateMs = 2000)
+    private val delta = ModelCatalogEntry("delta", "d-1", freeTier = true, quotaRemaining = 500, latencyEstimateMs = 250)
+
+    private val candidates: Series<ModelCatalogEntry> = listOf(alpha, bravo, charlie, delta).toSeries()
+
+    /** Project the ranking to its labels for assertion — the ranking itself never leaves Series form. */
+    private fun Series<ModelCatalogEntry>.providers(): List<String> =
+        (this α { it.provider }).toList()
+
+    @Test
+    fun priority_preservesStableInputOrder() {
+        val ranked = priorityOf<Unit>().invoke(candidates, Unit)
+        assertEquals(listOf("alpha", "bravo", "charlie", "delta"), ranked.providers())
+        assertEquals("priority", priorityOf<Unit>().strategyName)
+    }
+
+    @Test
+    fun weighted_ranksByQuotaOverLatencyPenalty() {
+        // score = quota / (1 + latencyMs/1000):
+        //   alpha   900 / 1.10 = 818.2
+        //   delta   500 / 1.25 = 400.0
+        //   charlie 500 / 3.00 = 166.7
+        //   bravo    50 / 5.00 =  10.0
+        val ranked = weightedOf<Unit>().invoke(candidates, Unit)
+        assertEquals(listOf("alpha", "delta", "charlie", "bravo"), ranked.providers())
+    }
+
+    @Test
+    fun costOptimized_ranksFreeTierThenQuota_andBreaksTiesByInputOrder() {
+        // free tier first (bravo, charlie, delta), by quota desc within the tier
+        // (charlie 500, delta 500, bravo 50); charlie precedes delta on the quota tie
+        // only because it came first in the input — a stable sort, not a provider preference.
+        val ranked = costOptimizedOf<Unit>().invoke(candidates, Unit)
+        assertEquals(listOf("charlie", "delta", "bravo", "alpha"), ranked.providers())
+    }
+
+    @Test
+    fun roundRobin_rotatesStartOffsetPerInvocation() {
+        val rr = roundRobinOf<Unit>()
+        assertEquals(0, rr.invocations)
+        assertEquals(listOf("alpha", "bravo", "charlie", "delta"), rr.invoke(candidates, Unit).providers())
+        assertEquals(listOf("bravo", "charlie", "delta", "alpha"), rr.invoke(candidates, Unit).providers())
+        assertEquals(listOf("charlie", "delta", "alpha", "bravo"), rr.invoke(candidates, Unit).providers())
+        assertEquals(listOf("delta", "alpha", "bravo", "charlie"), rr.invoke(candidates, Unit).providers())
+        // wraps back around
+        assertEquals(listOf("alpha", "bravo", "charlie", "delta"), rr.invoke(candidates, Unit).providers())
+        assertEquals(5, rr.invocations)
+    }
+
+    @Test
+    fun roundRobin_spreadSurvivesAChangingCandidateCount() {
+        // Callers filter by capability before ranking, so the candidate count varies between
+        // invocations of one strategy instance. A cursor normalized against the *current* count
+        // would be clamped by the short list and restart the long list at index 0 every time.
+        val rr = roundRobinOf<Unit>()
+        val two: Series<ModelCatalogEntry> = listOf(alpha, bravo).toSeries()
+        val heads = mutableListOf<String>()
+        repeat(4) {
+            heads.add(rr.invoke(candidates, Unit).providers().first())
+            rr.invoke(two, Unit)
+        }
+        assertEquals(listOf("alpha", "charlie", "alpha", "charlie"), heads)
+        // with a cursor normalized against the current count, the two-candidate call would clamp
+        // it and every four-candidate head would come back "alpha", starving indices 1..3.
+        assertTrue(heads.toSet().size > 1, "short-list calls must not starve the long list")
+    }
+
+    @Test
+    fun roundRobin_onEmptyCandidatesIsIdentity() {
+        val rr = roundRobinOf<Unit>()
+        val empty: Series<ModelCatalogEntry> = emptyList<ModelCatalogEntry>().toSeries()
+        assertEquals(0, rr.invoke(empty, Unit).size)
+        assertEquals(0, rr.invocations, "an empty route must not consume a rotation slot")
+    }
+
+    @Test
+    fun costAndAuto_sinkExhaustedCandidatesBelowUsableOnes() {
+        // A free tier with nothing left cannot serve the request, so it must not head the
+        // ranking — the head is what the selection point reports as chosen.
+        val drained = ModelCatalogEntry("echo", "e-1", freeTier = true, quotaRemaining = 0, latencyEstimateMs = 10)
+        val withDrained: Series<ModelCatalogEntry> = listOf(drained, alpha, charlie).toSeries()
+
+        assertEquals(listOf("charlie", "alpha", "echo"), costOptimizedOf<Unit>().invoke(withDrained, Unit).providers())
+        assertEquals(listOf("charlie", "alpha", "echo"), autoOf<Unit>().invoke(withDrained, Unit).providers())
+        // weighted needs no special case: quota is its numerator, so a drained candidate scores 0
+        assertEquals("echo", weightedOf<Unit>().invoke(withDrained, Unit).providers().last())
+    }
+
+    @Test
+    fun auto_isCostOrderRefinedByLatencyTiebreak() {
+        // Same cost ordering as CostOptimized, but the charlie/delta quota tie now resolves
+        // on latency (delta 250ms beats charlie 2000ms) instead of on input position.
+        val ranked = autoOf<Unit>().invoke(candidates, Unit)
+        assertEquals(listOf("delta", "charlie", "bravo", "alpha"), ranked.providers())
+    }
+
+    @Test
+    fun compose_runsAThenB_andPassThroughIsTheIdentityElement() {
+        val cost = costOptimizedOf<Unit>()
+        val pass = PassThroughStrategy<ModelCatalogEntry, Unit>()
+        val expected = cost.invoke(candidates, Unit).providers()
+
+        // right identity: a j pass == a
+        assertEquals(expected, (cost j pass).invoke(candidates, Unit).providers())
+        // left identity: pass j a == a
+        assertEquals(expected, (pass j cost).invoke(candidates, Unit).providers())
+
+        // b really runs on a's output, not on the original input: priority is a no-op, so the
+        // composite is whatever cost produced; and the composite names both halves.
+        val composed = priorityOf<Unit>() j cost
+        assertEquals(expected, composed.invoke(candidates, Unit).providers())
+        assertEquals("priority j cost-optimized", composed.strategyName)
+
+        // associativity of the ranking, as a function
+        val left = ((cost j pass) j PriorityStrategy<ModelCatalogEntry, Unit>()).invoke(candidates, Unit)
+        val right = (cost j (pass j PriorityStrategy<ModelCatalogEntry, Unit>())).invoke(candidates, Unit)
+        assertEquals(left.providers(), right.providers())
+    }
+
+    @Test
+    fun compose_bSeesAOutput_notTheOriginalInput() {
+        val cost = costOptimizedOf<Unit>()
+        val rr = roundRobinOf<Unit>()
+        // burn three rotations so `rr` next emits the input starting at delta
+        repeat(3) { rr.invoke(candidates, Unit) }
+        assertEquals(listOf("delta", "alpha", "bravo", "charlie"), rr.invoke(candidates, Unit).providers())
+        rr.invoke(candidates, Unit); rr.invoke(candidates, Unit); rr.invoke(candidates, Unit)
+
+        // rotate-then-cost: cost still wins the primary ordering, but the charlie/delta quota
+        // tie now falls out delta-first, because cost's stable tiebreak sees the *rotated* order.
+        assertEquals(listOf("delta", "charlie", "bravo", "alpha"), (rr j cost).invoke(candidates, Unit).providers())
+        // whereas on the unrotated input the same tie falls out charlie-first
+        assertEquals(listOf("charlie", "delta", "bravo", "alpha"), cost.invoke(candidates, Unit).providers())
+    }
+
+    @Test
+    fun modelSelected_isEmittedAtTheSelectionPoint() {
+        val mux = ModelMux(KeyMux {}) {
+            model("gpt-4", caps = setOf("chat", "tools"))
+            model("embed-3", caps = setOf("embed"))
+        }
+        val seen = mutableListOf<ModelSelectionEvent.ModelSelected>()
+        mux.selectionObserver = { e -> if (e is ModelSelectionEvent.ModelSelected) seen.add(e) }
+
+        val result = mux.route("chat", "tools")
+        assertEquals(1, result.a.size)
+
+        assertEquals(1, seen.size, "exactly one ModelSelected per non-empty route")
+        val event = seen.single()
+        assertEquals("gpt-4", event.model)
+        assertEquals("gpt-4", event.provider)
+        // the default label describes what CapabilityRouter actually does — filter and preserve
+        // catalog order — rather than naming a strategy that never ran
+        assertEquals("capability", event.strategy)
+        assertTrue(event.requestId.startsWith("req"), "requestId came from SecureIdGenerator: ${event.requestId}")
+        assertTrue(event.at > 0L, "at is an epoch-millis stamp")
+
+        // the requestId is recoverable for reconciliation against a downstream receipt
+        assertEquals(event, mux.lastSelection)
+
+        // the event serializes as one line for the forge event stream
+        val line = event.toJsonLine()
+        assertTrue("ModelSelected" in line && "gpt-4" in line, line)
+        assertEquals(1, line.lineSequence().count())
+
+        // an owner that ranks through a strategy stamps that strategy's own name
+        mux.strategyName = autoOf<Unit>().strategyName
+        mux.route("chat", "tools")
+        assertEquals("auto", seen.last().strategy)
+        assertEquals(2, seen.size)
+    }
+
+    @Test
+    fun aThrowingObserverDoesNotFailTheRoute() {
+        val mux = ModelMux(KeyMux {}) { model("gpt-4", caps = setOf("chat")) }
+        mux.selectionObserver = { throw IllegalStateException("sink is closed") }
+
+        // observability must not be able to destroy an already-computed result
+        val result = mux.route("chat")
+        assertEquals(1, result.a.size)
+        assertEquals("gpt-4", result.a[0].a)
+        assertNotNull(mux.lastSelection, "the selection is still recorded when the sink fails")
+    }
+
+    @Test
+    fun modelSelected_notEmittedWhenNothingMatches() {
+        val mux = ModelMux(KeyMux {}) {
+            model("embed-3", caps = setOf("embed"))
+        }
+        var emitted: ModelSelectionEvent? = null
+        mux.selectionObserver = { e -> emitted = e }
+
+        val result = mux.route("chat", "tools")
+        assertEquals(0, result.a.size)
+        assertEquals(null, emitted, "an empty route selects nothing, so it must emit nothing")
+
+        // and the same mux does emit once a route succeeds
+        assertNotNull(mux.route("embed").a[0])
+        assertNotNull(emitted)
+    }
+}


### PR DESCRIPTION
Replaces the five identity stubs in `modelmux/RoutingStrategy.kt` with real rankings, and wires the **first-ever** emission of `ModelSelectionEvent.ModelSelected` (nothing constructed it before this PR).

## Strategies

All five are provider-blind — no ranking reads `provider` or `model`.

| Strategy | Ranking |
|---|---|
| `Priority` | Stable input order — a documented true identity. Priority is configuration, not measurement. |
| `Weighted` | `quota / (1 + latencyMs/1000)`, desc. Exhausted candidates score zero and sink with no special case. |
| `CostOptimized` | `ModelCatalogEntry` has no cost field, so "cheap" is: usable-before-exhausted, free tier before paid, quota desc. |
| `RoundRobin` | Rotate the start offset one position per invocation. |
| `Auto` | The `CostOptimized` ordering, refined by a latency tiebreak. |

Ranking stays lazy. `rankedBy()` is decorate-sort-undecorate over an index permutation computed on first access: candidates are never demoted to a `List` and each is pulled from the source exactly once. The stable sort makes input order the universal final tiebreak, which is why no strategy ever needs a provider-name tiebreak.

The generic `RoutingStrategy<C,H>` interface, the `PassThrough` identity, `ComposedStrategy` running `b(a(x))` and infix `j` are unchanged. Typed access to `ModelCatalogEntry` comes from an `EntryLens<C>` plus entry-typed factories (`priorityOf`/`weightedOf`/`costOptimizedOf`/`roundRobinOf`/`autoOf`) — no unchecked casts.

## Selection point

`ModelMux.route()` now stamps the head of the ranking as `ModelSelected` on a non-empty route (`requestId` from `SecureIdGenerator`, `at` from `kotlinx.datetime.Clock`) and hands it to an opt-in `selectionObserver`. `ModelMux.kt` was touched only for this.

## Decisions taken at ambiguous points

- **`Auto` is one comparator, not `CostOptimized j latencySort`.** A second stable sort on latency alone would overwrite the cost ordering rather than refine it; the single comparator is that composition's intent, correctly spelled.
- **`RoundRobin`'s counter is un-normalized**, reduced mod `n` only at use. Normalizing in place reset the spread whenever the candidate count changed — and it changes constantly, since callers filter by capability before ranking. A two-candidate call clamped the counter and restarted six-candidate calls at index 0 every time, picking the same head twice and starving indices 1..5. Covered by a test.
- **Usable-before-exhausted is the dominant cost key.** Free tier alone would let a `quotaRemaining == 0` entry head the ranking, making the reported selection a guaranteed failure.
- **Observer calls are isolated** with `try`/`catch`: an observability hook must not fail the operation it observes. `lastSelection` exposes the `requestId`, which `route()` has no way to return.
- **`strategyName` is a declared label with nothing verifying it.** Defaulted to `"capability"` — what `CapabilityRouter` actually does — and documented as a declaration rather than asserting a discipline that never ran.
- **`LazyThreadSafetyMode.PUBLICATION`, not `NONE`**, for the permutation: a ranked result is a value handed to callers in a coroutine-heavy codebase.

## Tests

13 tests in `src/commonTest/kotlin/modelmux/RoutingStrategyTest.kt`: one per strategy, exhausted-quota demotion, round-robin spread across a changing candidate count, the `a j b` composition law (`PassThrough` identity on both sides, plus associativity and b-sees-a's-output), and `ModelSelected` emission — including non-emission on an empty route and survival of a throwing observer.

## Verification

- `./gradlew jvmMainClasses --console=plain` — **BUILD SUCCESSFUL**
- `./gradlew jvmTest --tests 'modelmux.RoutingStrategyTest' --console=plain` — **13/13 pass**
- `./gradlew jvmTest --tests 'modelmux.ModelMuxTest' --console=plain` — **5/5 pass** (no regression from the `route()` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
