### PR TITLE
Refactor oroboros reconcile elements and FunnelResidualMerge for commonMain purity

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
@@ -4,6 +4,7 @@ import borg.trikeshed.collections.associative.FunnelHashIndex
 import borg.trikeshed.job.ContentId
 import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.get
+import borg.trikeshed.cursor.monotonicNanoTime
 import borg.trikeshed.lib.j
 import borg.trikeshed.lib.size
 import borg.trikeshed.lib.α
@@ -566,7 +567,7 @@ object FunnelResidualMerge {
 
             if (changes.isNotEmpty()) {
                 val patchId = borg.trikeshed.patch.Blake3Hash.hash(
-                    ("pijul-merge-$s-${System.nanoTime()}").encodeToByteArray()
+                    ("pijul-merge-$s-${monotonicNanoTime()}").encodeToByteArray()
                 )
                 val patch = borg.trikeshed.pijul.Patch(
                     id = patchId,

--- a/src/commonMain/kotlin/borg/trikeshed/util/oroboros/element/GitReconcileElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/util/oroboros/element/GitReconcileElement.kt
@@ -5,6 +5,7 @@ import borg.trikeshed.context.AsyncContextElement
 import borg.trikeshed.context.AsyncContextKey
 import borg.trikeshed.context.ElementState
 import borg.trikeshed.lib.j
+import borg.trikeshed.cursor.currentTimeMillis
 import borg.trikeshed.memory.CouchIndexBridge
 import borg.trikeshed.util.oroboros.GitCouchGateway
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +33,7 @@ class GitReconcileElement(
         if (state != ElementState.CREATED) return
         super.open()
 
-        kotlinx.coroutines.CoroutineScope(supervisor).launch(Dispatchers.IO) {
+        kotlinx.coroutines.CoroutineScope(supervisor).launch(Dispatchers.Default) {
             var lastReconcledSha = ""
             while (isActive) {
                 // Wait for object-dirty signal, then reconcile
@@ -44,7 +45,7 @@ class GitReconcileElement(
                             forgeHome = forgeHome,
                             agentId = "oroboros",
                             revision = currentSha,
-                            sequence = System.currentTimeMillis(),
+                            sequence = currentTimeMillis(),
                         )
                         couchIndexBridge.indexReconciliation(
                             GitCouchGateway.GIT_PREFIX,
@@ -53,7 +54,8 @@ class GitReconcileElement(
                         lastReconcledSha = currentSha
                         println("[OROBOROS] Git→Couch reactive reconcile: ${snap.paths.size} paths @ ${currentSha.take(12)}")
                     }.onFailure {
-                        System.err.println("[OROBOROS] Git→Couch reconcile failed: ${it.message}")
+                        // note stdout
+                        println("[OROBOROS] Git→Couch reconcile failed: ${it.message}")
                     }
                 }
             }

--- a/src/commonMain/kotlin/borg/trikeshed/util/oroboros/element/WorktreeReconcileElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/util/oroboros/element/WorktreeReconcileElement.kt
@@ -5,6 +5,7 @@ import borg.trikeshed.context.AsyncContextElement
 import borg.trikeshed.context.AsyncContextKey
 import borg.trikeshed.context.ElementState
 import borg.trikeshed.lib.j
+import borg.trikeshed.cursor.currentTimeMillis
 import borg.trikeshed.memory.CouchIndexBridge
 import borg.trikeshed.util.oroboros.MemoryBridge
 import borg.trikeshed.util.oroboros.WorktreeCouchGateway
@@ -37,7 +38,7 @@ class WorktreeReconcileElement(
         if (state != ElementState.CREATED) return
         super.open()
 
-        kotlinx.coroutines.CoroutineScope(supervisor).launch(Dispatchers.IO) {
+        kotlinx.coroutines.CoroutineScope(supervisor).launch(Dispatchers.Default) {
             while (isActive) {
                 worktreeDirty.receive()
                 delay(250)
@@ -49,7 +50,7 @@ class WorktreeReconcileElement(
                         repoRoot = repoRoot,
                         agentId = "oroboros",
                         revision = currentSha,
-                        sequence = System.currentTimeMillis(),
+                        sequence = currentTimeMillis(),
                     )
                     couchIndexBridge.indexReconciliation(
                         WorktreeCouchGateway.WORKTREE_PREFIX,
@@ -61,7 +62,8 @@ class WorktreeReconcileElement(
                             "$bridged memory updates @ ${currentSha.take(12)}"
                     )
                 }.onFailure {
-                    System.err.println("[OROBOROS] Worktree→Couch reconcile failed: ${it.message}")
+                    // note stdout
+                    println("[OROBOROS] Worktree→Couch reconcile failed: ${it.message}")
                 }
             }
         }


### PR DESCRIPTION
This pull request resolves the T04 specification to refactor `GitReconcileElement.kt`, `WorktreeReconcileElement.kt`, and `FunnelResidualMerge.kt` to be purely `commonMain` compatible without relying on `java.*` or `System.*` APIs.

**Modifications:**
*   **GitReconcileElement & WorktreeReconcileElement:**
    *   Switched from `Dispatchers.IO` (which is JVM specific) to `Dispatchers.Default`.
    *   Replaced the usage of `System.currentTimeMillis()` with the Trikeshed-native `currentTimeMillis()` from `borg.trikeshed.cursor`.
    *   Substituted `System.err.println(...)` with standard `println(...)` along with an added `// note stdout` comment to denote the switch from standard error output to standard output in the shared logic.
*   **FunnelResidualMerge.kt:**
    *   Updated the `System.nanoTime()` call to use the Trikeshed-native `monotonicNanoTime()` method from `borg.trikeshed.cursor`.

These changes were validated by ensuring proper Kotlin JVM compilation (`./gradlew jvmMainClasses`) and a zero per-file count for compilation errors through JS Webpack. No logic flows or component architectures were disrupted.

---
*PR created automatically by Jules for task [585193293075177249](https://jules.google.com/task/585193293075177249) started by @jnorthrup*