### PR TITLE
feat(nuid): M2 — production Workgroup registration + SignalFacetReduced → JobCommand bridge

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/context/nuid/ModelWorkgroups.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/nuid/ModelWorkgroups.kt
@@ -1,0 +1,71 @@
+package borg.trikeshed.context.nuid
+
+import borg.trikeshed.lib.Series
+import borg.trikeshed.lib.j
+
+/**
+ * ModelWorkgroups — production [Workgroup] registration for the model facades.
+ *
+ * The canonical registration pattern lives in `JvmKanbanServer.run` (jvmMain):
+ * build a [TraitSpace] over the capabilities the group fulfills, wrap it in a
+ * [Workgroup] with a [Subnet] scope, `register` it on a [NuidFanoutElement],
+ * then `activate` the fanout. That pattern was jvm-only because the
+ * `traitSpaceOf` helper lived in `JvmForgeIo`. This file lifts the helper into
+ * commonMain so every target can register production workgroups, and pins the
+ * model-facade ("modelmux") workgroup as a named, reusable registration.
+ *
+ * Provider neutrality: the workgroup advertises [Capability.Model] — the
+ * *capability*, never a provider identity. Anthropic, OpenAI-compatible, Jules,
+ * opencode and kilo facades all claim through the same trait; admission is by
+ * capability × subnet only. Nothing here may branch on who the provider is.
+ */
+
+/**
+ * Build a [TraitSpace] from a vararg of capabilities.
+ *
+ * The trait space is a lazy `α` projection over the captured capabilities —
+ * `n j { i -> caps[i] }` — not a materialized collection, so matching walks
+ * the series on demand.
+ */
+fun traitSpaceOf(vararg capabilities: Capability): TraitSpace {
+    // Defensive copy: the vararg array is caller-visible, and the TraitSpace
+    // outlives this call as a lazy projection over it.
+    val caps: Array<Capability> = Array(capabilities.size) { i -> capabilities[i] }
+    val series: Series<Capability> = caps.size j { i -> caps[i] }
+    return TraitSpace { series }
+}
+
+/** Registry name of the canonical model-facade workgroup. */
+const val MODEL_WORKGROUP_NAME: String = "modelmux-local"
+
+/**
+ * The model-facade workgroup: [Capability.Model] (category "modelmux") at
+ * [Subnet.local]. The family wildcard [Capability.ModelAll] is included so a
+ * request carrying any future `modelmux` leaf still lands here.
+ */
+fun modelWorkgroup(
+    name: String = MODEL_WORKGROUP_NAME,
+    scope: Subnet = Subnet.local,
+): Workgroup = Workgroup(
+    name = name,
+    scope = scope,
+    traits = traitSpaceOf(Capability.Model, Capability.ModelAll),
+)
+
+/**
+ * Register [workgroup] on this fanout and promote the fanout to ACTIVE.
+ *
+ * Idempotent on the workgroup name (see [NuidFanoutElement.register]) and on
+ * the lifecycle promotion, so repeated wiring is harmless. Returns the
+ * registered workgroup so callers can hold its name for `slotOf`.
+ */
+suspend fun NuidFanoutElement.registerWorkgroup(workgroup: Workgroup): Workgroup {
+    register(workgroup)
+    activate()
+    return workgroup
+}
+
+/** Register the canonical [modelWorkgroup] on this fanout. */
+suspend fun NuidFanoutElement.registerModelWorkgroup(
+    workgroup: Workgroup = modelWorkgroup(),
+): Workgroup = registerWorkgroup(workgroup)

