### PR TITLE
Refactor jules/ APIs to support Multiplatform commonMain

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/jules/BrainClient.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/BrainClient.kt
@@ -76,7 +76,7 @@ class BrainClient(
     }
 
     /** Last model id that answered a chat. */
-    @Volatile private var lastGoodModelId: String? = endpoints.firstOrNull()?.model
+    private var lastGoodModelId: String? = endpoints.firstOrNull()?.model
 
     /** True if at least one provider endpoint was discovered. */
     fun hasEndpoints(): Boolean = endpoints.isNotEmpty()
@@ -105,11 +105,13 @@ class BrainClient(
     /** Inner loop: called inside the outer timeout. */
     private suspend fun chatInner(messages: List<Pair<String, String>>, maxTokens: Int, temperature: Double): String {
         var lastError = "all providers exhausted"
-        val routed = withContext(Dispatchers.IO) { modelMux.route("conflict-resolve").a }
+        // IO is JVM/Native-only; revisit via PlatformHost
+        val routed = withContext(Dispatchers.Default) { modelMux.route("conflict-resolve").a }
         for (modelId in orderedModelIds(routed)) {
             val endpoint = endpointByModel[modelId] ?: continue
             val session = try {
-                withContext(Dispatchers.IO) { modelMux.session(modelId).getOrThrow() }
+                // IO is JVM/Native-only; revisit via PlatformHost
+                withContext(Dispatchers.Default) { modelMux.session(modelId).getOrThrow() }
             } catch (t: Throwable) {
                 lastError = "Brain ${endpoint.name} session failed: ${t.message}"
                 logError(endpoint.name, -1, t.message.orEmpty().take(500))

--- a/src/commonMain/kotlin/borg/trikeshed/jules/JulesRestClient.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/JulesRestClient.kt
@@ -45,7 +45,7 @@ class JulesRestClient(
                 .onSuccess { return it }
                 .onFailure { ex: Throwable ->
                     // Empty/truncated response body — treat as retryable server malfunction
-                    val isParseEx = ex is IndexOutOfBoundsException || ex is java.lang.StringIndexOutOfBoundsException
+                    val isParseEx = ex is IndexOutOfBoundsException
                     val is5xx = ex.message?.contains("500") == true || ex.message?.contains("502") == true ||
                             ex.message?.contains("503") == true || ex.message?.contains("504") == true
                     val is429 = ex.message?.contains("429") == true ||
@@ -69,7 +69,7 @@ class JulesRestClient(
             runCatching { transport().post(path, json) }
                 .onSuccess { return it }
                 .onFailure { ex: Throwable ->
-                    val isParseEx = ex is IndexOutOfBoundsException || ex is java.lang.StringIndexOutOfBoundsException
+                    val isParseEx = ex is IndexOutOfBoundsException
                     val is5xx = ex.message?.contains("500") == true || ex.message?.contains("502") == true ||
                             ex.message?.contains("503") == true || ex.message?.contains("504") == true
                     val is429 = ex.message?.contains("429") == true ||

--- a/src/commonMain/kotlin/borg/trikeshed/jules/ui/JulesBlackboardAdapter.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/ui/JulesBlackboardAdapter.kt
@@ -5,6 +5,7 @@ import borg.trikeshed.forge.blackboard.ForgeBlackboardView
 import borg.trikeshed.forge.blackboard.ForgeDomainSurface
 import borg.trikeshed.forge.blackboard.ForgeSurfaceGeometry
 import borg.trikeshed.jules.JulesRestClient
+import borg.trikeshed.userspace.nio.platform.spi.SystemOperations
 import kotlinx.datetime.Clock
 
 /**
@@ -78,7 +79,7 @@ data class JulesBlackboardSurface(
  * Override with system property: -Djules.blackboard.ttl.ms=<millis>
  */
 val TTL_MS: Long = run {
-    val override = System.getProperty("jules.blackboard.ttl.ms")
+    val override = SystemOperations.default.getProperty("jules.blackboard.ttl.ms")
     if (override != null) override.toLongOrNull() ?: 300_000L else 300_000L
 }
 
@@ -330,7 +331,7 @@ object JulesBlackboardAdapter {
     fun evictExpired(): List<String> {
         val now = Clock.System.now().toEpochMilliseconds()
         val evicted = sessionCache.entries.filter { (_, entry) -> now > entry.expiresAt }.map { it.key }
-        sessionCache.entries.removeIf { (_, entry) -> now > entry.expiresAt }
+        sessionCache.entries.removeAll { (_, entry) -> now > entry.expiresAt }
         return evicted
     }
 


### PR DESCRIPTION
This commit removes usage of JVM-specific APIs (`Dispatchers.IO`, `java.lang.StringIndexOutOfBoundsException`, `System.getProperty`, `removeIf`, `@Volatile`) inside the `jules/` module, ensuring successful `commonMain` compilation for all Kotlin Multiplatform targets, including JS.

---
*PR created automatically by Jules for task [4824867579784626474](https://jules.google.com/task/4824867579784626474) started by @jnorthrup*