### PR TITLE
🎨 Palette: Improve keyboard accessibility for button roles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 ## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
 **Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
 **Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.
+## $(date +%Y-%m-%d) - Keyboard accessibility for pseudo-buttons
+**Learning:** Elements using `role="button"` and `tabindex="0"` do not natively fire click events on `Enter` or `Space` like standard `<button>` elements do.
+**Action:** Always add a generic or specific `keydown` event listener to these elements to translate `Enter` and `Space` key presses into `.click()` calls.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -486,6 +486,19 @@
     slashAnchor = null;
   }
 
+
+  // ── Global keyboard accessibility for role="button" ───────────────────
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      if (document.activeElement &&
+          document.activeElement.getAttribute('role') === 'button' &&
+          document.activeElement.getAttribute('tabindex') === '0') {
+        e.preventDefault();
+        document.activeElement.click();
+      }
+    }
+  });
+
   document.addEventListener('mousedown', (e) => {
     if (!slashMenuEl.hidden && !slashMenuEl.contains(e.target)) closeSlashMenu();
   });


### PR DESCRIPTION
💡 What: Added global keyboard event handler for pseudo-buttons.
🎯 Why: Elements using `role="button"` (like the workspace-switcher and drop-zone) do not natively respond to Enter/Space keys, making them inaccessible to keyboard users.
📸 Before/After: No visual changes; behavior change allows keyboard activation.
♿ Accessibility: Ensures custom button implementations are fully keyboard navigable and operable.

---
*PR created automatically by Jules for task [7649863834975833318](https://jules.google.com/task/7649863834975833318) started by @jnorthrup*