### PR TITLE
🎨 Palette: Add keyboard support for upload drop zone

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 ## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
 **Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
 **Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.
+## 2024-05-19 - Keyboard Accessibility for Interactive Elements
+**Learning:** UI elements designated as buttons via `role="button"` and `tabindex="0"` (like `#drop-zone`) must explicitly handle keyboard events (`Enter` and `Space`) in JavaScript to be fully accessible, especially when wrapping native inputs like file uploaders. Without this, keyboard-only or screen reader users cannot activate the element.
+**Action:** Always attach both `click` and `keydown` listeners to custom interactive elements that do not use native `<button>` tags.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -580,6 +580,20 @@
     titleEl.focus();
   });
 
+
+  // ── Drop zone accessibility ───────────────────────────────────────────
+  const dropZoneEl = document.getElementById('drop-zone');
+  const fileInputEl = document.getElementById('file-input');
+  if (dropZoneEl && fileInputEl) {
+    dropZoneEl.addEventListener('click', () => fileInputEl.click());
+    dropZoneEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        fileInputEl.click();
+      }
+    });
+  }
+
   // ── Seed note ───────────────────────────────────────────────────────
   (function renderSeedNote() {
     const parts = [];


### PR DESCRIPTION
* 💡 **What:** Added keyboard accessibility (Enter/Space) and explicit click handling to the `#drop-zone` file upload element.
* 🎯 **Why:** To allow keyboard-only and screen reader users to trigger the file upload dialog, ensuring the custom interactive element behaves like a native button.
* 📸 **Before/After:** No visual changes. Behaviorally, users can now focus the drop zone via Tab and press Enter or Space to open the file dialog.
* ♿ **Accessibility:** Fixes a critical keyboard accessibility gap where a `role="button"` element could not be activated without a mouse pointer.

---
*PR created automatically by Jules for task [8428690250287129683](https://jules.google.com/task/8428690250287129683) started by @jnorthrup*