### PR TITLE
🛡️ Sentinel: [Medium] Fix namespace token masking

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/userspace/containment/FusePathCanonicalizer.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/containment/FusePathCanonicalizer.kt
@@ -23,6 +23,17 @@ interface FusePathCanonicalizer {
 expect fun createFusePathCanonicalizer(instanceId: String): FusePathCanonicalizer
 
 /**
+ * Sanitizes a subvolume name by mapping arbitrary semantic names to deterministic
+ * pseudo-random content hashes (dir_0a4f91e/ style) using namespace token masking.
+ */
+fun sanitizeSubvolName(name: String, instanceId: String = "global"): String? {
+    if (name.startsWith("dir_") || name.startsWith("file_")) return name // Already canonicalized
+    if (name.isEmpty() || name == "." || name == "..") return null
+    if (name.contains("/") || name.contains("\\")) return null
+    return generateCanonicalName(name, isDirectory = true, instanceId = instanceId)
+}
+
+/**
  * Helper to generate the canonical name using SHA-256 truncation to 8 hex chars.
  */
 fun generateCanonicalName(originalName: String, isDirectory: Boolean, instanceId: String): String {


### PR DESCRIPTION
🛡️ Sentinel: [Medium] Fix namespace token masking

* 🚨 Severity: Medium
* 💡 Vulnerability: FUSE-based namespace canonicalization was not implemented for subvolume names. BtrfsUserspaceVolume only verified if names were valid (reject-only sanitization) but did not map them to content hashes.
* 🎯 Impact: Arbitrary subvolume names were not token masked into the dir_0a4f91e/ style hashes as required by the Legion Doc 04 Layer 1 containment policy.
* 🔧 Fix: Implemented `sanitizeSubvolName` in `FusePathCanonicalizer.kt` to map arbitrary semantic names to deterministic pseudo-random content hashes.
* ✅ Verification: Verified that tests pass and `generateCanonicalName` correctly handles token masking.

---
*PR created automatically by Jules for task [15378520016874031539](https://jules.google.com/task/15378520016874031539) started by @jnorthrup*