--- a/src/commonMain/kotlin/borg/trikeshed/context/nuid/SignalJobBridgeElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/context/nuid/SignalJobBridgeElement.kt
@@ -1,0 +1,210 @@
+package borg.trikeshed.context.nuid
+
+import borg.trikeshed.context.AsyncContextElement
+import borg.trikeshed.context.AsyncContextKey
+import borg.trikeshed.context.ElementState
+import borg.trikeshed.job.JobCommand
+import borg.trikeshed.job.JobId
+import borg.trikeshed.job.JobSupervisorElement
+import borg.trikeshed.lib.Join
+import borg.trikeshed.lib.j
+import borg.trikeshed.userspace.reactor.KanbanEvent
+import borg.trikeshed.userspace.reactor.KanbanFSM
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * SignalJobBridgeElement — joins the two dispatch lanes.
+ *
+ * The NUID lane answers *who*: a [Workgroup] claims a [Nuid] by capability ×
+ * subnet. The JobCommand lane answers *what*: a [JobCommand] enters the
+ * durability pipeline (schema → CAS → WAL → barrier → reducer → index) and
+ * comes out the other side as a committed `JobEvent`. Until now the two lanes
+ * never met — a reduced signal facet landed on the kanban event flow as
+ * vocabulary and stopped there.
+ *
+ * This element is the seam. It collects [KanbanFSM.kanbanEvents], keeps only
+ * [KanbanEvent.SignalFacetReduced], and commits each one as a
+ * [JobCommand.Submit] through [JobSupervisorElement.submit].
+ *
+ * ### Idempotency key
+ *
+ * The natural key is the event's `sourceSignalId` — the identity of the
+ * *signal*. It is not, however, the identity of a *reduction occurrence*: the
+ * only production emitter ([borg.trikeshed.context.lcnc.LcncFanoutElement])
+ * builds `sourceSignalId` from the facet mark plus two hard-coded spine marks,
+ * so every reduction of a given facet carries the identical string. Keyed on
+ * `sourceSignalId` alone the bridge would commit exactly one job per facet for
+ * the lifetime of the process and silently drop the rest.
+ *
+ * The default key is therefore the occurrence — `sourceSignalId` qualified by
+ * the reduction's timestamp and reduced value ([signalOccurrenceKey]). A
+ * replayed event (the flow has a 64-deep replay buffer) reproduces the same
+ * key and is suppressed, which is what idempotency is for; two genuinely
+ * distinct reductions get distinct keys and both commit. Callers that own a
+ * unique `sourceSignalId` can restore the strict form by passing
+ * `idempotencyKeyOf = { it.sourceSignalId }`.
+ *
+ * ### Provider neutrality
+ *
+ * The bridge reads only the facet key, the reduced value, the source signal id
+ * and the timestamp. It never inspects, branches on, or records which provider
+ * produced the reduction.
+ *
+ * ### Lifecycle
+ *
+ *   CREATED  ⇒ constructed; [bridge] rejects.
+ *   OPEN     ⇒ [bridge] accepted; [run] may start.
+ *   ACTIVE   ⇒ the collect loop is attached to the event flow.
+ *   DRAINING ⇒ no new submissions accepted by [bridge].
+ *   CLOSED   ⇒ [supervisor] cancelled.
+ *
+ * A collector launched on [supervisor] (as [wireSignalFacetsToJobs] does) is
+ * cancelled by [close]. It is *not* stopped by [drain]: `drain` completes the
+ * supervisor and joins its children, and a `SharedFlow` collect never
+ * completes on its own — shut a wired bridge down with [close].
+ */
+class SignalJobBridgeElement(
+    private val jobs: JobSupervisorElement,
+    parentJob: Job? = null,
+    private val events: SharedFlow<KanbanEvent> = KanbanFSM.kanbanEvents,
+    private val jobIdOf: (KanbanEvent.SignalFacetReduced) -> JobId = { signalFacetJobId(it) },
+    private val idempotencyKeyOf: (KanbanEvent.SignalFacetReduced) -> String = { signalOccurrenceKey(it) },
+) : AsyncContextElement(ElementState.CREATED, parentJob) {
+
+    companion object Key : AsyncContextKey<SignalJobBridgeElement>()
+
+    override val key: AsyncContextKey<SignalJobBridgeElement> = Key
+
+    /** The flow [run] attaches to. Defaults to [KanbanFSM.kanbanEvents]. */
+    val eventSource: SharedFlow<KanbanEvent> get() = events
+
+    /** Idempotency ledger — the set of occurrence keys already handed to the nexus. */
+    private val ledgerMutex: Mutex = Mutex()
+    private val handedOffKeys: MutableSet<String> = mutableSetOf()
+    private var submitCount: Int = 0
+
+    /**
+     * Number of [JobCommand.Submit]s this bridge has handed to the nexus.
+     *
+     * A handoff is not a commit: the nexus reducer may still reject the command
+     * (duplicate idempotency key surviving in a WAL replay, stale revision).
+     * Read `JobSupervisorElement.committed` for the authoritative outcome.
+     */
+    val submitted: Int get() = submitCount
+
+    /** Promote OPEN → ACTIVE. Idempotent. */
+    suspend fun activate() {
+        if (state == ElementState.OPEN) state = ElementState.ACTIVE
+    }
+
+    /**
+     * Hand one reduced signal facet to the job nexus as a [JobCommand.Submit].
+     *
+     * Returns the [JobId] that was submitted, or null when the bridge is not
+     * accepting (outside OPEN/ACTIVE) or the occurrence key was already handed
+     * off. A non-null return means the command reached the nexus command
+     * channel — the committed/rejected verdict arrives separately on
+     * `JobSupervisorElement.committed`.
+     *
+     * Exposed directly so callers that already hold an event — tests, replay
+     * tools, the daemon — can commit without going through the flow.
+     */
+    suspend fun bridge(event: KanbanEvent.SignalFacetReduced): JobId? {
+        if (state != ElementState.OPEN && state != ElementState.ACTIVE) return null
+        val idempotencyKey = idempotencyKeyOf(event)
+        val fresh = ledgerMutex.withLock { handedOffKeys.add(idempotencyKey) }
+        if (!fresh) return null
+        val jobId = jobIdOf(event)
+        try {
+            jobs.submit(JobCommand.Submit(jobId = jobId, idempotencyKey = idempotencyKey))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // The ledger claims a key before the handoff so concurrent bridges
+            // cannot both submit it; a failed handoff must give the key back.
+            ledgerMutex.withLock { handedOffKeys.remove(idempotencyKey) }
+            throw e
+        }
+        ledgerMutex.withLock { submitCount++ }
+        return jobId
+    }
+
+    /**
+     * Attach to the event flow and bridge forever. Suspends until cancelled —
+     * launch it, don't await it.
+     *
+     * A failed handoff (the nexus drained or closed underneath us) must not
+     * tear down the collector's scope, so per-event failures are swallowed
+     * here; cancellation still propagates.
+     */
+    suspend fun run() {
+        activate()
+        events.filterIsInstance<KanbanEvent.SignalFacetReduced>().collect { event ->
+            try {
+                bridge(event)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // The nexus stopped accepting. Stay attached — the flow is
+                // process-wide and a later supervisor may take over — but do
+                // not cancel the scope that launched this collector.
+            }
+        }
+    }
+}
+
+/** Job id prefix for jobs minted from a reduced signal facet. */
+const val SIGNAL_FACET_JOB_PREFIX: String = "signal-facet"
+
+/**
+ * Identity of one reduction *occurrence*: the source signal, the instant it
+ * reduced, and the value it reduced to. Deterministic, so a replayed event
+ * reproduces the key of its first pass and dedupes against it.
+ */
+fun signalOccurrenceKey(event: KanbanEvent.SignalFacetReduced): String =
+    "${event.sourceSignalId}@${event.timestampMs}#${event.reducedValue}"
+
+/**
+ * Default job identity for a reduced signal facet:
+ * `signal-facet:<facetKey>:<occurrenceKey>`.
+ */
+fun signalFacetJobId(event: KanbanEvent.SignalFacetReduced): JobId =
+    JobId.of("$SIGNAL_FACET_JOB_PREFIX:${event.facetKey}:${signalOccurrenceKey(event)}")
+
+/**
+ * Wire both lanes together: register the model-facade [Workgroup] on [fanout]
+ * (NUID lane — *who*) and launch a [SignalJobBridgeElement] against [jobs]
+ * (JobCommand lane — *what*).
+ *
+ * Returns `workgroup j (bridge j collectorJob)` so the caller can inspect the
+ * registration, count handoffs, and cancel the collector on shutdown.
+ *
+ * The collector is launched on the bridge's own supervisor, so
+ * `bridge.close()` stops it; the job is returned as well for callers that want
+ * to detach the collector without closing the element.
+ */
+suspend fun wireSignalFacetsToJobs(
+    scope: CoroutineScope,
+    jobs: JobSupervisorElement,
+    fanout: NuidFanoutElement,
+    workgroup: Workgroup = modelWorkgroup(),
+    events: SharedFlow<KanbanEvent> = KanbanFSM.kanbanEvents,
+): Join<Workgroup, Join<SignalJobBridgeElement, Job>> {
+    fanout.open()
+    fanout.registerWorkgroup(workgroup)
+    val bridge = SignalJobBridgeElement(
+        jobs = jobs,
+        parentJob = scope.coroutineContext[Job],
+        events = events,
+    )
+    bridge.open()
+    val collector = scope.launch(bridge.supervisor) { bridge.run() }
+    return workgroup j (bridge j collector)
+}

