### PR TITLE
M3: ForgeSurfaceProjection — one surface contract for every ring

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ForgeSurfaceProjection.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ForgeSurfaceProjection.kt
@@ -1,0 +1,269 @@
+package borg.trikeshed.forge.blackboard
+
+import borg.trikeshed.lib.α
+import kotlinx.datetime.Clock
+
+/**
+ * ## ForgeSurfaceProjection — one surface contract for every ring.
+ *
+ * Every ring (jules sessions, rete fires, modelmux telemetry, kanban, metrics …)
+ * lands on the forge blackboard the same way:
+ *
+ *  1. a domain item is wrapped in a [ForgeSurfaceEnvelope] carrying its own
+ *     `sectionId` + geometry (`centerX/centerY/width/height/elevation`) plus
+ *     `updatedAt` / `ttlMs`;
+ *  2. the envelopes are collected into a [ForgeDomainSurface];
+ *  3. the [ForgeBlackboardView] is *rebuilt* by concatenating the new section
+ *     ids and [ForgeBlackboardSection3D]s onto [ForgeBlackboardView.DEFAULT],
+ *     which keeps the view's init constraint (`layout3D` ids == `sections`)
+ *     satisfied by construction.
+ *
+ * This generalizes the pattern verified in
+ * `borg.trikeshed.jules.ui.JulesBlackboardAdapter.projectFullSurface`.
+ *
+ * Projection is a *pure function* of `(domain, base view, now)` — no I/O, no
+ * clock read unless the caller omits `now`, no mutation of the base view.
+ */
+
+// ── Geometry ────────────────────────────────────────────────────────────────
+
+/**
+ * Geometry every projected surface item carries so a renderer can place it
+ * without a second round-trip.
+ */
+interface ForgeSurfaceGeometry {
+    val sectionId: String
+    val centerX: Double
+    val centerY: Double
+    val width: Double
+    val height: Double
+    val elevation: Double
+}
+
+/** Lift any surface item into the blackboard's 3D layout row. */
+fun ForgeSurfaceGeometry.asSection3D(): ForgeBlackboardSection3D = ForgeBlackboardSection3D(
+    sectionId = sectionId,
+    centerX = centerX,
+    centerY = centerY,
+    width = width,
+    height = height,
+    elevation = elevation,
+)
+
+// ── Surface ─────────────────────────────────────────────────────────────────
+
+/**
+ * A TTL-stamped bag of geometry-bearing items — the `<DomainSurface>` half of a
+ * projection result. Ring-specific surfaces (e.g. `JulesBlackboardSurface`)
+ * implement this so downstream seeds/renderers can treat every ring alike.
+ */
+interface ForgeDomainSurface {
+    /** Every item this surface puts on the board, in render order. */
+    val items: List<ForgeSurfaceGeometry>
+
+    /** Epoch millis when this projection was minted. */
+    val updatedAt: Long
+
+    /** Time-to-live for this projection, in milliseconds. */
+    val ttlMs: Long
+}
+
+/** True when `now` has moved past `updatedAt + ttlMs`. */
+fun ForgeDomainSurface.isStaleAt(now: Long): Boolean = now - updatedAt > ttlMs
+
+/**
+ * Payload + sectionId + geometry + updatedAt + ttlMs — the section-agnostic
+ * envelope every ring wraps its domain item in.
+ */
+data class ForgeSurfaceEnvelope<out P>(
+    val payload: P,
+    override val sectionId: String,
+    override val centerX: Double,
+    override val centerY: Double,
+    override val width: Double,
+    override val height: Double,
+    override val elevation: Double,
+    val updatedAt: Long,
+    val ttlMs: Long,
+) : ForgeSurfaceGeometry
+
+/** The generic surface produced by [ForgeSurfaceProjection.project]. */
+data class ForgeSectionSurface<out P>(
+    /** The DEFAULT-layout section these envelopes hang beneath ("board", "gallery", …). */
+    val anchorSectionId: String,
+    val envelopes: List<ForgeSurfaceEnvelope<P>>,
+    override val updatedAt: Long,
+    override val ttlMs: Long,
+) : ForgeDomainSurface {
+    override val items: List<ForgeSurfaceGeometry> get() = envelopes
+}
+
+// ── View rebuild ────────────────────────────────────────────────────────────
+
+/**
+ * Rebuild this view with [items] appended as sections.
+ *
+ * An item whose `sectionId` the view already carries keeps its existing
+ * placement — the view is the authority on where a section sits, and [project]
+ * mints its envelopes from that same placement so the two never disagree.
+ * The result therefore always satisfies `ForgeBlackboardView`'s init constraint
+ * and re-appending the same items is a no-op.
+ */
+fun ForgeBlackboardView.withSurface(items: List<ForgeSurfaceGeometry>): ForgeBlackboardView {
+    val seen = sections.toMutableSet()
+    val fresh = items.filter { seen.add(it.sectionId) }
+    return if (fresh.isEmpty()) this
+    else copy(
+        sections = sections + (fresh α { it.sectionId }),
+        layout3D = layout3D + (fresh α { it.asSection3D() }),
+    )
+}
+
+// ── Layout ──────────────────────────────────────────────────────────────────
+
+/**
+ * Y below which every ring's tile strip starts.
+ *
+ * The DEFAULT 2x2 quadrant layout occupies `y ∈ [-560, 560]`. Strips begin below
+ * that band so a long strip can never grow into a neighbouring quadrant; each
+ * ring stays visually attached to its anchor through shared `centerX` instead.
+ */
+const val FORGE_SURFACE_STRIP_BASELINE_Y: Double = 700.0
+
+/**
+ * Grid that lays surface tiles out in a strip beneath their anchor section.
+ *
+ * A **full** row of [columns] cells is centered on the anchor's `centerX`, so a
+ * given column always lands at the same X no matter how many tiles the strip
+ * holds — tiles never slide sideways as the strip fills. A partly-filled last
+ * row is therefore left-aligned within that fixed row, not re-centered.
+ *
+ * Rows grow downward (+Y) from `max(anchor bottom + gapY, baselineY)`.
+ */
+data class ForgeSurfaceGrid(
+    val columns: Int = 3,
+    val cellWidth: Double = 280.0,
+    val cellHeight: Double = 160.0,
+    val gapX: Double = 40.0,
+    val gapY: Double = 40.0,
+    val elevation: Double = 18.0,
+    val baselineY: Double = FORGE_SURFACE_STRIP_BASELINE_Y,
+) {
+    init {
+        require(columns > 0) { "grid needs at least one column, got $columns" }
+        require(cellWidth > 0.0 && cellHeight > 0.0) { "grid cells must be positive: ${cellWidth}x$cellHeight" }
+    }
+
+    /** Y of the strip's first row of cell *tops*, clear of the default quadrants. */
+    fun originYOf(anchor: ForgeBlackboardSection3D): Double =
+        maxOf(anchor.centerY + anchor.height / 2.0 + gapY, baselineY)
+
+    /** X of the tile in slot [slot] relative to [anchor]. */
+    fun centerXOf(anchor: ForgeBlackboardSection3D, slot: Int): Double {
+        val pitch = cellWidth + gapX
+        return anchor.centerX - (columns - 1) * pitch / 2.0 + (slot % columns) * pitch
+    }
+
+    /** Y of the tile in slot [slot] relative to [anchor]. */
+    fun centerYOf(anchor: ForgeBlackboardSection3D, slot: Int): Double =
+        originYOf(anchor) + cellHeight / 2.0 + (slot / columns) * (cellHeight + gapY)
+}
+
+// ── Contract ────────────────────────────────────────────────────────────────
+
+/**
+ * Section-agnostic projection of a ring's domain items onto the forge blackboard.
+ *
+ * Implementations supply only the ring-specific bits — which section to anchor
+ * under, how to name a tile, and what payload to carry. [project] does the rest
+ * and is identical for every ring.
+ *
+ * @param D the ring's domain item type
+ * @param P the payload carried in each [ForgeSurfaceEnvelope]
+ */
+interface ForgeSurfaceProjection<in D, out P> {
+
+    /** Section of [ForgeBlackboardView.DEFAULT] these tiles hang beneath. */
+    val anchorSectionId: String
+
+    /** TTL stamped onto every envelope and the surface. */
+    val ttlMs: Long
+
+    /** Tile layout beneath [anchorSectionId]. */
+    val grid: ForgeSurfaceGrid
+
+    /**
+     * Section id for one domain item.
+     *
+     * Must be derived from the item's *content*, not from [index] — [project]
+     * treats a repeated id as the same tile and gives it the placement it
+     * already has, which is only correct when the id is stable across calls.
+     * [index] is the item's position in the projected list, offered for rings
+     * whose identity genuinely is ordinal.
+     */
+    fun sectionIdOf(item: D, index: Int): String
+
+    /** Render-relevant payload lifted out of one domain item. */
+    fun payloadOf(item: D, index: Int): P
+}
+
+/** Default TTL for forge surface projections: 5 minutes. */
+const val FORGE_SURFACE_TTL_MS: Long = 300_000L
+
+/**
+ * Project [domain] onto [base], returning
+ * `(rebuilt view, domain surface, index by sectionId)`.
+ *
+ * Pure: pass [now] to get a fully deterministic result.
+ *
+ * Two rules keep the view and the surface in agreement, which is what makes
+ * re-projecting onto an already-projected view idempotent:
+ *
+ *  - **one tile per section id** — a repeated id inside [domain] is projected
+ *    once, first occurrence wins;
+ *  - **placement is sticky** — an id [base] already carries keeps the geometry
+ *    [base] gave it, and only genuinely new tiles consume a fresh grid slot.
+ *
+ * @throws IllegalArgumentException when [ForgeSurfaceProjection.anchorSectionId]
+ *   is not a section of [base].
+ */
+fun <D, P> ForgeSurfaceProjection<D, P>.project(
+    domain: List<D>,
+    base: ForgeBlackboardView = ForgeBlackboardView.DEFAULT,
+    now: Long = Clock.System.now().toEpochMilliseconds(),
+): Triple<ForgeBlackboardView, ForgeSectionSurface<P>, Map<String, ForgeSurfaceEnvelope<P>>> {
+    val anchor = requireNotNull(ForgeBlackboardView.sectionPlacement(base, anchorSectionId)) {
+        "anchor section '$anchorSectionId' is not on view '${base.surface}' ${base.sections}"
+    }
+
+    val byId = LinkedHashMap<String, ForgeSurfaceEnvelope<P>>(domain.size)
+    var slot = 0
+    domain.forEachIndexed { i: Int, item: D ->
+        val sectionId = sectionIdOf(item, i)
+        if (sectionId in byId) return@forEachIndexed
+        val held = ForgeBlackboardView.sectionPlacement(base, sectionId)
+        byId[sectionId] = ForgeSurfaceEnvelope(
+            payload = payloadOf(item, i),
+            sectionId = sectionId,
+            centerX = held?.centerX ?: grid.centerXOf(anchor, slot),
+            centerY = held?.centerY ?: grid.centerYOf(anchor, slot),
+            width = held?.width ?: grid.cellWidth,
+            height = held?.height ?: grid.cellHeight,
+            elevation = held?.elevation ?: (anchor.elevation + grid.elevation),
+            updatedAt = now,
+            ttlMs = ttlMs,
+        )
+        if (held == null) slot++
+    }
+
+    val envelopes: List<ForgeSurfaceEnvelope<P>> = byId.values α { it }
+
+    val surface = ForgeSectionSurface(
+        anchorSectionId = anchorSectionId,
+        envelopes = envelopes,
+        updatedAt = now,
+        ttlMs = ttlMs,
+    )
+
+    return Triple(base.withSurface(envelopes), surface, byId)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ModelMuxSurfaceProjection.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ModelMuxSurfaceProjection.kt
@@ -1,0 +1,82 @@
+package borg.trikeshed.forge.blackboard
+
+import borg.trikeshed.lib.α
+import kotlinx.datetime.Clock
+import modelmux.ModelSelectionEvent
+import modelmux.QuotaSnapshot
+
+/**
+ * Payload union for the modelmux ring's `gallery` tiles.
+ *
+ * Both variants stay value-shaped and carry the original telemetry record so a
+ * renderer never has to re-query modelmux.
+ */
+sealed interface ModelMuxTelemetry {
+
+    /** Provider quota window snapshot. */
+    data class Quota(val snapshot: QuotaSnapshot) : ModelMuxTelemetry
+
+    /** A settled provider/model choice. */
+    data class Selection(val event: ModelSelectionEvent.ModelSelected) : ModelMuxTelemetry
+}
+
+/** Lift a [QuotaSnapshot] into the gallery payload union. */
+fun QuotaSnapshot.asTelemetry(): ModelMuxTelemetry = ModelMuxTelemetry.Quota(this)
+
+/** Lift a [ModelSelectionEvent.ModelSelected] into the gallery payload union. */
+fun ModelSelectionEvent.ModelSelected.asTelemetry(): ModelMuxTelemetry = ModelMuxTelemetry.Selection(this)
+
+/**
+ * ModelMux ring → `gallery` section.
+ *
+ * Quota snapshots and model-selection events share one strip of tiles beneath
+ * the gallery quadrant, in the order the caller hands them over.
+ */
+object ModelMuxSurfaceProjection : ForgeSurfaceProjection<ModelMuxTelemetry, ModelMuxTelemetry> {
+
+    override val anchorSectionId: String = "gallery"
+
+    override val ttlMs: Long = FORGE_SURFACE_TTL_MS
+
+    override val grid: ForgeSurfaceGrid = ForgeSurfaceGrid(
+        columns = 3,
+        cellWidth = 260.0,
+        cellHeight = 140.0,
+        gapX = 28.0,
+        gapY = 28.0,
+        elevation = 14.0,
+    )
+
+    /**
+     * Content-derived, so a tile keeps its place across projections: one tile per
+     * provider quota window, one per selection request. A fresher snapshot of the
+     * same window updates that window's tile rather than minting a new one.
+     */
+    override fun sectionIdOf(item: ModelMuxTelemetry, index: Int): String = when (item) {
+        is ModelMuxTelemetry.Quota ->
+            "gallery-quota-${item.snapshot.provider.forgeSectionToken()}-${item.snapshot.windowStart}"
+
+        is ModelMuxTelemetry.Selection ->
+            "gallery-model-${item.event.provider.forgeSectionToken()}-${item.event.requestId.forgeSectionToken()}"
+    }
+
+    override fun payloadOf(item: ModelMuxTelemetry, index: Int): ModelMuxTelemetry = item
+}
+
+/**
+ * Project modelmux telemetry onto the `gallery` section in one pass:
+ * quota snapshots first, then selection events.
+ *
+ * Pure — pass [now] for a deterministic result.
+ */
+fun projectModelMuxTelemetry(
+    quotas: List<QuotaSnapshot>,
+    selections: List<ModelSelectionEvent.ModelSelected>,
+    base: ForgeBlackboardView = ForgeBlackboardView.DEFAULT,
+    now: Long = Clock.System.now().toEpochMilliseconds(),
+): Triple<ForgeBlackboardView, ForgeSectionSurface<ModelMuxTelemetry>, Map<String, ForgeSurfaceEnvelope<ModelMuxTelemetry>>> =
+    ModelMuxSurfaceProjection.project(
+        domain = (quotas α { it.asTelemetry() }) + (selections α { it.asTelemetry() }),
+        base = base,
+        now = now,
+    )

--- a/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ReteFireSurfaceProjection.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ReteFireSurfaceProjection.kt
@@ -1,0 +1,221 @@
+package borg.trikeshed.forge.blackboard
+
+import borg.trikeshed.dag.ReteAgent
+import borg.trikeshed.dag.bindOrCreateAgent
+import borg.trikeshed.graph.CausalGraphNodeIndex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+
+/**
+ * Rete ring → `board` section.
+ *
+ * Every distinct [ReteAgent.Fire] becomes one tile in the strip below the
+ * blackboard's `board` quadrant. The fire *is* the payload — it already carries
+ * exactly the fields a renderer needs (rule, node, causal key, payload, agent).
+ */
+object ReteFireSurfaceProjection : ForgeSurfaceProjection<ReteAgent.Fire, ReteAgent.Fire> {
+
+    override val anchorSectionId: String = "board"
+
+    override val ttlMs: Long = FORGE_SURFACE_TTL_MS
+
+    override val grid: ForgeSurfaceGrid = ForgeSurfaceGrid(
+        columns = 4,
+        cellWidth = 240.0,
+        cellHeight = 120.0,
+        gapX = 24.0,
+        gapY = 24.0,
+        elevation = 10.0,
+    )
+
+    /**
+     * Content-derived and therefore stable: the same fire always names the same
+     * tile, whatever its position in the window. Rule and node stay readable in
+     * the id; the causal key and payload fold into the hash so two fires of the
+     * same rule on the same node still get separate tiles.
+     */
+    override fun sectionIdOf(item: ReteAgent.Fire, index: Int): String = buildString {
+        append("board-fire-")
+        append(item.ruleName.forgeSectionToken())
+        append('-')
+        append(item.nodeId.forgeSectionToken())
+        append('-')
+        append(forgeSectionHash(item.causalKey, item.payload, item.agentId))
+    }
+
+    override fun payloadOf(item: ReteAgent.Fire, index: Int): ReteAgent.Fire = item
+}
+
+/**
+ * Squash a free-form label into a section-id token: keeps letters, digits, `-`
+ * and `_`, collapses every run of anything else -- the U+001F/U+001E separators
+ * inside a causal key, slashes, whitespace -- into a single `-`, and trims the
+ * result. Input with nothing keepable becomes `"x"`, so a section id is never
+ * left empty.
+ */
+fun String.forgeSectionToken(): String {
+    val out = StringBuilder(length)
+    for (c in this) {
+        val ok = c in 'a'..'z' || c in 'A'..'Z' || c in '0'..'9' || c == '-' || c == '_'
+        if (ok) out.append(c)
+        else if (out.isNotEmpty() && out.last() != '-') out.append('-')
+    }
+    return out.toString().trim('-').ifEmpty { "x" }
+}
+
+/**
+ * FNV-1a over [parts] (separated by `0x1F`) rendered as 8 lowercase hex digits.
+ *
+ * Deliberately not `hashCode()`: this has to agree across platforms and across
+ * runs, because it names a blackboard section.
+ */
+fun forgeSectionHash(vararg parts: String): String {
+    val prime = 0x01000193u
+    var h = 0x811C9DC5u
+
+    fun mix(byte: Int) {
+        h = h xor (byte and 0xFF).toUInt()
+        h *= prime
+    }
+
+    parts.forEachIndexed { i, part ->
+        if (i > 0) mix(0x1F)
+        for (c in part) {
+            mix(c.code)
+            mix(c.code shr 8)
+        }
+    }
+
+    val bits = h.toInt()
+    return buildString(8) {
+        for (shift in 28 downTo 0 step 4) append(FORGE_HEX[(bits ushr shift) and 0xF])
+    }
+}
+
+private const val FORGE_HEX: String = "0123456789abcdef"
+
+/**
+ * Bounded, coroutine-safe collector for [ReteAgent.Fire]s on their way to the
+ * `board` section.
+ *
+ * [onFire] is the non-suspending hook handed to
+ * [CausalGraphNodeIndex.bindOrCreateAgent]. It `trySend`s onto a [Channel] of
+ * [capacity] with [BufferOverflow.DROP_OLDEST], so it never blocks the agent's
+ * rule loop and never grows without bound when nobody drains: the newest
+ * [capacity] fires are what survive, at the queue and in the window alike.
+ *
+ * [drain] moves whatever is queued into the window and returns it oldest-first;
+ * [awaitFires] is the suspending variant for callers that need a known number of
+ * *further* fires to have landed.
+ *
+ * **Single-consumer.** [drain], [awaitFires], [project] and [clear] are each
+ * individually safe, but the tap assumes one consuming coroutine. Two coroutines
+ * pulling concurrently can interleave a suspended [awaitFires] receive with a
+ * [drain], and observe the window briefly out of order.
+ */
+class ReteFireBoardTap(
+    val capacity: Int = 32,
+    val projection: ForgeSurfaceProjection<ReteAgent.Fire, ReteAgent.Fire> = ReteFireSurfaceProjection,
+) {
+    init {
+        require(capacity > 0) { "tap capacity must be positive, got $capacity" }
+    }
+
+    private val sink: Channel<ReteAgent.Fire> =
+        Channel(capacity = capacity, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val mutex = Mutex()
+    private val window = ArrayDeque<ReteAgent.Fire>()
+
+    /** Monotonic count of fires ever absorbed into the window. Guarded by [mutex]. */
+    private var absorbed: Long = 0L
+
+    /** Hand this to `bindOrCreateAgent(onFire = tap::onFire)`. Never suspends. */
+    fun onFire(fire: ReteAgent.Fire) {
+        sink.trySend(fire)
+    }
+
+    /** Drain the queue into the window; returns the window oldest-first. */
+    suspend fun drain(): List<ReteAgent.Fire> = mutex.withLock {
+        pump()
+        window.toList()
+    }
+
+    /**
+     * Suspend until [count] *more* fires have been absorbed than when the call
+     * started, then return the window oldest-first.
+     *
+     * Counting arrivals rather than window size is what makes a second call
+     * meaningful: the window is a rolling view that is never emptied by
+     * [drain], so `window.size >= count` would be satisfied forever after the
+     * first batch. Wrap in `withTimeout*` to bound the wait.
+     */
+    suspend fun awaitFires(count: Int): List<ReteAgent.Fire> {
+        require(count >= 0) { "count must be non-negative, got $count" }
+        val target = mutex.withLock { absorbed } + count
+        while (true) {
+            mutex.withLock {
+                pump()
+                if (absorbed >= target) return window.toList()
+            }
+            // Received before re-locking, so it still precedes anything a later
+            // pump() could pull off the same queue.
+            val fire = sink.receive()
+            mutex.withLock {
+                push(fire)
+                pump()
+            }
+        }
+    }
+
+    /** Drain, then project the window onto [base]. */
+    suspend fun project(
+        base: ForgeBlackboardView = ForgeBlackboardView.DEFAULT,
+        now: Long = Clock.System.now().toEpochMilliseconds(),
+    ): Triple<ForgeBlackboardView, ForgeSectionSurface<ReteAgent.Fire>, Map<String, ForgeSurfaceEnvelope<ReteAgent.Fire>>> =
+        projection.project(drain(), base, now)
+
+    /** Forget every queued and buffered fire (e.g. on board reset). */
+    suspend fun clear(): Unit = mutex.withLock {
+        while (sink.tryReceive().getOrNull() != null) { /* discard */ }
+        window.clear()
+    }
+
+    /** Move everything currently queued into the window. Caller holds [mutex]. */
+    private fun pump() {
+        var next = sink.tryReceive().getOrNull()
+        while (next != null) {
+            push(next)
+            next = sink.tryReceive().getOrNull()
+        }
+    }
+
+    /** Append one fire, evicting the oldest past [capacity]. Caller holds [mutex]. */
+    private fun push(fire: ReteAgent.Fire) {
+        window.addLast(fire)
+        while (window.size > capacity) window.removeFirst()
+        absorbed++
+    }
+}
+
+/**
+ * Bind [tap] to this index so every rete fire lands on the `board` section.
+ *
+ * @throws IllegalArgumentException when the index already has a bound agent —
+ *   [CausalGraphNodeIndex.bindOrCreateAgent] would keep that agent and silently
+ *   leave [tap] empty forever. Call [CausalGraphNodeIndex.unbindAgent] first, or
+ *   check [CausalGraphNodeIndex.hasBoundAgent] before tapping.
+ */
+fun CausalGraphNodeIndex.tapFiresToBoard(
+    scope: CoroutineScope,
+    tap: ReteFireBoardTap,
+    agentId: String = "forge-board-fire-tap",
+): ReteAgent.Agent {
+    require(!hasBoundAgent()) {
+        "index already has a bound agent; unbind it before tapping fires to the board"
+    }
+    return bindOrCreateAgent(scope = scope, agentId = agentId, onFire = tap::onFire)
+}

--- a/src/commonMain/kotlin/borg/trikeshed/jules/ui/JulesBlackboardAdapter.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/ui/JulesBlackboardAdapter.kt
@@ -2,6 +2,8 @@ package borg.trikeshed.jules.ui
 
 import borg.trikeshed.forge.blackboard.ForgeBlackboardSection3D
 import borg.trikeshed.forge.blackboard.ForgeBlackboardView
+import borg.trikeshed.forge.blackboard.ForgeDomainSurface
+import borg.trikeshed.forge.blackboard.ForgeSurfaceGeometry
 import borg.trikeshed.jules.JulesRestClient
 import kotlinx.datetime.Clock
 
@@ -17,13 +19,13 @@ data class ForgeSurfaceSession(
     val patchBytes: Long,
     val source: String,
     val updateTime: String,
-    val sectionId: String,
-    val centerX: Double,
-    val centerY: Double,
-    val width: Double,
-    val height: Double,
-    val elevation: Double,
-)
+    override val sectionId: String,
+    override val centerX: Double,
+    override val centerY: Double,
+    override val width: Double,
+    override val height: Double,
+    override val elevation: Double,
+) : ForgeSurfaceGeometry
 
 /**
  * Projected surface content emitted into the Forge blackboard for one Jules activity.
@@ -38,13 +40,13 @@ data class ForgeSurfaceActivity(
     val kind: String,
     val patchBytes: Long,
     val excerpt: String,
-    val sectionId: String,
-    val centerX: Double,
-    val centerY: Double,
-    val width: Double,
-    val height: Double,
-    val elevation: Double,
-)
+    override val sectionId: String,
+    override val centerX: Double,
+    override val centerY: Double,
+    override val width: Double,
+    override val height: Double,
+    override val elevation: Double,
+) : ForgeSurfaceGeometry
 
 /**
  * Aggregated surface projection of all Jules sessions and activities.
@@ -59,9 +61,16 @@ data class ForgeSurfaceActivity(
 data class JulesBlackboardSurface(
     val sessions: List<ForgeSurfaceSession>,
     val activities: List<ForgeSurfaceActivity>,
-    val updatedAt: Long = Clock.System.now().toEpochMilliseconds(),
-    val ttlMs: Long = TTL_MS,
-)
+    override val updatedAt: Long = Clock.System.now().toEpochMilliseconds(),
+    override val ttlMs: Long = TTL_MS,
+) : ForgeDomainSurface {
+    /**
+     * Every tile this surface puts on the board: sessions first, then their
+     * activities. Concatenated once at construction — a `get()` would reallocate
+     * on every read and break identity for callers that cache it.
+     */
+    override val items: List<ForgeSurfaceGeometry> = sessions + activities
+}
 
 /**
  * TTL for a JulesBlackboardSurface projection in milliseconds.

--- a/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForgeSurfaceProjectionTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/forge/blackboard/ForgeSurfaceProjectionTest.kt
@@ -1,0 +1,353 @@
+package borg.trikeshed.forge.blackboard
+
+import borg.trikeshed.cursor.blackboardContext
+import borg.trikeshed.dag.ReteAgent
+import borg.trikeshed.graph.CausalGraphNode
+import borg.trikeshed.graph.CausalGraphNodeIndex
+import borg.trikeshed.graph.causalGraphNode
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import modelmux.ModelSelectionEvent
+import modelmux.QuotaSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * M3 — the one surface contract: a rete Fire and a modelmux QuotaSnapshot both
+ * project onto valid [ForgeBlackboardView]s through [ForgeSurfaceProjection].
+ *
+ * The load-bearing invariant is the view's own init constraint:
+ * `layout3D.map { sectionId }.toSet() == sections.toSet()`. A view that
+ * violates it cannot be constructed at all, so every successful projection is
+ * already proof — the assertions below make that explicit and pin geometry,
+ * anchoring and idempotence.
+ */
+class ForgeSurfaceProjectionTest {
+
+    private val fixedNow = 1_700_000_000_000L
+
+    private fun fire(nodeId: String, rule: String = "node-planning") = ReteAgent.Fire(
+        ruleName = rule,
+        nodeId = nodeId,
+        causalKey = "op\u001Fv1\u001Fseed\u001Fboard-a",
+        payload = "planned",
+        agentId = "node-planning-agent",
+    )
+
+    private fun node(nodeId: String): CausalGraphNode = causalGraphNode(
+        nodeId = nodeId,
+        opId = "op",
+        opVersion = "v1",
+        parentNodeIds = emptyList(),
+        inputFingerprint = "seed-$nodeId",
+        blackboard = blackboardContext(id = "board-a"),
+        causalClock = 0L,
+        topoOrdinal = 0,
+        outputHash = null,
+    )
+
+    private fun assertViewInvariant(view: ForgeBlackboardView) {
+        assertEquals(
+            view.sections.toSet(),
+            view.layout3D.map { it.sectionId }.toSet(),
+            "layout3D section ids must equal sections",
+        )
+        assertEquals(
+            view.layout3D.size,
+            view.layout3D.map { it.sectionId }.toSet().size,
+            "layout3D must not carry duplicate section ids",
+        )
+    }
+
+    // ── (a) rete Fire → board ────────────────────────────────────────────────
+
+    @Test
+    fun fireProjectsOntoBoardSection() {
+        val (view, surface, index) = ReteFireSurfaceProjection.project(
+            domain = listOf(fire("n1"), fire("n2")),
+            now = fixedNow,
+        )
+
+        assertViewInvariant(view)
+        assertEquals("board", surface.anchorSectionId)
+        assertEquals(2, surface.envelopes.size)
+        assertEquals(2, index.size)
+
+        val first = surface.envelopes[0]
+        assertEquals("n1", first.payload.nodeId)
+        assertEquals("planned", first.payload.payload)
+        assertEquals(fixedNow, first.updatedAt)
+        assertEquals(FORGE_SURFACE_TTL_MS, first.ttlMs)
+        assertSame(first, index[first.sectionId])
+
+        // Every tile carries its own section id + geometry, and the board grew by exactly 2.
+        assertEquals(ForgeBlackboardView.DEFAULT.sections.size + 2, view.sections.size)
+        surface.envelopes.forEach { e ->
+            assertTrue(e.sectionId.startsWith("board-fire-"), e.sectionId)
+            assertNotNull(ForgeBlackboardView.sectionPlacement(view, e.sectionId))
+            assertTrue(e.width > 0.0 && e.height > 0.0)
+            assertTrue(e.elevation > 0.0)
+        }
+
+        // Tiles hang beneath the anchor quadrant.
+        val anchor = ForgeBlackboardView.sectionPlacement(ForgeBlackboardView.DEFAULT, "board")!!
+        assertTrue(surface.envelopes.all { it.centerY > anchor.centerY + anchor.height / 2.0 })
+
+        assertFalse(surface.isStaleAt(fixedNow + 1_000L))
+        assertTrue(surface.isStaleAt(fixedNow + FORGE_SURFACE_TTL_MS + 1L))
+    }
+
+    @Test
+    fun identicalFiresCollapseToOneTile() {
+        val (view, surface, index) = ReteFireSurfaceProjection.project(
+            domain = List(9) { fire("n1") },   // nine identical fires
+            now = fixedNow,
+        )
+        assertViewInvariant(view)
+        assertEquals(1, surface.envelopes.size, "identical fires name the same tile")
+        assertEquals(1, index.size)
+        assertEquals(ForgeBlackboardView.DEFAULT.sections.size + 1, view.sections.size)
+    }
+
+    @Test
+    fun distinctFiresFillTheGridRowByRow() {
+        val (view, surface, _) = ReteFireSurfaceProjection.project(
+            domain = (1..9).map { fire("n$it") },
+            now = fixedNow,
+        )
+        assertViewInvariant(view)
+        assertEquals(9, surface.envelopes.size)
+        assertEquals(9, surface.envelopes.map { it.sectionId }.toSet().size)
+        // 4-column grid ⇒ 3 rows, 4 distinct columns.
+        assertEquals(3, surface.envelopes.map { it.centerY }.toSet().size)
+        assertEquals(4, surface.envelopes.map { it.centerX }.toSet().size)
+    }
+
+    @Test
+    fun boardStripClearsTheDefaultQuadrants() {
+        val (_, surface, _) = ReteFireSurfaceProjection.project(
+            domain = (1..32).map { fire("n$it") },
+            now = fixedNow,
+        )
+        // No tile may reach up into the page/board/gallery/graph band.
+        val quadrantFloor = ForgeBlackboardView.DEFAULT.layout3D.maxOf { it.centerY + it.height / 2.0 }
+        assertTrue(
+            surface.envelopes.all { it.centerY - it.height / 2.0 > quadrantFloor },
+            "a full strip must stay below y=$quadrantFloor",
+        )
+    }
+
+    @Test
+    fun tapCollectsAgentFiresAndProjectsThem() = runTest {
+        val index = CausalGraphNodeIndex()
+        val tap = ReteFireBoardTap()
+        val agent = index.tapFiresToBoard(scope = backgroundScope, tap = tap)
+
+        index.addOrGet(node("n1"))
+        index.addOrGet(node("n2"))
+
+        // The agent's rule loop is its own coroutine — await it rather than poll.
+        assertEquals(2, (withTimeoutOrNull(2_000) { tap.awaitFires(2) } ?: emptyList()).size)
+
+        val (view, surface, byId) = tap.project(now = fixedNow)
+        assertViewInvariant(view)
+        assertEquals(2, surface.envelopes.size)
+        assertEquals(setOf("n1", "n2"), surface.envelopes.map { it.payload.nodeId }.toSet())
+        assertTrue(surface.envelopes.all { it.payload.agentId == "forge-board-fire-tap" })
+        assertEquals(surface.envelopes.map { it.sectionId }.toSet(), byId.keys)
+
+        ReteAgent.stop(agent)
+        agent.job.join()
+    }
+
+    @Test
+    fun awaitFiresCountsFreshArrivalsNotWindowSize() = runTest {
+        val index = CausalGraphNodeIndex()
+        val tap = ReteFireBoardTap()
+        val agent = index.tapFiresToBoard(scope = backgroundScope, tap = tap)
+
+        index.addOrGet(node("n1"))
+        index.addOrGet(node("n2"))
+        assertEquals(2, (withTimeoutOrNull(2_000) { tap.awaitFires(2) } ?: emptyList()).size)
+
+        // The window is never emptied, so a second await must count *new* arrivals
+        // rather than being satisfied instantly by the two fires already held.
+        index.addOrGet(node("n3"))
+        index.addOrGet(node("n4"))
+        val second = withTimeoutOrNull(2_000) { tap.awaitFires(2) } ?: emptyList()
+        assertEquals(listOf("n1", "n2", "n3", "n4"), second.map { it.nodeId })
+
+        ReteAgent.stop(agent)
+        agent.job.join()
+    }
+
+    @Test
+    fun tapRejectsAnIndexThatAlreadyHasAnAgent() = runTest {
+        val index = CausalGraphNodeIndex()
+        val agent = index.tapFiresToBoard(scope = backgroundScope, tap = ReteFireBoardTap())
+        assertFailsWith<IllegalArgumentException> {
+            index.tapFiresToBoard(scope = backgroundScope, tap = ReteFireBoardTap())
+        }
+        ReteAgent.stop(agent)
+        agent.job.join()
+    }
+
+    // ── (b) modelmux telemetry → gallery ─────────────────────────────────────
+
+    @Test
+    fun quotaSnapshotProjectsOntoGallerySection() {
+        val snapshot = QuotaSnapshot(
+            provider = "anthropic",
+            windowStart = 1_699_999_000_000L,
+            quotaRemaining = 42.5,
+            spent = 7.5,
+        )
+        val (view, surface, index) = projectModelMuxTelemetry(
+            quotas = listOf(snapshot),
+            selections = emptyList(),
+            now = fixedNow,
+        )
+
+        assertViewInvariant(view)
+        assertEquals("gallery", surface.anchorSectionId)
+        assertEquals(1, surface.envelopes.size)
+
+        val e = surface.envelopes[0]
+        val payload = e.payload
+        assertIs<ModelMuxTelemetry.Quota>(payload)
+        assertEquals(snapshot, payload.snapshot)
+        assertEquals("gallery-quota-anthropic-1699999000000", e.sectionId)
+        assertEquals(fixedNow, e.updatedAt)
+        assertNotNull(ForgeBlackboardView.sectionPlacement(view, e.sectionId))
+        assertSame(e, index[e.sectionId])
+
+        val anchor = ForgeBlackboardView.sectionPlacement(ForgeBlackboardView.DEFAULT, "gallery")!!
+        assertTrue(e.centerY > anchor.centerY + anchor.height / 2.0)
+    }
+
+    @Test
+    fun quotaAndSelectionShareTheGalleryStrip() {
+        val (view, surface, _) = projectModelMuxTelemetry(
+            quotas = listOf(QuotaSnapshot("anthropic", 1L, 10.0, 1.0)),
+            selections = listOf(
+                ModelSelectionEvent.ModelSelected(
+                    provider = "anthropic",
+                    model = "opus",
+                    strategy = "quota-first",
+                    requestId = "req/42",
+                    at = fixedNow,
+                ),
+            ),
+            now = fixedNow,
+        )
+
+        assertViewInvariant(view)
+        assertEquals(2, surface.envelopes.size)
+        assertIs<ModelMuxTelemetry.Quota>(surface.envelopes[0].payload)
+        assertIs<ModelMuxTelemetry.Selection>(surface.envelopes[1].payload)
+        // '/' is not section-id safe and must be squashed.
+        assertEquals("gallery-model-anthropic-req-42", surface.envelopes[1].sectionId)
+    }
+
+    // ── contract-level invariants ────────────────────────────────────────────
+
+    @Test
+    fun ringsCompose_boardThenGalleryOnOneView() {
+        val (boardView, boardSurface, _) = ReteFireSurfaceProjection.project(
+            domain = listOf(fire("n1")),
+            now = fixedNow,
+        )
+        val (bothView, gallerySurface, _) = projectModelMuxTelemetry(
+            quotas = listOf(QuotaSnapshot("gemini", 5L, 1.0, 0.0)),
+            selections = emptyList(),
+            base = boardView,
+            now = fixedNow,
+        )
+
+        assertViewInvariant(bothView)
+        assertEquals(ForgeBlackboardView.DEFAULT.sections.size + 2, bothView.sections.size)
+        assertNotNull(ForgeBlackboardView.sectionPlacement(bothView, boardSurface.envelopes[0].sectionId))
+        assertNotNull(ForgeBlackboardView.sectionPlacement(bothView, gallerySurface.envelopes[0].sectionId))
+    }
+
+    @Test
+    fun emptyDomainLeavesTheDefaultViewUntouched() {
+        val (view, surface, index) = ReteFireSurfaceProjection.project(emptyList(), now = fixedNow)
+        assertViewInvariant(view)
+        assertEquals(ForgeBlackboardView.DEFAULT.sections, view.sections)
+        assertEquals(ForgeBlackboardView.DEFAULT.layout3D, view.layout3D)
+        assertTrue(surface.envelopes.isEmpty())
+        assertTrue(index.isEmpty())
+    }
+
+    @Test
+    fun reprojectingKeepsEveryTileWhereTheViewPutIt() {
+        val fires = listOf(fire("n1"), fire("n2"), fire("n3"))
+        val (once, first, _) = ReteFireSurfaceProjection.project(fires, now = fixedNow)
+
+        // Same fires, different order, onto the view they already live on.
+        val (twice, second, _) =
+            ReteFireSurfaceProjection.project(fires.reversed(), base = once, now = fixedNow + 5L)
+
+        assertViewInvariant(twice)
+        assertEquals(once.sections, twice.sections, "no new sections for tiles already on the board")
+        assertEquals(once.layout3D, twice.layout3D)
+
+        val again = second.envelopes.associateBy { it.sectionId }
+        first.envelopes.forEach { e ->
+            val e2 = again.getValue(e.sectionId)
+            // Placement is the view's, so surface and view can never disagree…
+            assertEquals(e.centerX, e2.centerX)
+            assertEquals(e.centerY, e2.centerY)
+            assertEquals(e.width, e2.width)
+            assertEquals(e.height, e2.height)
+            assertEquals(e.elevation, e2.elevation)
+            // …while the envelope itself is freshly stamped.
+            assertEquals(fixedNow + 5L, e2.updatedAt)
+        }
+    }
+
+    @Test
+    fun withSurfaceIsIdempotent() {
+        val (once, surface, _) = ReteFireSurfaceProjection.project(listOf(fire("n1")), now = fixedNow)
+        val twice = once.withSurface(surface.envelopes)
+        assertViewInvariant(twice)
+        assertEquals(once.sections, twice.sections)
+        assertEquals(once.layout3D, twice.layout3D)
+    }
+
+    @Test
+    fun projectRejectsAnAnchorMissingFromTheBaseView() {
+        val narrow = ForgeBlackboardView(
+            surface = "forge.blackboard.narrow",
+            sections = listOf("page"),
+            defaultCamera = ForgeBlackboardCamera(),
+            cornerButtons = emptyList(),
+            layout3D = listOf(ForgeBlackboardSection3D("page", 0.0, 0.0, 100.0, 100.0, 1.0)),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            ReteFireSurfaceProjection.project(listOf(fire("n1")), base = narrow, now = fixedNow)
+        }
+    }
+
+    @Test
+    fun sectionHashIsDeterministicAndPartAware() {
+        assertEquals(forgeSectionHash("a", "b"), forgeSectionHash("a", "b"))
+        assertEquals(8, forgeSectionHash("a").length)
+        assertTrue(forgeSectionHash("a", "b") != forgeSectionHash("ab"), "part boundaries must matter")
+        assertTrue(forgeSectionHash("") .all { it in "0123456789abcdef" })
+    }
+
+    @Test
+    fun sectionTokenSquashesSeparators() {
+        assertEquals("op-v1-seed-board-a", "op\u001Fv1\u001Fseed\u001Fboard-a".forgeSectionToken())
+        assertEquals("x", "///".forgeSectionToken())
+        assertEquals("a_b-c", "a_b/c".forgeSectionToken())
+    }
+}


