### PR TITLE
⚡ Bolt: [performance improvement] Avoid redundant list allocations in JulesPatchContinuity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -104,3 +104,6 @@
 ## 2024-05-24 - Avoiding intermediate List allocations in filter followed by forEach
 **Learning:** In Kotlin, chaining `.filter { ... }` and `.forEach { ... }` generates an intermediate `ArrayList` containing all matched elements, leading to unnecessary memory allocation and GC pressure, especially when the collection is large or processed frequently.
 **Action:** Iterate with `.forEach { if (condition(it)) { ... } }` to avoid intermediate list allocations and improve performance in hot paths.
+## 2025-02-18 - Avoid Unnecessary List Allocations on Iterables
+**Learning:** Calling `.toList()` on an `Iterable` that is already a collection (like a `List`) creates a full copy, allocating an intermediate `ArrayList` and incurring an O(N) penalty.
+**Action:** When a function accepts an `Iterable<T>` but needs a `List<T>` (e.g. for indexed access or multiple iterations), use safe casting to avoid the copy if it's already a list: `iterable as? List<T> ?: iterable.toList()`.

--- a/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
@@ -67,7 +67,7 @@ sealed interface JulesReportSettlementSelection {
  * overrides this monotonicity gate without losing either CAS object.
  */
 fun selectJulesPatchForDrain(causes: Iterable<JulesCause>): JulesPatchDrainSelection {
-    val causalList = causes.toList()
+    val causalList = causes as? List<JulesCause> ?: causes.toList()
     val observations = causalList.filterIsInstance<JulesCause.PatchSnapshotObserved>()
     if (observations.isEmpty()) return JulesPatchDrainSelection.Unobserved
 
@@ -158,7 +158,7 @@ fun selectJulesPatchForDrain(causes: Iterable<JulesCause>): JulesPatchDrainSelec
  * not interpreted as "no-op", "already landed", or any other disposition.
  */
 fun selectJulesReportForSettlement(causes: Iterable<JulesCause>): JulesReportSettlementSelection {
-    val causalList = causes.toList()
+    val causalList = causes as? List<JulesCause> ?: causes.toList()
     val reports = causalList.filterIsInstance<JulesCause.AgentReportObserved>()
     if (reports.isEmpty()) return JulesReportSettlementSelection.Unobserved
 


### PR DESCRIPTION
💡 What: Replaced unconditional `.toList()` calls on Iterables with safe casting `as? List<T> ?: toList()` in JulesPatchContinuity.kt.
🎯 Why: In `selectJulesPatchForDrain` and `selectJulesReportForSettlement`, `causes` is passed as an Iterable but is often already a List in practice. Calling `.toList()` on an Iterable that is a Collection creates a full copy, allocating an intermediate ArrayList and incurring an O(N) penalty.
📊 Impact: Eliminates unnecessary O(N) List allocations during patch and report selection, reducing memory pressure and garbage collection overhead in the flywheel loop.
🔬 Measurement: Verify reduction in ArrayList allocations during `FlywheelDriver` drain passes via profiler or by confirming standard test suite passage.

---
*PR created automatically by Jules for task [12238614578870150638](https://jules.google.com/task/12238614578870150638) started by @jnorthrup*