### PR TITLE
🎨 Palette: Add aria-selected to sheet tabs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,7 @@
 ## 2026-08-20 - Global keyboard handlers for custom buttons
 **Learning:** When using custom DOM elements (like \`div\` or \`span\`) as interactive buttons by adding \`role="button"\` and \`tabindex="0"\`, they do not natively respond to \`Enter\` or \`Space\` keys like standard \`<button>\` elements do. Adding individual \`keydown\` listeners to every custom button creates redundant code, risks inconsistency, and is easy to miss on new components.
 **Action:** Implement a global event delegation listener on the \`document\` for the \`keydown\` event. When \`Enter\` or \`Space\` is pressed, check if the \`e.target.getAttribute('role') === 'button'\`, and if so, call \`e.target.click()\`. This ensures all current and future custom buttons are automatically keyboard accessible without duplicate logic.
+
+## 2025-10-24 - Adding aria-selected to dynamic tab elements
+**Learning:** When dynamically generating components with `role="tab"`, adding an `active` CSS class is not enough for screen readers. Without the `aria-selected` attribute, screen reader users cannot tell which tab in the `tablist` is currently active.
+**Action:** Always pair visual active states (like `.active` classes) on `role="tab"` elements with `aria-selected="true"` or `aria-selected="false"` to ensure the active state is programmatically announced by assistive technologies.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -907,8 +907,10 @@
     let rootOf = cur; while (rootOf && rootOf.parent && sheetById[rootOf.parent]) rootOf = sheetById[rootOf.parent];
     rootSheets.forEach((sh) => {
       const b = document.createElement('button');
-      b.className = 'sheet-tab' + (rootOf && rootOf.id === sh.id ? ' active' : '');
+      const isActive = rootOf && rootOf.id === sh.id;
+      b.className = 'sheet-tab' + (isActive ? ' active' : '');
       b.setAttribute('role', 'tab');
+      b.setAttribute('aria-selected', isActive ? 'true' : 'false');
       b.textContent = sh.title;
       const n = document.createElement('span'); n.className = 'sheet-count'; n.textContent = sh.rows.length + ' × ' + sh.columns.length; b.appendChild(n);
       b.addEventListener('click', () => openSheet(sh.id));


### PR DESCRIPTION
💡 What: Added `aria-selected` attribute to dynamic tab elements in the sheet view.
🎯 Why: Screen readers need `aria-selected` to properly announce which tab is currently active. The existing `active` class is only a visual indicator.
📸 Before/After: No visual change.
♿ Accessibility: Ensures that screen reader users can distinguish the selected tab from unselected ones.

---
*PR created automatically by Jules for task [10468224395341971995](https://jules.google.com/task/10468224395341971995) started by @jnorthrup*