### PR TITLE
🎨 Palette: Add proper styling and interaction to file drop zone

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
 **Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
 **Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.
+
+## 2024-05-24 - Add interactive and focus styles to unstyled drop zone
+**Learning:** The drop zone for the file ingest feature (`#drop-zone`) lacked CSS styling and interactive handlers, making it appear as unstyled inline text without any keyboard interactivity. This is a common pattern where newer features in the app shell get added to the HTML but corresponding CSS/JS are missed.
+**Action:** Added proper styles (`.drop-zone`, `:hover`, `:focus-visible`) and wired up a click/keydown event listener in `script.js` to correctly forward interactions to the hidden file input. In the future, verify that new features using `aria-label` and `role="button"` also have corresponding keyboard handlers (`Enter`/`Space`) and visible focus states.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -561,6 +561,24 @@
   const viewDocBtn = document.getElementById('btn-view-doc');
   const viewBoardBtn = document.getElementById('btn-view-board');
 
+  // ── Drop zone interaction ───────────────────────────────────────────
+  const dropZoneEl = document.getElementById('drop-zone');
+  const fileInputEl = document.getElementById('file-input');
+
+  if (dropZoneEl && fileInputEl) {
+    dropZoneEl.addEventListener('click', () => {
+      fileInputEl.click();
+    });
+
+    dropZoneEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        fileInputEl.click();
+      }
+    });
+  }
+
+
   function setView(view) {
     mutate((s) => { s.view = view; });
     docScrollEl.hidden = view !== 'doc';

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -97,6 +97,37 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-add { color: var(--text-secondary); margin-top: 2px; }
+
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  margin-top: 8px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.2s;
+}
+.drop-zone:hover, .drop-zone:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  outline: none;
+}
+.drop-zone-icon {
+  font-size: 20px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.drop-zone-text {
+  font-size: 12px;
+  color: var(--text-faint);
+  line-height: 1.4;
+}
+
 .sidebar-bottom { padding: 8px 16px; }
 .sidebar-seed-note { font-size: 11px; color: var(--text-faint); line-height: 1.4; }
 


### PR DESCRIPTION
* 💡 What: Added CSS styles (`.drop-zone`, `:hover`, `:focus-visible`) and JavaScript click/keydown handlers for the file ingest drop zone (`#drop-zone`).
* 🎯 Why: The drop zone in the sidebar was previously just unstyled text and lacked any interactive JS handlers, making it unusable for keyboard users and confusing visually.
* 📸 Before/After: The drop zone is now styled with a dashed border, background colors for hover and focus states, and handles clicking or pressing Enter/Space to open the file selection dialog.
* ♿ Accessibility: Improved keyboard accessibility by adding a `keydown` listener to the `role="button"` `div` and provided visual focus indicators via `:focus-visible`.

---
*PR created automatically by Jules for task [7207519305931731413](https://jules.google.com/task/7207519305931731413) started by @jnorthrup*