### PR TITLE
🎨 Palette: Add contextual ARIA labels to Kanban cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 ## 2025-01-22 - Contextual ARIA labels for grouped dynamic buttons
 **Learning:** Buttons created dynamically within grouped structures (like Kanban board columns) often have generic visible text like "+ New" or "Add". While visual users infer context from the surrounding column or list grouping, screen reader users exploring by tab order or elements list lose this visual context, hearing only "Add, button".
 **Action:** When creating interactive elements inside visual groupings, dynamically generate a contextual `aria-label` that includes the grouping's name (e.g., `addBtn.setAttribute('aria-label', 'Add new card to ' + col.name);`) to restore context for assistive technologies.
+## 2025-01-22 - Contextual ARIA labels for interactive Kanban cards
+**Learning:** Kanban cards that double as buttons (e.g., clicking moves them to the next column) are disorienting for screen reader users if they lack context. A screen reader will just read the card's text, without indicating its current status/column or what action activating it performs.
+**Action:** When creating interactive items like Kanban cards, dynamically generate an `aria-label` that includes the card's name, its current column, and the action triggered upon interaction (e.g., "Move card 'Task' from 'To Do' to 'In Progress'").

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -514,6 +514,10 @@
         cardEl.className = 'board-card' + (col.id === 'done' ? ' done-card' : '');
         cardEl.role = 'button';
         cardEl.tabIndex = 0;
+        const order = state.board.columns.map((c) => c.id);
+        const nextColId = order[(order.indexOf(card.column) + 1) % order.length];
+        const nextColName = state.board.columns.find((c) => c.id === nextColId)?.name || 'next column';
+        cardEl.setAttribute('aria-label', `Move card '${card.title}' from '${col.name}' to '${nextColName}'`);
         const title = document.createElement('div');
         title.className = 'board-card-title';
         title.textContent = card.title;


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to Kanban cards that explain their current column and the action that will occur when clicked (moving to the next column).
🎯 Why: Screen reader users previously heard only the card title when focusing on it, with no context about its current status (column) or the fact that activating it moves it.
📸 Before/After: Visuals remain unchanged. Screen readers now read, for example, "Move card 'Task 1' from 'To Do' to 'In Progress'".
♿ Accessibility: Significantly improves Kanban board usability for assistive technologies.

---
*PR created automatically by Jules for task [17164243292451837872](https://jules.google.com/task/17164243292451837872) started by @jnorthrup*