### PR TITLE
T09: ReteFactRule — let rules match facts, not only causal nodes

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/dag/ReteAgent.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/dag/ReteAgent.kt
@@ -49,6 +49,17 @@ object ReteAgent {
         val agentId: String,
     )
 
+    data class ReteFactRule(
+        val name: String,
+        val predicate: (ReteFact) -> Boolean,
+        val transform: (ReteFact) -> Fire,
+    )
+
+    data class FactAgent(
+        val job: Job,
+        val sink: Channel<ReteFact>,
+    )
+
     /**
      * Result of [run]: the agent's [Job] and the [Channel] used to feed it
      * nodes. Callers push a node into [sink] every time they call
@@ -83,8 +94,31 @@ object ReteAgent {
         return Agent(job = job, sink = sink)
     }
 
+    fun runFacts(
+        rules: List<ReteFactRule>,
+        scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        agentId: String = "rete-fact-agent",
+        onFire: (Fire) -> Unit,
+    ): FactAgent {
+        val sink = Channel<ReteFact>(capacity = Channel.UNLIMITED)
+        val job = scope.launch {
+            for (fact in sink) {
+                for (rule in rules) {
+                    if (rule.predicate(fact)) {
+                        onFire(rule.transform(fact).copy(agentId = agentId))
+                    }
+                }
+            }
+        }
+        return FactAgent(job = job, sink = sink)
+    }
+
     /** Cancel [agent.job]. The [Agent.sink] is closed by the caller if desired. */
     fun stop(agent: Agent) {
+        agent.job.cancel()
+    }
+
+    fun stop(agent: FactAgent) {
         agent.job.cancel()
     }
 }

--- a/src/commonTest/kotlin/borg/trikeshed/dag/ReteFactRuleTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/dag/ReteFactRuleTest.kt
@@ -1,0 +1,136 @@
+package borg.trikeshed.dag
+
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReteFactRuleTest {
+
+    private fun fact(
+        className: String,
+        bytecodeOffset: Int = 0,
+        timestamp: Long = 0L,
+        threadId: Long = 1L
+    ): ReteFact.DagFact {
+        val coord = DagCoordinate(
+            className = className,
+            methodName = "m",
+            bytecodeOffset = bytecodeOffset,
+            timestamp = timestamp,
+            threadId = threadId
+        )
+        return ReteFact.DagFact(
+            coordinate = coord,
+            event = BlackboardEvent.ClassLoad(coord, className, "loader")
+        )
+    }
+
+    @Test fun sinkFeedFiresRulesAsynchronously() = runTest {
+        val fired = Channel<ReteAgent.Fire>(capacity = Channel.UNLIMITED)
+        val agent = ReteAgent.runFacts(
+            rules = listOf(
+                ReteAgent.ReteFactRule(
+                    name = "any-fact",
+                    predicate = { true },
+                    transform = { f -> ReteAgent.Fire("any-fact", f.factId, "ckey", "ok", "x") },
+                ),
+            ),
+            scope = this,
+            onFire = { fired.trySend(it) },
+        )
+
+        agent.sink.send(fact("A"))
+        agent.sink.send(fact("B"))
+        agent.sink.send(fact("C"))
+        advanceUntilIdle()
+
+        val collected: List<ReteAgent.Fire> = withTimeoutOrNull(2_000) {
+            buildList {
+                repeat(3) {
+                    val fire = fired.receiveCatching().getOrNull() ?: return@buildList
+                    add(fire)
+                }
+            }
+        } ?: emptyList()
+
+        assertEquals(3, collected.size, "expected 3 fires, saw ${collected.size}")
+        assertEquals(setOf("dag:A@0", "dag:B@0", "dag:C@0"), collected.map { it.nodeId }.toSet())
+        assertTrue(collected.all { it.agentId == "rete-fact-agent" })
+        assertTrue(collected.all { it.ruleName == "any-fact" })
+
+        ReteAgent.stop(agent)
+        agent.job.join()
+    }
+
+    @Test fun classScopedRuleDoesNotFireForOtherClasses() = runTest {
+        val fired = Channel<ReteAgent.Fire>(capacity = Channel.UNLIMITED)
+        val agent = ReteAgent.runFacts(
+            rules = listOf(
+                ReteAgent.ReteFactRule(
+                    name = "class-A-only",
+                    predicate = { (it as? ReteFact.DagFact)?.coordinate?.className == "A" },
+                    transform = { f -> ReteAgent.Fire("class-A-only", f.factId, "ckey", "ok", "x") },
+                ),
+            ),
+            scope = this,
+            onFire = { fired.trySend(it) },
+        )
+
+        agent.sink.send(fact("A", 1))
+        agent.sink.send(fact("B", 1))
+        agent.sink.send(fact("A", 2))
+        advanceUntilIdle()
+
+        val collected: List<ReteAgent.Fire> = withTimeoutOrNull(2_000) {
+            buildList {
+                repeat(2) {
+                    val fire = fired.receiveCatching().getOrNull() ?: return@buildList
+                    add(fire)
+                }
+            }
+        } ?: emptyList()
+
+        assertEquals(2, collected.size)
+        assertEquals(setOf("dag:A@1", "dag:A@2"), collected.map { it.nodeId }.toSet())
+
+        ReteAgent.stop(agent)
+        agent.job.join()
+    }
+
+    @Test fun stopCancelsAgentAndStopsFiring() = runTest {
+        val fired = Channel<ReteAgent.Fire>(capacity = Channel.UNLIMITED)
+        val agent = ReteAgent.runFacts(
+            rules = listOf(
+                ReteAgent.ReteFactRule(
+                    name = "f",
+                    predicate = { true },
+                    transform = { f -> ReteAgent.Fire("f", f.factId, "ckey", "ok", "x") },
+                ),
+            ),
+            scope = this,
+            onFire = { fired.trySend(it) },
+        )
+
+        agent.sink.send(fact("A"))
+        advanceUntilIdle()
+        val first = withTimeoutOrNull(2_000) { fired.receive() } ?: error("agent never fired")
+        assertEquals("dag:A@0", first.nodeId)
+
+        ReteAgent.stop(agent)
+        agent.job.join()
+        this.coroutineContext.cancelChildren()
+
+        // After stop(), the agent's consumer is gone
+        agent.sink.trySend(fact("B"))
+        advanceUntilIdle()
+        val lateFire = fired.tryReceive().getOrNull()
+        assertEquals(null, lateFire, "agent must not fire more after stop()")
+    }
+}


### PR DESCRIPTION
Implemented `ReteFactRule` and `runFacts` to allow rete agent rules matching facts. Includes all corresponding unit tests.

---
*PR created automatically by Jules for task [11475220054252337838](https://jules.google.com/task/11475220054252337838) started by @jnorthrup*