### PR TITLE
🛡️ Sentinel: [LOW] Add Prepared Statement to prevent potential SQL injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** The codebase was using `java.security.SecureRandom.getInstanceStrong()` to generate random bytes for temporary passwords and peer IDs.
 **Learning:** On Linux/Unix systems, `getInstanceStrong()` often defaults to the blocking `/dev/random` pool. If system entropy is depleted, any thread calling `nextBytes()` on this instance will block indefinitely, leading to a Denial of Service (DoS) and application hang.
 **Prevention:** Use the default `SecureRandom()` constructor instead. It utilizes the non-blocking CSPRNG (`/dev/urandom`), which is cryptographically strong enough for general application use and immune to entropy-depletion blocking.
+
+## 2025-05-24 - SQL Injection Prevention
+**Vulnerability:** In `HermesDonorTrace.kt`, queries to the `tasks` table were constructed manually via `createStatement().executeQuery(...)`. Although currently executing a hardcoded `SELECT id, title, body, status, parent_ids FROM tasks ORDER BY id ASC` string, constructing statements statically leaves room for future SQL injections if filters/where clauses are appended dynamically without migration to safe query methods.
+**Learning:** Hardcoded query strings in `executeQuery` expose applications to a high risk of SQL injection if developer changes ever append user parameters. Using prepared statements prevents injection via parameter binding separation.
+**Prevention:** Always use `prepareStatement` over `createStatement` when executing queries, even for initially parameter-less queries, to ensure the safest default posture.

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
@@ -58,8 +58,8 @@ object HermesDonorTrace {
 
         var sourceDescription = ""
         dataSource.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                val rs = stmt.executeQuery("SELECT id, title, body, status, parent_ids FROM tasks ORDER BY id ASC")
+            conn.prepareStatement("SELECT id, title, body, status, parent_ids FROM tasks ORDER BY id ASC").use { stmt ->
+                val rs = stmt.executeQuery()
                 val sb = java.lang.StringBuilder()
                 sb.append("TARGET: SQLite Donor Replay\n\n6. Work packages\n\n")
 


### PR DESCRIPTION
Added defense in depth security enhancement to prevent future SQL injections by converting `createStatement()` to `prepareStatement()` in `HermesDonorTrace.kt`. Documented the learning in `.jules/sentinel.md`. All unit tests (`:jvmTest` and `:jvmMainClasses`) passed.

---
*PR created automatically by Jules for task [2315385524314975953](https://jules.google.com/task/2315385524314975953) started by @jnorthrup*