### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded waitFor DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** The codebase was using `java.security.SecureRandom.getInstanceStrong()` to generate random bytes for temporary passwords and peer IDs.
 **Learning:** On Linux/Unix systems, `getInstanceStrong()` often defaults to the blocking `/dev/random` pool. If system entropy is depleted, any thread calling `nextBytes()` on this instance will block indefinitely, leading to a Denial of Service (DoS) and application hang.
 **Prevention:** Use the default `SecureRandom()` constructor instead. It utilizes the non-blocking CSPRNG (`/dev/urandom`), which is cryptographically strong enough for general application use and immune to entropy-depletion blocking.
+
+## 2023-11-20 - [Denial of Service via Unbounded waitFor]
+**Vulnerability:** Found `waitFor()` being called on a `Process` without a timeout in `JvmProcessOperations.kt`.
+**Learning:** `Process.waitFor()` without a timeout can lead to thread starvation and Denial of Service (DoS) if the subprocess hangs. This violates the "Fail securely" and "Do not expose system resources" principles.
+**Prevention:** Always use bounded `waitFor(timeout, TimeUnit)` and explicitly terminate the process via `destroyForcibly()` if the timeout occurs.

--- a/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/userspace/nio/channels/spi/JvmProcessOperations.kt
@@ -49,7 +49,13 @@ class JvmProcessOperations : ProcessOperations {
                 stderrOut.toByteArray()
             }
 
-            val exitCode = proc.waitFor()
+            // Security: Prevent thread starvation and DoS by using bounded waitFor
+            val finished = proc.waitFor(60, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) {
+                proc.destroyForcibly()
+                throw java.util.concurrent.TimeoutException("Process timed out: $command")
+            }
+            val exitCode = proc.exitValue()
             ProcessResult(exitCode, stdoutDeferred.await(), stderrDeferred.await())
         } }
     }


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: `JvmProcessOperations.kt` used an unbounded `Process.waitFor()` which could block threads indefinitely if a subprocess hung.
* 🎯 Impact: Potential thread starvation and Denial of Service (DoS).
* 🔧 Fix: Replaced unbounded `waitFor()` with a bounded wait of 60 seconds and forcefully terminated the process if the timeout is reached. Appended the learning to the Sentinel journal.
* ✅ Verification: Ran `./gradlew :jvmTest` and verified that no regressions were introduced.

---
*PR created automatically by Jules for task [470739124799492774](https://jules.google.com/task/470739124799492774) started by @jnorthrup*