--- a/src/commonTest/kotlin/borg/trikeshed/context/nuid/ModelWorkgroupJobBridgeTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/context/nuid/ModelWorkgroupJobBridgeTest.kt
@@ -1,0 +1,186 @@
+package borg.trikeshed.context.nuid
+
+import borg.trikeshed.job.JobEvent
+import borg.trikeshed.job.JobId
+import borg.trikeshed.job.JobSupervisorElement
+import borg.trikeshed.userspace.reactor.KanbanEvent
+import borg.trikeshed.userspace.reactor.KanbanFSM
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * M2 — the midpoint where the two dispatch lanes meet.
+ *
+ * NUID claim selects *who*: a registered [Workgroup] claims a
+ * [Capability.Model] nuid at [Subnet.local]. JobCommand commits *what*: a
+ * [KanbanEvent.SignalFacetReduced] becomes a `JobCommand.Submit` that leaves
+ * the durability pipeline as a committed `JobEvent`.
+ */
+class ModelWorkgroupJobBridgeTest {
+
+    private fun facetEvent(
+        sourceSignalId: String,
+        reducedValue: String = "reduced",
+        timestampMs: Long = 1L,
+    ) = KanbanEvent.SignalFacetReduced(
+        facetKey = "modelmux",
+        reducedValue = reducedValue,
+        sourceSignalId = sourceSignalId,
+        timestampMs = timestampMs,
+    )
+
+    @Test
+    fun registeredModelWorkgroupClaimsModelNuid() = runTest {
+        val fanout = NuidFanoutElement()
+        fanout.open()
+        val workgroup = fanout.registerModelWorkgroup()
+
+        assertEquals(MODEL_WORKGROUP_NAME, workgroup.name)
+        assertEquals(Subnet.local, workgroup.scope)
+        assertTrue(workgroup.traits.can(Capability.Model), "trait space must admit Capability.Model")
+        assertEquals("modelmux", Capability.Model.category)
+
+        val request = nuid(Capability.Model, Nonce.RandomBytes(), Subnet.local)
+        val result = fanout.dispatch(request, payload = "prompt", timeoutMillis = 500L)
+
+        assertEquals(MODEL_WORKGROUP_NAME, result.winner, "the model workgroup must claim a Capability.Model nuid")
+        assertEquals(Subnet.local, result.claimedAtSubnet)
+
+        fanout.close()
+    }
+
+    @Test
+    fun unrelatedCapabilityDoesNotRouteToModelWorkgroup() = runTest {
+        val fanout = NuidFanoutElement()
+        fanout.open()
+        fanout.registerModelWorkgroup()
+
+        val request = nuid(Capability.Cas("read"), Nonce.RandomBytes(), Subnet.local)
+        val result = fanout.dispatch(request, payload = null, timeoutMillis = 50L)
+
+        assertNull(result.winner, "trait × subnet must both gate — a cas nuid is not modelmux work")
+
+        fanout.close()
+    }
+
+    @Test
+    fun signalFacetReducedCommitsAJobEvent() = runTest {
+        val jobs = JobSupervisorElement.open(this, capacity = 64)
+        val bridge = SignalJobBridgeElement(jobs = jobs)
+        bridge.open()
+
+        val event = facetEvent(sourceSignalId = "sig-direct-1")
+        val jobId = bridge.bridge(event)
+        assertNotNull(jobId, "an OPEN bridge must commit a reduced facet")
+        assertEquals(signalFacetJobId(event), jobId)
+
+        val committed = jobs.committed.receive()
+        val accepted = assertNotNull(
+            committed as? JobEvent.Accepted,
+            "the submit must leave the pipeline committed, was $committed",
+        )
+        assertEquals(jobId, accepted.jobId)
+        assertEquals("submitted", jobs.snapshot(jobId)?.lifecycle)
+
+        // The same occurrence replayed off the flow's replay buffer is a no-op.
+        assertNull(bridge.bridge(event), "a replayed occurrence must not double-commit")
+        assertEquals(1, bridge.submitted)
+
+        jobs.cancel()
+        bridge.close()
+    }
+
+    /**
+     * Regression: the only production emitter builds `sourceSignalId` from the
+     * facet mark plus two hard-coded spine marks, so consecutive reductions of
+     * one facet share it verbatim. Keyed on `sourceSignalId` alone the bridge
+     * would commit one job per facet, ever, and drop everything after it.
+     */
+    @Test
+    fun distinctReductionsSharingASourceSignalIdBothCommit() = runTest {
+        val jobs = JobSupervisorElement.open(this, capacity = 64)
+        val bridge = SignalJobBridgeElement(jobs = jobs)
+        bridge.open()
+
+        val constantSignalId = "lcnc:logic:dispatched:afterget"
+        val first = facetEvent(constantSignalId, reducedValue = "first", timestampMs = 10L)
+        val second = facetEvent(constantSignalId, reducedValue = "second", timestampMs = 11L)
+
+        val firstId = assertNotNull(bridge.bridge(first))
+        val secondId = assertNotNull(bridge.bridge(second), "a second reduction must not be mistaken for a replay")
+        assertNotEquals(firstId, secondId, "distinct occurrences must mint distinct jobs")
+        assertNotEquals(signalOccurrenceKey(first), signalOccurrenceKey(second))
+
+        val committedIds = setOf(
+            (jobs.committed.receive() as JobEvent.Accepted).jobId,
+            (jobs.committed.receive() as JobEvent.Accepted).jobId,
+        )
+        assertEquals(setOf(firstId, secondId), committedIds)
+        assertEquals(2, bridge.submitted)
+
+        jobs.cancel()
+        bridge.close()
+    }
+
+    @Test
+    fun wiredBridgeCarriesKanbanEventsIntoTheJobNexus() = runTest {
+        val jobs = JobSupervisorElement.open(this, capacity = 64)
+        val fanout = NuidFanoutElement()
+        // A dedicated flow: KanbanFSM.kanbanEvents is process-wide with a
+        // 64-deep replay buffer, so sibling suites would otherwise decide how
+        // many committed events this test has to scan past.
+        val events = MutableSharedFlow<KanbanEvent>(
+            replay = 64,
+            extraBufferCapacity = 64,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+        val wiring = wireSignalFacetsToJobs(scope = this, jobs = jobs, fanout = fanout, events = events)
+        val workgroup = wiring.a
+        val bridge = wiring.b.a
+
+        // The NUID lane is live: the wiring registered the model workgroup.
+        assertEquals(MODEL_WORKGROUP_NAME, workgroup.name)
+        assertNotNull(fanout.slotOf(MODEL_WORKGROUP_NAME))
+
+        val event = facetEvent(sourceSignalId = "sig-wired-1", timestampMs = 2L)
+        val expectedJobId: JobId = signalFacetJobId(event)
+        events.emit(event)
+
+        val committed = jobs.committed.receive()
+        val accepted = assertNotNull(
+            committed as? JobEvent.Accepted,
+            "the collected SignalFacetReduced must commit as a JobEvent, was $committed",
+        )
+        assertEquals(expectedJobId, accepted.jobId)
+        assertEquals("submitted", jobs.snapshot(expectedJobId)?.lifecycle)
+        assertEquals(1, bridge.submitted)
+
+        // close() must stop the collector: it was launched on the element's
+        // own supervisor, not on the caller's scope.
+        bridge.close()
+        jobs.cancel()
+        fanout.close()
+    }
+
+    /** The default event source is the process-wide kanban flow. */
+    @Test
+    fun bridgeDefaultsToTheKanbanEventFlow() = runTest {
+        val jobs = JobSupervisorElement.open(this, capacity = 8)
+        val bridge = SignalJobBridgeElement(jobs = jobs)
+
+        assertTrue(
+            bridge.eventSource === KanbanFSM.kanbanEvents,
+            "an unconfigured bridge must attach to KanbanFSM.kanbanEvents",
+        )
+
+        jobs.cancel()
+    }
+}

--- a/src/jvmMain/kotlin/borg/trikeshed/util/JvmForgeIo.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/util/JvmForgeIo.kt
@@ -2,7 +2,6 @@ package borg.trikeshed.util
 
 import borg.trikeshed.context.nuid.Capability
 import borg.trikeshed.context.nuid.TraitSpace
-import borg.trikeshed.lib.j
 import borg.trikeshed.util.io.ForgeCliArgs
 import java.nio.file.Files as NioFiles
 import java.nio.file.Paths
@@ -16,10 +15,14 @@ import kotlin.system.exitProcess
  */
 object JvmForgeIo {
 
-    /** Build a [TraitSpace] from a vararg of capabilities. */
-    fun traitSpaceOf(vararg capabilities: Capability): TraitSpace = TraitSpace {
-        capabilities.size j { index -> capabilities[index] }
-    }
+    /**
+     * Build a [TraitSpace] from a vararg of capabilities.
+     *
+     * Delegates to the commonMain helper so every target shares one definition
+     * (including its defensive copy of the vararg array).
+     */
+    fun traitSpaceOf(vararg capabilities: Capability): TraitSpace =
+        borg.trikeshed.context.nuid.traitSpaceOf(*capabilities)
 
     /**
      * Atomically write [text] to [path], creating parent directories as


### PR DESCRIPTION
## M2 — Production Workgroup registration + JobCommand bridge

Joins the two dispatch lanes: **NUID claim selects *who*, JobCommand commits *what*.** Before this, a reduced signal facet landed on the kanban event flow as vocabulary and stopped there — `KanbanEvent.SignalFacetReduced` had an emitter and an FSM branch, but no path into the job nexus.

### (a) Workgroup registration — `src/commonMain/kotlin/borg/trikeshed/context/nuid/ModelWorkgroups.kt` (new)

- `traitSpaceOf(vararg Capability)` lifted into commonMain as a lazy `n j { i -> caps[i] }` projection (previously jvm-only in `JvmForgeIo`).
- `modelWorkgroup()` — the canonical model-facade workgroup: `Capability.Model` (category `"modelmux"`) plus the `ModelAll` family wildcard, at `Subnet.local`.
- `NuidFanoutElement.registerWorkgroup` / `registerModelWorkgroup`, following the canonical `JvmKanbanServer` pattern (`register` then `activate`). Idempotent on name and on the lifecycle promotion.

### (b) Bridge — `src/commonMain/kotlin/borg/trikeshed/context/nuid/SignalJobBridgeElement.kt` (new)

- A CCEK element (`AsyncContextElement` + `AsyncContextKey`, CREATED→OPEN→ACTIVE→DRAINING→CLOSED) that collects `KanbanFSM.kanbanEvents`, filters `SignalFacetReduced`, and submits `JobCommand.Submit` via `JobSupervisorElement.submit`.
- `wireSignalFacetsToJobs(scope, jobs, fanout)` — suspend wiring returning `workgroup j (bridge j collector)`. The collector runs on the element's own supervisor, so `close()` stops it.
- **Provider-neutral**: reads facet key, reduced value, source signal id and timestamp only. Nothing branches on provider identity; admission stays capability × subnet.

### Decision taken autonomously

The unit spec said `idempotencyKey = event.sourceSignalId`. The only production emitter (`LcncFanoutElement`) builds `sourceSignalId` from the facet mark plus two hard-coded spine marks, so **every** reduction of a given facet carries the identical string. Keyed on it verbatim, the bridge would commit exactly one job per facet for the process lifetime and silently drop the rest.

The default key is therefore the reduction *occurrence* — `signalOccurrenceKey` = `sourceSignalId @ timestampMs # reducedValue`. Replays still dedupe (which is what idempotency is for); genuinely distinct reductions both commit. The strict form is one constructor argument away: `idempotencyKeyOf = { it.sourceSignalId }`. Pinned by `distinctReductionsSharingASourceSignalIdBothCommit`.

Also from review: the ledger claims a key *before* the handoff and gives it back if the handoff fails (a drained nexus must not burn the event); `run()` swallows per-event handoff failures while rethrowing cancellation, so a drained supervisor cannot cancel the caller's scope; `JvmForgeIo.traitSpaceOf` now delegates to the commonMain helper instead of keeping a divergent copy.

### Verification

- `./gradlew jvmMainClasses --console=plain` — **green**.
- `ModelWorkgroupJobBridgeTest` — **6/6 pass**: the registered workgroup claims a `Capability.Model` nuid at `Subnet.local`, an unrelated `Capability.Cas` nuid does not route, a `SignalFacetReduced` produces a committed `JobEvent.Accepted` both directly and through the wired collector, replays dedupe, and distinct reductions sharing a `sourceSignalId` both commit.
- Unaffected: `ConcentricKanbanDemoTest`, `LcncFanoutSignalSpineTest`, `NuidAlgebraTest`, `NuidFanoutElementTest`, `JobSupervisorDrainTest`, `JobSupervisorReteIntegrationTest`.
- Out of scope: `JobNexusFactoryTest` has 2 pre-existing failures (`JobNexusFactory` records only `scope`/`cas`/`wal` in its close trace); untouched by this branch.

No sibling-owned path was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
