### PR TITLE
fix(metrics): purge JVM leakage from commonMain FlywheelMetrics

### DIFF
--- a/src/commonMain/kotlin/metrics/FlywheelMetrics.kt
+++ b/src/commonMain/kotlin/metrics/FlywheelMetrics.kt
@@ -1,27 +1,38 @@
 package metrics
 
+import borg.trikeshed.isam.synchronizedLock
 import fsm.FlywheelState
-import kotlin.time.TimeSource
+import kotlin.concurrent.Volatile
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlinx.datetime.Clock
 
 /**
  * Flywheel telemetry — in-memory metrics with JSON and Prometheus text-format export.
  *
- * Thread-safe via synchronized access on all mutating operations. The daemon writes
- * this to the UNIX health socket on every connection and exports it via /metrics.
+ * Thread-safe via [synchronizedLock] on all mutating operations (the project's
+ * expect/actual monitor: a real monitor on the JVM, a no-op on the JS/Wasm actuals;
+ * the Native actual is also a no-op, so Native callers must stay single-threaded).
+ * Cross-lock reads are published through the multiplatform
+ * [kotlin.concurrent.Volatile] annotation.
+ *
+ * Pure commonMain: no `java.*`, no `System.*`, no JVM `synchronized`. Wall clock
+ * comes from [kotlinx.datetime.Clock]; the daemon writes this to the UNIX health
+ * socket on every connection and exports it via /metrics.
  */
 object FlywheelMetrics {
+
+    private const val MS_PER_DAY = 86_400_000L
+
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
 
     // ── State machine transitions ────────────────────────────────────────────────
 
     private val _transitionCounts = mutableMapOf<String, Long>()
-    private var _lastTransitionMark = TimeSource.Monotonic.markNow()
     private val _transitionLock = Any()
 
     fun recordTransition(from: FlywheelState, to: FlywheelState) {
-        val now = TimeSource.Monotonic.markNow()
-        synchronized(_transitionLock) {
-            val duration = _lastTransitionMark.elapsedNow()
-            _lastTransitionMark = now
+        synchronizedLock(_transitionLock) {
             val key = "${from::class.simpleName}->${to::class.simpleName}"
             _transitionCounts[key] = (_transitionCounts[key] ?: 0L) + 1L
         }
@@ -52,22 +63,19 @@ object FlywheelMetrics {
     private var _cyclesTodayResetMs: Long = currentDayStartMs()
     private val _cycleLock = Any()
 
-    private fun currentDayStartMs(): Long {
-        val now = java.time.Instant.ofEpochMilli(System.currentTimeMillis())
-            .atZone(java.time.ZoneOffset.UTC)
-            .toLocalDate()
-            .atStartOfDay(java.time.ZoneOffset.UTC)
-            .toInstant()
-            .toEpochMilli()
-        return now
-    }
+    /**
+     * Epoch millis of the most recent midnight UTC. Unix time has no leap seconds,
+     * so flooring to the day boundary is exactly `atStartOfDay(UTC)`.
+     */
+    private fun currentDayStartMs(): Long = (nowMs() / MS_PER_DAY) * MS_PER_DAY
 
     /** Call once per completed cycle from CycleBody.run() */
     fun recordCycle(hadErrors: Boolean) {
-        synchronized(_cycleLock) {
-            val nowMs = System.currentTimeMillis()
-            if (nowMs >= _cyclesTodayResetMs + 86_400_000L) {
-                // Midnight UTC passed — reset daily counter
+        synchronizedLock(_cycleLock) {
+            val nowMs = nowMs()
+            if (nowMs >= _cyclesTodayResetMs + MS_PER_DAY) {
+                // Midnight UTC passed — bank the finished day, then reset the daily counter
+                rollDayWindow(cyclesToday)
                 cyclesToday = 0L
                 _cyclesTodayResetMs = currentDayStartMs()
             }
@@ -101,10 +109,26 @@ object FlywheelMetrics {
     var lastCycleMs: Long = 0L
         private set
 
-    /** Rolling window: cycles-per-day for the last 7 days (index 0 = today). */
+    /**
+     * Rolling window: cycles-per-day for the last 7 days (index 0 = today).
+     * Slot 0 tracks the running total for the current UTC day; the midnight
+     * rollover in [recordCycle] shifts the completed day into slot 1.
+     */
     private val _cyclesPerDayRing = LongArray(7)
-    private var _ringIndex = 0
     private val _ringLock = Any()
+
+    /**
+     * Shift the day window one slot to the right, dropping the oldest day.
+     * Called from [recordCycle] while `_cycleLock` is held — `_cycleLock` → `_ringLock`
+     * is the only lock nesting in this object, and never occurs in the other order.
+     */
+    private fun rollDayWindow(finishedDayTotal: Long) = synchronizedLock(_ringLock) {
+        for (i in _cyclesPerDayRing.lastIndex downTo 2) {
+            _cyclesPerDayRing[i] = _cyclesPerDayRing[i - 1]
+        }
+        _cyclesPerDayRing[1] = finishedDayTotal
+        _cyclesPerDayRing[0] = 0L
+    }
 
     // ── Phase latency histograms ──────────────────────────────────────────────────
 
@@ -114,10 +138,15 @@ object FlywheelMetrics {
      */
     private val _latencyBuckets = longArrayOf(10, 50, 100, 250, 500, 1000, 2500, 5000, 10000)
     private val _histogramCounters = LongArray(_latencyBuckets.size + 1) // +Inf bucket
-    private val _histogramSum = java.util.concurrent.atomic.AtomicLong(0)
+    private var _histogramSum = 0L
     private val _histogramLock = Any()
 
+    /** Consistent (counts, sum) snapshot of the latency histogram. */
+    private fun histogramSnapshot(): Pair<LongArray, Long> =
+        synchronizedLock(_histogramLock) { _histogramCounters.copyOf() to _histogramSum }
+
     /** Timestamp (epoch ms) of the most recent cycle start. */
+    @Volatile
     private var _lastCycleTimestampMs: Long = 0L
 
     /**
@@ -125,12 +154,10 @@ object FlywheelMetrics {
      * last two completed cycles. Zero until at least two cycles have run.
      */
     val cyclesPerSecond: Double
-        get() {
-            synchronized(_cycleLock) {
-                if (_lastCycleTimestampMs == 0L || totalCycles < 2L) return 0.0
-                val elapsed = System.currentTimeMillis() - _lastCycleTimestampMs
-                return if (elapsed > 0) 1_000.0 / elapsed else 0.0
-            }
+        get() = synchronizedLock(_cycleLock) {
+            if (_lastCycleTimestampMs == 0L || totalCycles < 2L) return@synchronizedLock 0.0
+            val elapsed = nowMs() - _lastCycleTimestampMs
+            if (elapsed > 0) 1_000.0 / elapsed else 0.0
         }
 
     /**
@@ -138,13 +165,11 @@ object FlywheelMetrics {
      * Compared at midnight-UTC boundary — cyclesToday / seconds-today.
      */
     val cyclesAt100PerDay: Boolean
-        get() {
-            synchronized(_cycleLock) {
-                val msToday = System.currentTimeMillis() - _cyclesTodayResetMs
-                val secondsToday = (msToday / 1_000.0).coerceAtLeast(1.0)
-                val rateToday = cyclesToday / secondsToday
-                return rateToday >= 100.0 / 86_400.0
-            }
+        get() = synchronizedLock(_cycleLock) {
+            val msToday = nowMs() - _cyclesTodayResetMs
+            val secondsToday = (msToday / 1_000.0).coerceAtLeast(1.0)
+            val rateToday = cyclesToday / secondsToday
+            rateToday >= 100.0 / 86_400.0
         }
 
     // ── Slot utilization ─────────────────────────────────────────────────────────
@@ -163,16 +188,16 @@ object FlywheelMetrics {
     }
 
     fun recordPhaseLatencies(latencies: List<PhaseLatency>, totalMs: Long, phase: String) {
-        synchronized(_ringLock) {
+        synchronizedLock(_ringLock) {
             lastPhaseLatencies = latencies
             lastPhase = phase
             lastCycleMs = totalMs
-            _cyclesPerDayRing[_ringIndex] = cyclesToday
+            _cyclesPerDayRing[0] = cyclesToday
         }
         // Record total cycle time in histogram for percentile queries.
         val total = totalMs.coerceAtLeast(0)
-        _histogramSum.addAndGet(total)
-        synchronized(_histogramLock) {
+        synchronizedLock(_histogramLock) {
+            _histogramSum += total
             val bucketIdx = _latencyBuckets.indexOfFirst { total <= it }
             val idx = if (bucketIdx >= 0) bucketIdx else _latencyBuckets.size
             _histogramCounters[idx]++
@@ -182,27 +207,26 @@ object FlywheelMetrics {
     // ── Reset (call from daemon startup) ────────────────────────────────────────
 
     fun reset() {
-        synchronized(_transitionLock) { _transitionCounts.clear() }
-        synchronized(_cycleLock) {
+        synchronizedLock(_transitionLock) { _transitionCounts.clear() }
+        synchronizedLock(_cycleLock) {
             totalCycles = 0L
             cleanCycles = 0L
             errorCycles = 0L
             cyclesToday = 0L
             _cyclesTodayResetMs = currentDayStartMs()
+            _lastCycleTimestampMs = 0L
         }
-        synchronized(_ringLock) {
+        synchronizedLock(_ringLock) {
             _cyclesPerDayRing.fill(0L)
-            _ringIndex = 0
+            lastPhaseLatencies = emptyList()
+            lastPhase = "POLL"
+            lastCycleMs = 0L
         }
-        synchronized(_histogramLock) {
+        synchronizedLock(_histogramLock) {
             _histogramCounters.fill(0L)
+            _histogramSum = 0L
         }
-        _histogramSum.set(0L)
         activeSlots = 0
-        _lastCycleTimestampMs = 0L
-        lastPhaseLatencies = emptyList()
-        lastPhase = "POLL"
-        lastCycleMs = 0L
     }
 
     // ── JSON export ──────────────────────────────────────────────────────────────
@@ -213,12 +237,9 @@ object FlywheelMetrics {
      */
     fun toJsonMap(): Map<String, Any> = buildMap {
         // Transition counts
-        val tc: Map<String, Long>
-        val cpd: LongArray
-        val lat: List<PhaseLatency>
-        synchronized(_transitionLock) { tc = _transitionCounts.toMap() }
-        synchronized(_ringLock) { cpd = _cyclesPerDayRing.copyOf() }
-        lat = lastPhaseLatencies
+        val tc: Map<String, Long> = synchronizedLock(_transitionLock) { _transitionCounts.toMap() }
+        val cpd: LongArray = synchronizedLock(_ringLock) { _cyclesPerDayRing.copyOf() }
+        val lat: List<PhaseLatency> = lastPhaseLatencies
 
         put("totalCycles", totalCycles)
         put("cleanCycles", cleanCycles)
@@ -230,7 +251,7 @@ object FlywheelMetrics {
         put("targetSlots", TARGET_SLOTS)
         put("lastPhase", lastPhase)
         put("lastCycleMs", lastCycleMs)
-        put("lastUpdated", System.currentTimeMillis())
+        put("lastUpdated", nowMs())
 
         // Per-transition counts as nested map
         put("transitions", tc)
@@ -239,10 +260,7 @@ object FlywheelMetrics {
         put("phaseLatencies", lat.map { mapOf("phase" to it.phase, "ms" to it.ms) })
 
         // Histogram bucket counts and sum for percentiles
-        val hc: LongArray
-        val hSum: Long
-        synchronized(_histogramLock) { hc = _histogramCounters.copyOf() }
-        hSum = _histogramSum.get()
+        val (hc, hSum) = histogramSnapshot()
         put("histogramBuckets", _latencyBuckets.toList())
         put("histogramCounts", hc.toList())
         put("histogramSumMs", hSum)
@@ -259,12 +277,9 @@ object FlywheelMetrics {
      * First help line documents each metric; subsequent lines are TYPE + VALUE.
      */
     fun toPrometheusFormat(): String = buildString {
-        val tc: Map<String, Long>
-        val cpd: LongArray
-        val lat: List<PhaseLatency>
-        synchronized(_transitionLock) { tc = _transitionCounts.toMap() }
-        synchronized(_ringLock) { cpd = _cyclesPerDayRing.copyOf() }
-        lat = lastPhaseLatencies
+        val tc: Map<String, Long> = synchronizedLock(_transitionLock) { _transitionCounts.toMap() }
+        val cpd: LongArray = synchronizedLock(_ringLock) { _cyclesPerDayRing.copyOf() }
+        val lat: List<PhaseLatency> = lastPhaseLatencies
 
         // flywheel_total_cycles_total
         appendLine("# HELP flywheel_total_cycles_total Total cycles completed since daemon start")
@@ -289,7 +304,7 @@ object FlywheelMetrics {
         // flywheel_cycles_per_second (instantaneous rate)
         appendLine("# HELP flywheel_cycles_per_second Instantaneous cycles per second")
         appendLine("# TYPE flywheel_cycles_per_second gauge")
-        appendLine("flywheel_cycles_per_second ${"%.6f".format(cyclesPerSecond)}")
+        appendLine("flywheel_cycles_per_second ${fixed6(cyclesPerSecond)}")
 
         // flywheel_cycles_at_100_per_day (1.0 or 0.0)
         appendLine("# HELP flywheel_cycles_at_100_per_day 1 if current rate >= 100/day, 0 otherwise")
@@ -321,12 +336,13 @@ object FlywheelMetrics {
         // flywheel_cycle_latency_seconds (histogram for P50/P95/P99)
         appendLine("# HELP flywheel_cycle_latency_seconds_cycle Cycle wall-clock latency histogram")
         appendLine("# TYPE flywheel_cycle_latency_seconds_cycle histogram")
-        val hc: LongArray
-        val hSum = _histogramSum.get()
-        synchronized(_histogramLock) { hc = _histogramCounters.copyOf() }
+        val (hc, hSum) = histogramSnapshot()
         val hTotal = hc.sum()
+        // Prometheus histogram buckets are cumulative: le="X" counts every observation <= X.
+        var cumulative = 0L
         for ((i, bound) in _latencyBuckets.withIndex()) {
-            appendLine("flywheel_cycle_latency_seconds_cycle_bucket{le=\"$bound\"} ${hc.getOrElse(i) { 0L }}")
+            cumulative += hc.getOrElse(i) { 0L }
+            appendLine("flywheel_cycle_latency_seconds_cycle_bucket{le=\"$bound\"} $cumulative")
         }
         appendLine("flywheel_cycle_latency_seconds_cycle_bucket{le=\"+Inf\"} $hTotal")
         appendLine("flywheel_cycle_latency_seconds_cycle_sum $hSum")
@@ -344,6 +360,31 @@ object FlywheelMetrics {
         appendLine("# TYPE flywheel_cycles_per_day gauge")
         for ((i, v) in cpd.withIndex()) {
             appendLine("flywheel_cycles_per_day{daysAgo=\"$i\"} $v")
+        }
+    }
+
+    /**
+     * Multiplatform stand-in for `"%.6f".format(v)` (JVM-only): six fraction digits,
+     * always all six, never scientific notation — Prometheus accepts nothing else.
+     *
+     * Rounding is half-up on the scaled binary value (`floor(x * 1e6 + 0.5)`), which can
+     * differ from `%.6f` by one unit in the last digit for values that scale to an exact
+     * `.5`; irrelevant for the sole caller ([cyclesPerSecond]), a gauge. Magnitudes at or
+     * above ~9.2e12 overflow `Long` once scaled and are out of range here — again far
+     * above anything [cyclesPerSecond] can produce.
+     */
+    internal fun fixed6(v: Double): String {
+        if (v.isNaN()) return "NaN"
+        if (v.isInfinite()) return if (v > 0) "+Inf" else "-Inf"
+        val negative = v < 0.0
+        val scaled = floor(abs(v) * 1_000_000.0 + 0.5).toLong()
+        val whole = scaled / 1_000_000L
+        val frac = (scaled % 1_000_000L).toString().padStart(6, '0')
+        return buildString {
+            if (negative && scaled != 0L) append('-')
+            append(whole)
+            append('.')
+            append(frac)
         }
     }
 }

--- a/src/commonTest/kotlin/metrics/FlywheelMetricsTest.kt
+++ b/src/commonTest/kotlin/metrics/FlywheelMetricsTest.kt
@@ -1,0 +1,161 @@
+package metrics
+
+import fsm.FlywheelState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the commonMain purge of [FlywheelMetrics]: the object must keep its
+ * synchronous public surface and its counter / histogram / export semantics with
+ * no JVM-only primitives behind it.
+ */
+class FlywheelMetricsTest {
+
+    @Test
+    fun resetClearsEveryCounter() {
+        FlywheelMetrics.recordCycle(hadErrors = true)
+        FlywheelMetrics.recordSlots(4)
+        FlywheelMetrics.reset()
+
+        assertEquals(0L, FlywheelMetrics.totalCycles)
+        assertEquals(0L, FlywheelMetrics.cleanCycles)
+        assertEquals(0L, FlywheelMetrics.errorCycles)
+        assertEquals(0L, FlywheelMetrics.cyclesToday)
+        assertEquals(0, FlywheelMetrics.activeSlots)
+        assertEquals(0L, FlywheelMetrics.lastCycleMs)
+        assertEquals("POLL", FlywheelMetrics.lastPhase)
+        assertEquals(emptyList(), FlywheelMetrics.lastPhaseLatencies)
+        assertEquals(0.0, FlywheelMetrics.cyclesPerSecond)
+    }
+
+    @Test
+    fun cycleCountersSplitCleanAndError() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordCycle(hadErrors = false)
+        FlywheelMetrics.recordCycle(hadErrors = false)
+        FlywheelMetrics.recordCycle(hadErrors = true)
+
+        assertEquals(3L, FlywheelMetrics.totalCycles)
+        assertEquals(2L, FlywheelMetrics.cleanCycles)
+        assertEquals(1L, FlywheelMetrics.errorCycles)
+        assertEquals(3L, FlywheelMetrics.cyclesToday)
+    }
+
+    @Test
+    fun slotsClampToTargetRange() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordSlots(-5)
+        assertEquals(0, FlywheelMetrics.activeSlots)
+        FlywheelMetrics.recordSlots(999)
+        assertEquals(FlywheelMetrics.TARGET_SLOTS, FlywheelMetrics.activeSlots)
+        FlywheelMetrics.recordSlots(7)
+        assertEquals(7, FlywheelMetrics.activeSlots)
+    }
+
+    @Test
+    fun phaseLatenciesLandInHistogramAndJson() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordPhaseLatencies(
+            listOf(FlywheelMetrics.PhaseLatency("POLL", 30L), FlywheelMetrics.PhaseLatency("PLAN", 90L)),
+            totalMs = 120L,
+            phase = "PLAN",
+        )
+
+        assertEquals("PLAN", FlywheelMetrics.lastPhase)
+        assertEquals(120L, FlywheelMetrics.lastCycleMs)
+        assertEquals(2, FlywheelMetrics.lastPhaseLatencies.size)
+
+        val json = FlywheelMetrics.toJsonMap()
+        assertEquals(120L, json["lastCycleMs"])
+        assertEquals(FlywheelMetrics.TARGET_SLOTS, json["targetSlots"])
+        assertEquals(120L, json["histogramSumMs"])
+
+        @Suppress("UNCHECKED_CAST")
+        val counts = json["histogramCounts"] as List<Long>
+        // buckets are 10,50,100,250,... — 120ms falls in the "<= 250" bucket (index 3)
+        assertEquals(1L, counts[3])
+        assertEquals(1L, counts.sum())
+    }
+
+    @Test
+    fun transitionsAreCountedByName() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordTransition(FlywheelState.Idle, FlywheelState.Spinning)
+        FlywheelMetrics.recordTransition(FlywheelState.Idle, FlywheelState.Spinning)
+        FlywheelMetrics.recordTransition(FlywheelState.Spinning, FlywheelState.Fault)
+
+        @Suppress("UNCHECKED_CAST")
+        val transitions = FlywheelMetrics.toJsonMap()["transitions"] as Map<String, Long>
+        assertEquals(2L, transitions["Idle->Spinning"])
+        assertEquals(1L, transitions["Spinning->Fault"])
+    }
+
+    @Test
+    fun prometheusExportIsWellFormed() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordCycle(hadErrors = false)
+        FlywheelMetrics.recordPhaseLatencies(
+            listOf(FlywheelMetrics.PhaseLatency("POLL", 5L)),
+            totalMs = 5L,
+            phase = "POLL",
+        )
+        FlywheelMetrics.recordSlots(3)
+
+        val text = FlywheelMetrics.toPrometheusFormat()
+        assertTrue("flywheel_total_cycles_total 1" in text, text)
+        assertTrue("flywheel_slots_active 3" in text, text)
+        assertTrue("flywheel_phase_current{phase=\"POLL\"} 1" in text, text)
+        assertTrue("flywheel_phase_latency_ms{phase=\"POLL\"} 5" in text, text)
+        assertTrue("flywheel_cycle_latency_seconds_cycle_bucket{le=\"10\"} 1" in text, text)
+        assertTrue("flywheel_cycle_latency_seconds_cycle_sum 5" in text, text)
+        // the one floating-point sample must be a plain decimal — never scientific notation
+        val rate = text.lines().single { it.startsWith("flywheel_cycles_per_second ") }
+            .removePrefix("flywheel_cycles_per_second ")
+        assertTrue(Regex("""-?\d+\.\d{6}""").matches(rate), rate)
+    }
+
+    @Test
+    fun histogramBucketsAreCumulativeAndMonotonic() {
+        FlywheelMetrics.reset()
+        val one = listOf(FlywheelMetrics.PhaseLatency("POLL", 1L))
+        FlywheelMetrics.recordPhaseLatencies(one, totalMs = 5L, phase = "POLL")
+        FlywheelMetrics.recordPhaseLatencies(one, totalMs = 120L, phase = "POLL")
+
+        val counts = FlywheelMetrics.toPrometheusFormat().lines()
+            .filter { it.startsWith("flywheel_cycle_latency_seconds_cycle_bucket") }
+            .map { it.substringAfterLast(' ').toLong() }
+
+        assertEquals(FlywheelMetrics.toJsonMap().let { (it["histogramBuckets"] as List<*>).size } + 1, counts.size)
+        assertEquals(counts.sorted(), counts, "cumulative buckets must be non-decreasing: $counts")
+        assertEquals(listOf(1L, 1L, 1L, 2L), counts.take(4)) // le=10, 50, 100, 250
+        assertEquals(2L, counts.last()) // le=+Inf
+        assertTrue("flywheel_cycle_latency_seconds_cycle_count 2" in FlywheelMetrics.toPrometheusFormat())
+        assertTrue("flywheel_cycle_latency_seconds_cycle_sum 125" in FlywheelMetrics.toPrometheusFormat())
+    }
+
+    @Test
+    fun dayWindowIsSevenSlotsWithTodayFirst() {
+        FlywheelMetrics.reset()
+        FlywheelMetrics.recordCycle(hadErrors = false)
+        FlywheelMetrics.recordCycle(hadErrors = false)
+        FlywheelMetrics.recordPhaseLatencies(emptyList(), totalMs = 1L, phase = "POLL")
+
+        @Suppress("UNCHECKED_CAST")
+        val perDay = FlywheelMetrics.toJsonMap()["cyclesPerDay7"] as List<Long>
+        assertEquals(7, perDay.size)
+        assertEquals(2L, perDay[0])
+        assertEquals(List(6) { 0L }, perDay.drop(1))
+    }
+
+    @Test
+    fun fixed6FormatsPlainDecimals() {
+        assertEquals("0.000000", FlywheelMetrics.fixed6(0.0))
+        assertEquals("1.000000", FlywheelMetrics.fixed6(1.0))
+        assertEquals("0.000010", FlywheelMetrics.fixed6(1e-5))
+        assertEquals("0.001157", FlywheelMetrics.fixed6(100.0 / 86_400.0))
+        assertEquals("12.345679", FlywheelMetrics.fixed6(12.3456789))
+        assertEquals("-2.500000", FlywheelMetrics.fixed6(-2.5))
+        assertEquals("0.000000", FlywheelMetrics.fixed6(-1e-9))
+    }
+}


### PR DESCRIPTION
## What

`src/commonMain/kotlin/metrics/FlywheelMetrics.kt` was commonMain in name only — `synchronized` ×2, `@Volatile` ×8, `System.currentTimeMillis` ×5, `java.time.Instant`, `java.util.concurrent.atomic.AtomicLong`, plus JVM-only `String.format`. It compiled only because the JVM target is the sole exercised one; `compileCommonMainKotlinMetadata` resolved none of it.

This purges the leakage using the substrate's own multiplatform conventions. **The public surface is unchanged** — every consumer (`fsm/FlywheelState.kt`, `daemon/CycleBody.kt`, `daemon/OroborosDaemon.kt`, `litebike/JvmKanbanServer.kt`) compiles untouched, all signatures stay synchronous.

| was | now |
| --- | --- |
| `synchronized(lock) {}` | `borg.trikeshed.isam.synchronizedLock` — the repo's existing expect/actual monitor (actuals already exist for jvm/js/native/wasmJs) |
| `@Volatile` (JVM) | `kotlin.concurrent.Volatile` (multiplatform stdlib) |
| `java.time.Instant` / `System.currentTimeMillis` | `kotlinx.datetime.Clock`; midnight-UTC via integer-floor division (exact — Unix time has no leap seconds) |
| `AtomicLong` histogram sum | plain `Long` under the existing histogram lock, snapshotted together with the counters |
| `"%.6f".format(v)` | `fixed6()` — six-digit plain decimal (Prometheus rejects scientific notation) |

## Why not atomicfu / expect-object

Neither preferred route applied: **kotlinx-atomicfu is not a dependency** (and adding one was out of scope), and an `expect object` would have duplicated a ~350-line surface across four actuals. The repo already solves this exact problem with `synchronizedLock` + `kotlin.concurrent.Volatile`, so the object stays a single common implementation.

## Bugs fixed in passing

- **Prometheus histogram buckets were not cumulative.** `le=` counts were per-bucket, so the sequence was non-monotonic and `histogram_quantile()` returned garbage.
- **`_ringIndex` was never advanced.** `cyclesPerDay7` / `flywheel_cycles_per_day` slots 1..6 were permanently `0`, and the midnight rollover overwrote the finished day instead of banking it. The window now shifts on rollover.
- **Torn histogram read**: sum and bucket counts were sampled under different synchronization.
- **`reset()`** missed `_lastCycleTimestampMs` / `_histogramSum` / `lastPhase*`, or cleared them outside their lock.

## Verification

- `./gradlew jvmMainClasses --console=plain` — **green**.
- New `src/commonTest/kotlin/metrics/FlywheelMetricsTest.kt` — **9/9 pass** (counters, slot clamping, transitions, JSON map, cumulative-and-monotonic Prometheus buckets, day window, formatter).
- `compileCommonMainKotlinMetadata`: 144 pre-existing commonMain errors remain repo-wide (other units of the consistency pass), **none in `metrics/` or `fsm/`** — this file is now genuinely common.
- `./gradlew jvmTest --tests '*.OroborosDaemonHealthTest'` fails identically at HEAD with the change stashed (`health.sock was not created`) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
