### PR TITLE
feat(reactor): CompletableDeferred awaitCompletion on FanoutDispatcherElement

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/reactor/FanoutDispatcherElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/reactor/FanoutDispatcherElement.kt
@@ -5,16 +5,40 @@ import borg.trikeshed.context.ElementState
 import borg.trikeshed.userspace.Liburing
 import borg.trikeshed.userspace.UringCompletion
 import borg.trikeshed.userspace.context.AsyncContextKey
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 /**
  * Fanout dispatcher CCEK element for liburing completion dispatch.
  * Moved here from userspace/LiburingElement.kt for proper package organization.
+ *
+ * Completion idiom aligned with the sibling ChannelRunner: a suspended awaiter
+ * parks on a [CompletableDeferred] keyed by userData token and is resumed by
+ * the channel-backed consumer loop. Each deferred is single-shot — the consumer
+ * takes it out of the registry as it completes it — so every [awaitCompletion]
+ * call arms a fresh one.
+ *
+ * Delivery rules for [awaitCompletion]:
+ *  - A completion is handed to exactly **one** awaiter, oldest first, the way
+ *    ChannelRunner drains its per-fd writer queue.
+ *  - A completion dispatched for a token nobody is awaiting yet is **stashed**
+ *    (bounded, see [UNCLAIMED_LIMIT]) rather than dropped, so the natural
+ *    io_uring order — submit the SQE, then await its userData — cannot lose a
+ *    CQE that arrives inside that window.
+ *
+ * Legacy multi-handler callbacks ([registerHandler]/[removeHandler]) are
+ * preserved for compatibility but deprecated in favor of [awaitCompletion].
+ * They keep their broadcast semantics: every registered handler sees every
+ * completion for its token, independently of any awaiter.
  */
 open class FanoutDispatcherElement(
     parentJob: Job? = null,
@@ -22,23 +46,101 @@ open class FanoutDispatcherElement(
 
     override val key: CoroutineContext.Key<*> get() = AsyncContextKey.FanoutDispatcherKey
 
+    /**
+     * Legacy callback registry, mutated by the non-suspending
+     * [registerHandler]/[removeHandler] and read by the consumer loop.
+     *
+     * Known pre-existing hazard, unchanged by the [awaitCompletion] work and
+     * deliberately not papered over here: those two entry points cannot take
+     * [mutex] without either blocking (forbidden in commonMain) or deferring
+     * the mutation off-thread, where a registration could miss completions
+     * dispatched right after it returned. A lock-free copy-on-write swap would
+     * fix it properly; until then this map carries exactly the concurrency
+     * guarantees it always had, which is one more reason to prefer
+     * [awaitCompletion], whose state IS mutex-guarded.
+     */
     private val handlers = mutableMapOf<Long, MutableList<(UringCompletion) -> Unit>>()
-    
+
+    /** Guards [awaiters] and [unclaimed]. */
+    private val mutex = Mutex()
+
+    /** userData token -> FIFO queue of single-shot deferreds awaiting it. */
+    private val awaiters = mutableMapOf<Long, ArrayDeque<CompletableDeferred<UringCompletion>>>()
+
+    /** userData token -> completions that arrived before anyone awaited them. */
+    private val unclaimed = mutableMapOf<Long, ArrayDeque<UringCompletion>>()
+
+    private var unclaimedCount = 0
+
     private val dispatchChannel = Channel<UringCompletion>(
         capacity = 64,
         onBufferOverflow = BufferOverflow.SUSPEND
     )
 
+    /** The consumer loop, so [close] can let it drain before the supervisor dies. */
+    private var consumer: Job? = null
+
     override suspend fun open() {
         super.open()
-        CoroutineScope(supervisor).launch {
+        if (consumer != null) return // open() is idempotent; one consumer loop only
+        consumer = CoroutineScope(supervisor).launch {
             for (completion in dispatchChannel) {
-                handlers[completion.userData]?.toList()?.forEach { it(completion) }
+                // Legacy callbacks are a broadcast independent of any awaiter, and
+                // they run before the deferred completes so a resuming awaiter
+                // observes all callback side effects. One misbehaving handler must
+                // not kill dispatch for every token.
+                handlers[completion.userData]?.toList()?.forEach { handler ->
+                    try {
+                        handler(completion)
+                    } catch (e: Throwable) {
+                        println("WARN: FanoutDispatcherElement handler threw for userData=${completion.userData}: $e")
+                    }
+                }
+                // Claim-or-stash must be ONE critical section: splitting it lets an
+                // awaiter arm in the gap, find nothing stashed, park — and then have
+                // its completion stashed behind it, where it never looks again.
+                val waiter = mutex.withLock {
+                    val claimed = takeWaiter(completion.userData)
+                    if (claimed == null) stash(completion)
+                    claimed
+                }
+                waiter?.complete(completion)
+            }
+        }
+    }
+
+    /**
+     * Suspend until a completion arrives for [userData], ChannelRunner-style.
+     *
+     * Returns immediately with a completion already stashed for the token, if
+     * any. Otherwise arms a fresh single-shot deferred and parks on it; with
+     * several awaiters on one token the oldest is served first. Cancellation
+     * disarms only this call's own deferred, leaving peers on the same token
+     * intact. [close] fails whatever is still armed.
+     */
+    suspend fun awaitCompletion(userData: Long): UringCompletion {
+        val deferred = mutex.withLock {
+            takeUnclaimed(userData)?.let { return it }
+            CompletableDeferred<UringCompletion>().also {
+                awaiters.getOrPut(userData) { ArrayDeque() }.addLast(it)
+            }
+        }
+        return try {
+            deferred.await()
+        } finally {
+            // NonCancellable: the common reason this finally runs is cancellation,
+            // and Mutex.lock() is itself cancellable — without this the entry leaks.
+            withContext(NonCancellable) {
+                mutex.withLock { disarm(userData, deferred) }
             }
         }
     }
 
     /** Register a handler for completions with the given userData token. */
+    @Deprecated(
+        "Use awaitCompletion(userData) — the CompletableDeferred idiom shared with ChannelRunner.",
+        ReplaceWith("awaitCompletion(userData)"),
+    )
     fun registerHandler(userData: Long, handler: (UringCompletion) -> Unit) {
         handlers.getOrPut(userData) { mutableListOf() }.add(handler)
         // Also register with liburing facade
@@ -46,13 +148,14 @@ open class FanoutDispatcherElement(
     }
 
     /** Remove a handler. */
+    @Deprecated("Callback API superseded by awaitCompletion(userData); pairs with registerHandler.")
     fun removeHandler(userData: Long, handler: (UringCompletion) -> Unit) {
         handlers[userData]?.remove(handler)
         if (handlers[userData].isNullOrEmpty()) handlers.remove(userData)
         Liburing.removeFanoutHandler(userData, handler)
     }
 
-    /** Dispatch a completion to all handlers for its userData. */
+    /** Dispatch a completion to all handlers/awaiters for its userData. */
     internal suspend fun dispatch(completion: UringCompletion) {
         val result = dispatchChannel.trySend(completion)
         if (result.isFailure) {
@@ -61,9 +164,83 @@ open class FanoutDispatcherElement(
         }
     }
 
+    /**
+     * Close the dispatch channel first so the consumer loop can finish; the base
+     * implementation's `supervisor.join()` would otherwise wait on a loop that
+     * never ends.
+     */
+    override suspend fun drain() {
+        dispatchChannel.close()
+        super.drain()
+    }
+
     override suspend fun close() {
         dispatchChannel.close()
+        // Let the loop hand out already-buffered completions before the
+        // supervisor is cancelled, so an awaiter whose completion was accepted
+        // is resumed with it rather than failed.
+        consumer?.join()
         handlers.clear()
+        val stranded = mutex.withLock {
+            val armed = awaiters.values.flatten()
+            awaiters.clear()
+            unclaimed.clear()
+            unclaimedCount = 0
+            armed
+        }
+        // Fail outside the lock: resuming an awaiter may run inline, and that
+        // awaiter's cleanup takes the same mutex. completeExceptionally rather
+        // than cancel() so the shutdown surfaces instead of silently killing
+        // launch-based awaiters.
+        stranded.forEach {
+            it.completeExceptionally(IllegalStateException("FanoutDispatcherElement closed while awaiting completion"))
+        }
         super.close()
+    }
+
+    /** Pop the oldest awaiter for [userData], if any. Caller holds [mutex]. */
+    private fun takeWaiter(userData: Long): CompletableDeferred<UringCompletion>? {
+        val queue = awaiters[userData] ?: return null
+        val waiter = queue.removeFirstOrNull()
+        if (queue.isEmpty()) awaiters.remove(userData)
+        return waiter
+    }
+
+    /** Drop [deferred] from [userData]'s queue if it is still parked. Caller holds [mutex]. */
+    private fun disarm(userData: Long, deferred: CompletableDeferred<UringCompletion>) {
+        val queue = awaiters[userData] ?: return
+        queue.remove(deferred)
+        if (queue.isEmpty()) awaiters.remove(userData)
+    }
+
+    /** Pop a completion stashed for [userData], if any. Caller holds [mutex]. */
+    private fun takeUnclaimed(userData: Long): UringCompletion? {
+        val queue = unclaimed[userData] ?: return null
+        val completion = queue.removeFirstOrNull()
+        if (completion != null) unclaimedCount--
+        if (queue.isEmpty()) unclaimed.remove(userData)
+        return completion
+    }
+
+    /** Hold a completion nobody is awaiting yet, evicting the oldest when full. Caller holds [mutex]. */
+    private fun stash(completion: UringCompletion) {
+        unclaimed.getOrPut(completion.userData) { ArrayDeque() }.addLast(completion)
+        unclaimedCount++
+        while (unclaimedCount > UNCLAIMED_LIMIT) {
+            val oldest = unclaimed.entries.firstOrNull() ?: break
+            oldest.value.removeFirstOrNull() ?: break
+            unclaimedCount--
+            if (oldest.value.isEmpty()) unclaimed.remove(oldest.key)
+        }
+    }
+
+    private companion object {
+        /**
+         * Cap on completions held for tokens nobody awaited. A userData token is
+         * short-lived, so an unclaimed stash that keeps growing means completions
+         * are being dispatched for tokens with no reader; drop the oldest rather
+         * than retain them forever.
+         */
+        const val UNCLAIMED_LIMIT = 256
     }
 }

--- a/src/jvmTest/kotlin/borg/trikeshed/userspace/reactor/FanoutDispatcherElementTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/userspace/reactor/FanoutDispatcherElementTest.kt
@@ -1,0 +1,169 @@
+package borg.trikeshed.userspace.reactor
+
+import borg.trikeshed.userspace.UringCompletion
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * FanoutDispatcherElement — ChannelRunner-idiom completion tests.
+ *
+ * Covers the [FanoutDispatcherElement.awaitCompletion] contract: distinct
+ * tokens resolve independently, a completion that arrives before its awaiter is
+ * stashed rather than dropped, cancelling one awaiter leaves its same-token peer
+ * armed, `close` fails whatever is still armed, and the deprecated
+ * registerHandler callback path still fires.
+ *
+ * Lives in jvmTest rather than commonTest because commonTest excludes
+ * `userspace/reactor` outside the focusedTransportSlice build, and the slice
+ * build has pre-existing unrelated compile failures — a commonTest placement
+ * would never actually execute.
+ *
+ * Two timing notes:
+ *  - The element's consumer loop runs on its own supervisor scope, i.e. a real
+ *    dispatcher rather than the test scheduler, so each body runs inside
+ *    `withContext(Dispatchers.Default)`: virtual time never advances here and
+ *    `withTimeout` must measure real elapsed time.
+ *  - Awaiters start [CoroutineStart.UNDISPATCHED] so each runs inline through
+ *    the uncontended `Mutex` that arms its deferred and only then suspends on
+ *    it. That makes "armed before dispatch" a property of the call rather than
+ *    of a scheduling race.
+ */
+class FanoutDispatcherElementTest {
+
+    @Test
+    fun concurrentAwaitersOnDistinctTokensEachReceiveTheirCompletion() = runTest {
+        withContext(Dispatchers.Default) {
+            val element = FanoutDispatcherElement()
+            element.open()
+            try {
+                val a = async(start = CoroutineStart.UNDISPATCHED) { element.awaitCompletion(1L) }
+                val b = async(start = CoroutineStart.UNDISPATCHED) { element.awaitCompletion(2L) }
+
+                // Dispatch out of order: each awaiter gets its own token's completion.
+                element.dispatch(UringCompletion(userData = 2L, res = 20, flags = 0))
+                element.dispatch(UringCompletion(userData = 1L, res = 10, flags = 0))
+
+                val first = withTimeout(TIMEOUT_MS) { a.await() }
+                val second = withTimeout(TIMEOUT_MS) { b.await() }
+
+                assertEquals(1L, first.userData)
+                assertEquals(10, first.res)
+                assertEquals(2L, second.userData)
+                assertEquals(20, second.res)
+            } finally {
+                element.close()
+            }
+        }
+    }
+
+    @Test
+    fun legacyRegisterHandlerCallbackStillFires() = runTest {
+        withContext(Dispatchers.Default) {
+            val element = FanoutDispatcherElement()
+            element.open()
+            val received = mutableListOf<UringCompletion>()
+            val handler: (UringCompletion) -> Unit = { received.add(it) }
+            @Suppress("DEPRECATION")
+            element.registerHandler(7L, handler)
+            try {
+                val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+                    element.awaitCompletion(7L)
+                }
+
+                element.dispatch(UringCompletion(userData = 7L, res = 42, flags = 0))
+
+                // The consumer loop runs legacy callbacks before completing the
+                // deferred, so a resumed awaiter proves the callback already ran.
+                val completion = withTimeout(TIMEOUT_MS) { awaiter.await() }
+                assertEquals(7L, completion.userData)
+                assertEquals(42, completion.res)
+
+                assertEquals(1, received.size)
+                assertEquals(7L, received[0].userData)
+                assertEquals(42, received[0].res)
+            } finally {
+                @Suppress("DEPRECATION")
+                element.removeHandler(7L, handler)
+                element.close()
+            }
+        }
+    }
+
+    /** Natural io_uring order is submit-then-await; the CQE may beat the awaiter. */
+    @Test
+    fun completionDispatchedBeforeAwaitIsStillDelivered() = runTest {
+        withContext(Dispatchers.Default) {
+            val element = FanoutDispatcherElement()
+            element.open()
+            try {
+                element.dispatch(UringCompletion(userData = 9L, res = 99, flags = 0))
+
+                val completion = withTimeout(TIMEOUT_MS) { element.awaitCompletion(9L) }
+                assertEquals(9L, completion.userData)
+                assertEquals(99, completion.res)
+            } finally {
+                element.close()
+            }
+        }
+    }
+
+    @Test
+    fun cancellingOneAwaiterLeavesItsSameTokenPeerArmed() = runTest {
+        withContext(Dispatchers.Default) {
+            val element = FanoutDispatcherElement()
+            element.open()
+            try {
+                // Both queue on token 3; `doomed` is the head, so cancelling it
+                // must not take the queue (or `survivor`) down with it.
+                val doomed = launch(start = CoroutineStart.UNDISPATCHED) { element.awaitCompletion(3L) }
+                val survivor = async(start = CoroutineStart.UNDISPATCHED) { element.awaitCompletion(3L) }
+
+                // cancelAndJoin waits for the NonCancellable disarm to finish.
+                doomed.cancelAndJoin()
+
+                element.dispatch(UringCompletion(userData = 3L, res = 33, flags = 0))
+
+                val completion = withTimeout(TIMEOUT_MS) { survivor.await() }
+                assertEquals(3L, completion.userData)
+                assertEquals(33, completion.res)
+            } finally {
+                element.close()
+            }
+        }
+    }
+
+    @Test
+    fun closeFailsStillArmedAwaiters() = runTest {
+        withContext(Dispatchers.Default) {
+            val element = FanoutDispatcherElement()
+            element.open()
+            // runCatching keeps the failure local: an async failing outright
+            // would tear down the enclosing test scope.
+            val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+                runCatching { element.awaitCompletion(4L) }
+            }
+
+            element.close()
+
+            val outcome = withTimeout(TIMEOUT_MS) { awaiter.await() }
+            assertTrue(outcome.isFailure, "close() must fail an armed awaiter, got $outcome")
+            assertTrue(
+                outcome.exceptionOrNull() is IllegalStateException,
+                "expected IllegalStateException, got ${outcome.exceptionOrNull()}",
+            )
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
+    }
+}


### PR DESCRIPTION
Adds `suspend fun awaitCompletion(userData: Long): UringCompletion` to `FanoutDispatcherElement` — the CompletableDeferred-per-userData idiom the sibling `ChannelRunner` already uses — so liburing completions can be consumed by a suspended coroutine instead of a callback. Deferreds are single-shot and re-armed on each await, guarded by a `Mutex` (not `synchronized`), and dispatch stays channel-backed.

## Delivery rules

- A completion goes to exactly **one** awaiter, oldest first, mirroring how `ChannelRunner` drains its per-fd writer queue.
- A completion for a token nobody is awaiting yet is **stashed** (bounded at 256, oldest evicted) rather than dropped, so the natural io_uring order — submit the SQE, then await its userData — cannot lose a CQE that lands in that window.
- Claim-or-stash is a single critical section. Splitting it across two `withLock` calls let an awaiter arm in the gap and then park forever behind its own stashed completion; that race reproduced as a real 10s hang before it was fixed.

## Preserved

The legacy multi-handler callback API (`registerHandler`/`removeHandler`) is deprecated, not deleted. It keeps its broadcast semantics, its `Liburing.registerFanoutHandler`/`removeFanoutHandler` mirroring, and the concurrency guarantees it always had — documented in place, since neither entry point can take the `Mutex` without blocking (forbidden in commonMain) or deferring the mutation off-thread.

## Also fixed, all reachable from the new API

- A throwing legacy handler no longer kills the consumer loop for every token.
- `close()` lets the loop drain already-buffered completions before the supervisor dies, and fails still-armed awaiters with an exception rather than a silent `cancel()` that `launch`-based callers would swallow.
- `drain()` closes the dispatch channel first, so the base implementation's `supervisor.join()` no longer waits on a loop that cannot end.
- `open()` is idempotent instead of launching a second consumer loop.
- The await cleanup runs `NonCancellable` — cancellation is exactly when it needs to take a cancellable `Mutex`.

## Tests

Five tests in `src/jvmTest/.../FanoutDispatcherElementTest.kt`: distinct-token awaiters, dispatch-before-await, cancel-one-of-two on a shared token, `close()` failing armed awaiters, and the legacy callback path.

They live in `jvmTest` rather than `commonTest` because `commonTest` excludes `**/userspace/reactor/**` outside `-PfocusedTransportSlice=true`, and that slice has pre-existing unrelated compile failures — a `commonTest` placement would never actually execute.

## Gates

- `./gradlew jvmMainClasses --console=plain` — BUILD SUCCESSFUL
- `./gradlew jvmTest --tests '*FanoutDispatcherElementTest*' --console=plain` — 5/5 PASSED, stable across repeated reruns

Pre-existing red, out of scope: `-PfocusedTransportSlice=true` fails to compile `commonTest` in 12 unrelated files (`util/oroboros/**`, `cli/htx/HtxAria2EngineTest`, `userspace/context/AsyncContextKeyElementTest`, and others), confirmed identical on a clean tree at `825331340`. `AsyncContextKeyElementTest` is the only other file referencing `FanoutDispatcherElement`; it does not compile today, before or after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