### PR DESCRIPTION
## What

Generalizes the pattern verified in `JulesBlackboardAdapter.projectFullSurface` into a **section-agnostic projection contract** every ring can land on the forge blackboard through, plus two concrete rings.

### Contract — `src/commonMain/kotlin/borg/trikeshed/forge/blackboard/ForgeSurfaceProjection.kt`

| Piece | Role |
|---|---|
| `ForgeSurfaceGeometry` | `sectionId` + `centerX/centerY/width/height/elevation`, carried by every surface item |
| `ForgeSurfaceEnvelope<P>` | payload + sectionId + geometry + `updatedAt` + `ttlMs` |
| `ForgeDomainSurface` / `ForgeSectionSurface<P>` | TTL-stamped bag of items |
| `ForgeBlackboardView.withSurface(items)` | rebuilds the view by concatenating section ids and `ForgeBlackboardSection3D`s onto `DEFAULT` |
| `ForgeSurfaceProjection<D, P>.project(domain, base, now)` | pure `(view, surface, index-by-sectionId)` |

The view's init constraint (`layout3D` ids == `sections`) holds by construction, so a successful projection *is* the proof.

Two rules keep the view and the surface in agreement, which is what makes re-projecting onto an already-projected view idempotent:

- **one tile per section id** — a repeated id is projected once, first occurrence wins;
- **placement is sticky** — an id the base view already carries keeps the geometry the view gave it; only genuinely new tiles consume a grid slot.

