### PR TITLE
Implement T11: Guest VM fidelity (Polyglot)

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutEvent.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/pointcut/PointcutEvent.kt
@@ -9,10 +9,13 @@ data class PointcutEvent(
     val target: Any?,
     val propertyName: String,
     val newValue: Any?,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val sourcePath: String? = null,
+    val line: Int = -1,
+    val column: Int = -1,
+    val isRoot: Boolean = false
 ) {
     fun toFieldSynapse(): FieldSynapse {
-        require(vmFacet == VmFacet.GRAAL_PYTHON) { "Expected GRAAL_PYTHON, got $vmFacet" }
         val methodIdx = TypedefProductionSystem.InternPool.intern(coordinate)
         val opcode = FieldSynapse.OP_L_GET.toByte()
         val cHash = TypedefProductionSystem.callsiteHash(opcode, methodIdx, 0)

--- a/src/jvmMain/kotlin/borg/trikeshed/pointcut/SubgraalPointcutRunner.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/pointcut/SubgraalPointcutRunner.kt
@@ -6,9 +6,13 @@ import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.HostAccess
 import org.graalvm.polyglot.ResourceLimits
 import org.graalvm.polyglot.Source
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import org.graalvm.polyglot.management.ExecutionEvent
 import org.graalvm.polyglot.management.ExecutionListener
 import java.io.InputStream
+import java.util.concurrent.ConcurrentHashMap
 import java.io.OutputStream
 
 class SubgraalPointcutRunner(
@@ -17,6 +21,19 @@ class SubgraalPointcutRunner(
     errStream: OutputStream = System.err,
     inStream: InputStream = System.`in`
 ) : AutoCloseable {
+
+    private val _events = MutableSharedFlow<PointcutEvent>(extraBufferCapacity = 10000)
+    val events: SharedFlow<PointcutEvent> = _events.asSharedFlow()
+
+    private val armedPaths = ConcurrentHashMap.newKeySet<String>()
+
+    fun arm(path: String) {
+        armedPaths.add(path)
+    }
+
+    fun disarm(path: String) {
+        armedPaths.remove(path)
+    }
 
     private val context: Context = Context.newBuilder("python", "js")
         .allowHostAccess(HostAccess.NONE)
@@ -46,7 +63,10 @@ class SubgraalPointcutRunner(
     private val listener = ExecutionListener.newBuilder()
         .onEnter(::handleEventEnter)
         .onReturn(::handleEventReturn)
-        .expressions(true)
+        .statements(true)
+        .roots(true)
+        .collectReturnValue(true)
+        .sourceFilter { armedPaths.isEmpty() || it.path in armedPaths }
         .attach(context.engine)
 
     private fun handleEventEnter(event: ExecutionEvent) {
@@ -60,14 +80,30 @@ class SubgraalPointcutRunner(
     private fun handleEvent(event: ExecutionEvent, isEnter: Boolean) {
         val phase = if (isEnter) 0.toByte() else 1.toByte()
 
-        // Since we are restricted to Polyglot ExecutionListener and cannot reliably filter or map
-        // AST tags directly without Truffle API integration (which is not configured for this project),
-        // we'll record generic expression evaluation events as L_GET to avoid fragile string parsing heuristics.
+        val location = event.location
+        val source = location?.source
+        val languageId = source?.language ?: "python"
+
+        val vmFacet = VmFacet.values().find { it.id == languageId } ?: VmFacet.GRAAL_PYTHON
+
+        val rootName = event.rootName ?: "unknown"
+        val pointcutEvent = PointcutEvent(
+            vmFacet = vmFacet,
+            coordinate = rootName,
+            target = null,
+            propertyName = "",
+            newValue = if (!isEnter) event.returnValue?.takeIf { !it.isNull }?.toString() else null,
+            timestamp = System.currentTimeMillis(),
+            sourcePath = source?.path,
+            line = location?.startLine ?: -1,
+            column = location?.startColumn ?: -1,
+            isRoot = event.isRoot
+        )
+        _events.tryEmit(pointcutEvent)
 
         val opcode = FieldSynapse.OP_L_GET.toByte()
 
-        val name = event.rootName ?: "expr"
-        val methodIdx = TypedefProductionSystem.InternPool.intern(name)
+        val methodIdx = TypedefProductionSystem.InternPool.intern(rootName)
 
         val templateIdx = when (opcode.toInt() and 0xFF) {
             FieldSynapse.OP_L_GET -> if (isEnter) FieldSynapse.TPL_BEFORE_GET else FieldSynapse.TPL_AFTER_GET

--- a/src/jvmTest/kotlin/borg/trikeshed/pointcut/SubgraalPointcutLocationTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/pointcut/SubgraalPointcutLocationTest.kt
@@ -1,0 +1,51 @@
+package borg.trikeshed.pointcut
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SubgraalPointcutLocationTest {
+
+    @Test
+    fun testStatementsAndRoots() = runTest(UnconfinedTestDispatcher()) {
+        try {
+            Class.forName("org.graalvm.polyglot.Engine")
+        } catch (e: ClassNotFoundException) {
+            assumeTrue(false, "GraalVM not resolvable on classpath")
+        }
+
+        val runner = SubgraalPointcutRunner()
+        val events = mutableListOf<PointcutEvent>()
+
+        val job = launch {
+            runner.events.collect { events.add(it) }
+        }
+
+        runner.use { r ->
+            r.eval("python", """
+                def foo():
+                    x = 1
+                    y = 2
+                    return x + y
+                foo()
+            """.trimIndent())
+        }
+
+        job.cancel()
+
+        assertTrue(events.size >= 2, "Should have at least 2 events")
+        val lines = events.map { it.line }.filter { it != -1 }.distinct()
+        assertTrue(lines.size >= 2, "Events should be on distinct lines")
+
+        val rootEvents = events.filter { it.isRoot }
+        assertTrue(rootEvents.isNotEmpty(), "Should have root events")
+        rootEvents.forEach {
+            assertTrue(it.isRoot, "Root event must have isRoot=true")
+        }
+    }
+}


### PR DESCRIPTION
Implement T11: Guest VM fidelity, step 1 — locations + statements + source filter (polyglot SDK only).

Do:
- Listener: `.statements(true).roots(true)` instead of `.expressions(true)`; `.collectReturnValue(true)`;
  `.sourceFilter { armedPaths.isEmpty() || it.path in armedPaths }` with `fun arm(path)`/`disarm(path)`.
- `handleEvent`: read `event.location` (`source.path`, `startLine`, `startColumn`) and `event.rootName`; keep publishing
  FieldSynapse for compatibility but ALSO expose `val events: SharedFlow<PointcutEvent>`; `PointcutEvent` gains
  `sourcePath: String?, line: Int, column: Int, isRoot: Boolean` (defaults keep existing call sites compiling);
  remove the hard-coded GRAAL_PYTHON in `toFieldSynapse()` (use `vmFacet`).
- Remove the "everything is L_GET" comment block; derive phase from enter/return.
- Test: eval a 3-line Python snippet; assert ≥2 events with distinct lines and that root events have isRoot=true.
Gate: JVM green; `jvmTest --tests '*.SubgraalPointcutLocationTest'` passes.

---
*PR created automatically by Jules for task [15114371446364554947](https://jules.google.com/task/15114371446364554947) started by @jnorthrup*