### PR TITLE
⚡ Bolt: Use inline Series.forEach instead of toList().forEach to avoid allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,3 +90,6 @@
 ## 2024-12-10 - Avoid O(N) boxing allocation when comparing ByteArray
 **Learning:** Comparing ByteArray objects using .toList() == other.toList() causes an O(N) memory allocation because each Byte gets boxed into an object within a new ArrayList. This can introduce unexpected GC pressure, especially when frequently hashing or comparing proofs.
 **Action:** Replace a.toList() == b.toList() on ByteArray with a.contentEquals(b) for a fast, zero-allocation byte-level comparison.
+## 2024-05-18 - Avoid O(N) allocation when iterating Series
+**Learning:** In Kotlin, using `.toList().forEach` to iterate over custom data structures like `Series` causes an unnecessary O(N) intermediate `ArrayList` allocation.
+**Action:** Use the `inline` extension `.forEach` directly on the `Series` (e.g. `series.forEach { ... }`) to avoid both list and lambda heap allocations in hot paths like network parsing.

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew :jvmTest --tests 'borg.trikeshed.htx.HtxRequestTest'

--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxElement.kt
@@ -168,7 +168,7 @@ open class HtxElement(
         // Bolt: Prevent intermediate List allocations with filterIsInstance<T>()
         // and avoid O(F*S) scaling by fast-path checking subscriber presence first
         if (fanoutSubscribers.any { it is FanoutEventSubscriber }) {
-            frames.toList().forEach { frame ->
+            frames.forEach { frame ->
                 fanoutSubscribers.forEach {
                     if (it is FanoutEventSubscriber) {
                         it.onFanoutEvent(frame)

--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxReactorElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxReactorElement.kt
@@ -308,7 +308,7 @@ class HtxReactorElement(
         fd: Int,
         frames: TlsFrames,
     ) {
-        frames.toList().forEach { frame ->
+        frames.forEach { frame ->
             when (frame.stage) {
                 TlsFlowStage.UPSTREAM_CIPHERTEXT,
                 TlsFlowStage.CLOSE_NOTIFY -> {

--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxRequest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxRequest.kt
@@ -129,7 +129,7 @@ fun HtxRequest.renderWireRequest(): String {
         append("Host: ")
         append(hostHeader)
         append("\r\n")
-        headers.toList().forEach { header ->
+        headers.forEach { header ->
             append(header.a)
             append(": ")
             append(header.b)

--- a/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lib/Series.kt
@@ -397,10 +397,10 @@ fun <B> Series<B>.dropLast(back: Int): Series<B> = get(0 until max(0, size - bac
 fun <B> Series<B>.take(exclusiveEnd: Int): Series<B> = get(0 until min(exclusiveEnd, size))
 
 //series foreachIndexed
-fun <T> Series<T>.forEachIndexed(action: (index: Int, T) -> Unit): Unit { var index = 0; for (item in this.view) action(index++, item) }
+inline fun <T> Series<T>.forEachIndexed(action: (index: Int, T) -> Unit): Unit { var index = 0; for (item in this.view) action(index++, item) }
 
 //series foreach
-fun <T> Series<T>.forEach(action: (T) -> Unit): Unit { for (item in this.view) action(item) }
+inline fun <T> Series<T>.forEach(action: (T) -> Unit): Unit { for (item in this.view) action(item) }
 
 fun <T> Series<T>.isEmpty(): Boolean = a == 0
 

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/TlsEndpoint.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/TlsEndpoint.kt
@@ -258,7 +258,7 @@ class TlsElement(
         // Bolt: Prevent intermediate List allocations with filterIsInstance<T>()
         // and avoid O(F*S) scaling by fast-path checking subscriber presence first
         if (fanoutSubscribers.any { it is FanoutEventSubscriber }) {
-            frames.toList().forEach { frame ->
+            frames.forEach { frame ->
                 fanoutSubscribers.forEach {
                     if (it is FanoutEventSubscriber) {
                         it.onFanoutEvent(frame)


### PR DESCRIPTION
💡 What: Made `Series.forEach` and `Series.forEachIndexed` inline, and replaced `frames.toList().forEach` and `headers.toList().forEach` with `frames.forEach` and `headers.forEach` in HtxElement, HtxRequest, HtxReactorElement, and TlsEndpoint. 
🎯 Why: Calling `.toList()` on a `Series` allocates an intermediate `ArrayList`, which creates unnecessary GC pressure during network frame and header parsing. Inline `forEach` eliminates both the list and lambda heap allocations. 
📊 Impact: Eliminates O(N) list allocations and O(1) lambda allocations per batch of frames/headers in hot reactive streams. 
🔬 Measurement: Ensure unit tests pass without errors; profiles of HtxElement.channelize should show reduced object allocations.

---
*PR created automatically by Jules for task [14813416382217667017](https://jules.google.com/task/14813416382217667017) started by @jnorthrup*