### Rings

- **(a) `ReteAgent.Fire` → `board`.** `ReteFireBoardTap` is the bounded, coroutine-safe collector wired through `CausalGraphNodeIndex.bindOrCreateAgent(onFire = …)` — whose default `onFire` was a no-op until now. `Channel(capacity, DROP_OLDEST)` plus a `Mutex`-guarded ring buffer; `awaitFires(n)` counts *fresh* arrivals rather than window size, since `drain()` never empties the rolling window.
- **(b) modelmux → `gallery`.** `QuotaSnapshot` and `ModelSelectionEvent.ModelSelected` share one strip: one tile per provider quota window, one per selection request.

### `JulesBlackboardAdapter`

Interface-only: `ForgeSurfaceSession`/`ForgeSurfaceActivity : ForgeSurfaceGeometry`, `JulesBlackboardSurface : ForgeDomainSurface`. No behavior change; `items` is a `val`, not a `get()`, so it does not reallocate per read.

## Decisions taken at ambiguous points (autonomy mode)

- Section ids are **content-derived** (FNV-1a via `forgeSectionHash`), never ring-buffer-ordinal — eviction cannot mint duplicate tiles for fires already on the board.
- Tile strips start below `FORGE_SURFACE_STRIP_BASELINE_Y` (700.0) rather than immediately under the anchor, so a long strip cannot grow into a neighbouring quadrant; rings stay attached to their anchor via shared `centerX`.
- A **full** row of `columns` cells is centered on the anchor, so a column's X is stable as the strip fills; a partly-filled last row is left-aligned rather than re-centered.
- `tapFiresToBoard` **requires an unbound index** — `bindOrCreateAgent` would otherwise keep the existing agent and leave the tap silently empty forever.
- `ReteFireBoardTap` is documented **single-consumer**: serializing channel receives against `drain()` would let a stalled `awaitFires` block every reader.

## Verification

- `./gradlew jvmMainClasses --console=plain` — green.
- `./gradlew jvmTest --tests '*.ForgeSurfaceProjectionTest' --tests '*.JulesBlackboardAdapterTest'` — 36/36 pass.
- Neighbours checked: `ForgeBlackboardCameraTest`, `ForgeBlackboardInteractionTest`, `ForgeGalleryPrinterTest`, `CausalGraphNodeIndexBindAgentTest` — all green.
- `ForgePersistenceDurabilityTest` and `ForceLayoutTest` fail **identically with these changes stashed** — pre-existing, out of scope.

A `/code-review high` pass returned 9 findings (1 HIGH, 4 MEDIUM, 4 LOW); all are addressed in this branch, the two LOWs kept as-is (fixed-column centering, single-consumer tap) are documented in KDoc with the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)