### PR TITLE
🎨 Palette: Add keyboard focus state to drop zone

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 ## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
 **Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
 **Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.
+## 2024-08-20 - Adding focus states for drag and drop drop zones
+**Learning:** For elements handling drag-and-drop file ingestions natively created as semantic `role="button"` placeholders like `.drop-zone` in index.html templates, ensuring they receive `:focus-visible` styling is crucial for keyboard users attempting to access upload functions.
+**Action:** Always add interactive form and UI upload containers defined with tabindex to the globally applied `:focus-visible` CSS selector lists.

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -380,7 +380,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 button:focus-visible,
 .page-tree-item:focus-visible,
 .board-card:focus-visible,
-.workspace-switcher:focus-visible {
+.workspace-switcher:focus-visible,
+.drop-zone:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }


### PR DESCRIPTION
🎨 Palette: Add keyboard focus state to drop zone

* 💡 What: Added `:focus-visible` CSS rule for `.drop-zone` element in `styles.css`.
* 🎯 Why: To ensure keyboard users have visual feedback when focusing on the drag-and-drop file ingestion area, enhancing accessibility.
* 📸 Before/After: N/A
* ♿ Accessibility: Improves visual indication of focus for keyboard navigation using `tabindex="0"` elements.

---
*PR created automatically by Jules for task [4987330851893637188](https://jules.google.com/task/4987330851893637188) started by @jnorthrup*