### PR TITLE
Implement T06: Gate wiring and commonMain purity check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -314,6 +314,16 @@ kotlin {
     }
 }
 
+tasks.register<Exec>("commonMainPurity") {
+    group = "verification"
+    description = "Checks that commonMain is free of platform-specific bindings"
+    commandLine(project.layout.projectDirectory.file("scripts/common-purity.sh").asFile.absolutePath)
+}
+
+tasks.named("check") {
+    dependsOn("commonMainPurity")
+}
+
 // ─────────────────────────────────────────────────────────────────
 // Gradle Configuration Cache / Deprecation Suppression Hooks
 // ─────────────────────────────────────────────────────────────────

--- a/docs/gates.md
+++ b/docs/gates.md
@@ -1,0 +1,15 @@
+# TrikeShed Development Gates
+
+The following validation gates are run to ensure PRs are safe to merge:
+
+*   `jvmMainClasses`: Validates that the core JVM target compiles cleanly.
+*   `compileKotlinJs`: Validates that the JS target (specifically the web app layer) compiles cleanly. Ensures `drainExactArtifacts` and `commonMain` pure files remain agnostic to JVM-specific libraries.
+*   `commonMainPurity`: A custom shell verification task that guarantees the `commonMain` source set remains completely devoid of platform-specific bindings. It fails the build if `java.*`, `System.*`, `Dispatchers.IO`, `Charsets`, `String.format`, `java.nio`, `Selector`, `SocketChannel`, or incorrect uses of `@JvmInline` are found in `src/commonMain/**/*.kt` without an explicit `// purity:allow <reason>` bypass comment on the line.
+
+### Running Gates Manually
+
+```bash
+./gradlew jvmMainClasses --console=plain
+./gradlew compileKotlinJs --console=plain
+./gradlew commonMainPurity --console=plain
+```

--- a/scripts/common-purity.sh
+++ b/scripts/common-purity.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+FAILURES=0
+
+while IFS= read -r file; do
+    TMP1=$(mktemp)
+    TMP2=$(mktemp)
+
+    grep -nE "^import java\.|\\bSystem\.|Dispatchers\.IO|Charsets\.|\\.format\(|java\.nio|Selector|SocketChannel" "$file" | grep -v "// purity:allow" > "$TMP1" || true
+
+    if [ -s "$TMP1" ]; then
+        echo "Purity violation in $file:"
+        cat "$TMP1"
+        FAILURES=1
+    fi
+
+    if grep -q "@JvmInline" "$file" && ! grep -q "import kotlin\.jvm\.JvmInline" "$file"; then
+        grep -n "@JvmInline" "$file" | grep -v "// purity:allow" > "$TMP2" || true
+        if [ -s "$TMP2" ]; then
+            echo "Purity violation (@JvmInline without import kotlin.jvm.JvmInline) in $file:"
+            cat "$TMP2"
+            FAILURES=1
+        fi
+    fi
+
+    rm -f "$TMP1" "$TMP2"
+done < <(find src/commonMain -type f -name "*.kt")
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "Purity check failed."
+    # Command fails
+    sh -c 'exit 1'
+else
+    echo "Purity check passed."
+    # Command passes
+    sh -c 'exit 0'
+fi


### PR DESCRIPTION
Implemented T06 task requirements:
- Documented gates (`jvmMainClasses`, `compileKotlinJs`, `commonMainPurity`) in `docs/gates.md`.
- Wrote `scripts/common-purity.sh` to verify `commonMain` codebase purity, enforcing rules against `java.*`, `System.*`, `Dispatchers.IO`, `Charsets`, `String.format`, `java.nio`, `Selector`, `SocketChannel`, and un-imported `@JvmInline`.
- Integrated `commonMainPurity` into `build.gradle.kts` via an Exec task and depended it onto the `check` lifecycle task.

---
*PR created automatically by Jules for task [6554291967591514750](https://jules.google.com/task/6554291967591514750) started by @jnorthrup*