### PR TITLE
🛡️ Sentinel: [Medium] Fix DoS vulnerability in JvmProcessOperations

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
@@ -49,7 +49,12 @@ class JvmProcessOperations : ProcessOperations {
                 stderrOut.toByteArray()
             }
 
-            val exitCode = proc.waitFor()
+            val finished = proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) {
+                proc.destroyForcibly()
+                throw RuntimeException("process timed out after 30 seconds")
+            }
+            val exitCode = proc.exitValue()
             ProcessResult(exitCode, stdoutDeferred.await(), stderrDeferred.await())
         } }
     }


### PR DESCRIPTION
* 🚨 Severity: Medium
* 💡 Vulnerability: Missing timeout configuration in `JvmProcessOperations.kt` process execution (`proc.waitFor()`). Subprocesses that hung could permanently block coroutines and `Dispatchers.IO` threads, causing resource exhaustion and Denial of Service.
* 🎯 Impact: An attacker or a misconfigured command could cause a subprocess to hang indefinitely, blocking application event loops and `Dispatchers.IO` threads, leading to application unresponsiveness and Denial of Service.
* 🔧 Fix: Replaced parameterless blocking `waitFor()` with a bounded `waitFor(30, TimeUnit.SECONDS)`. Added logic to forcefully terminate (`destroyForcibly()`) hanging subprocesses and throw a `RuntimeException` to break the coroutine.
* ✅ Verification: Verified by running `./gradlew :jvmTest`, which passed all process worker contract tests, ensuring no regressions.

---
*PR created automatically by Jules for task [1472389890787737620](https://jules.google.com/task/1472389890787737620) started by @jnorthrup*