### PR TITLE
⚡ Bolt: Remove redundant intermediate list allocation in JsIsamOperations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,3 +90,7 @@
 ## 2024-12-10 - Avoid O(N) boxing allocation when comparing ByteArray
 **Learning:** Comparing ByteArray objects using .toList() == other.toList() causes an O(N) memory allocation because each Byte gets boxed into an object within a new ArrayList. This can introduce unexpected GC pressure, especially when frequently hashing or comparing proofs.
 **Action:** Replace a.toList() == b.toList() on ByteArray with a.contentEquals(b) for a fast, zero-allocation byte-level comparison.
+
+## 2026-08-22 - Avoid redundant `.toList()` allocation after `.map { ... }` on Iterables
+**Learning:** In Kotlin, the `.map` extension function on Iterables natively returns a `List`. Chaining `.toList()` immediately after `.map { ... }` (e.g., `iterable.map { ... }.toList()`) is fully redundant. This practice negatively impacts performance by triggering a secondary, unnecessary shallow copy allocation of the entire collection, increasing GC pressure and CPU overhead for larger collections.
+**Action:** Remove trailing `.toList()` calls from functional `.map { ... }` chains operating on Iterables or standard collections.

--- a/src/jsMain/kotlin/borg/trikeshed/isam/JsIsamOperations.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/isam/JsIsamOperations.kt
@@ -140,7 +140,7 @@ class JsIsamOperations : IsamOperations {
             reader.open()
             reader.constraints
         } else {
-            val rows = msf.map { transform?.invoke(it) ?: it }.toList()
+            val rows = msf.map { transform?.invoke(it) ?: it }
             val cursor = rows.toSeries()
             write(cursor, datafilename, varChars, useMonocursorGroupings)
             return


### PR DESCRIPTION
💡 What: Removed a redundant `.toList()` call after an `Iterable.map { ... }` block in `JsIsamOperations.kt`.
🎯 Why: Kotlin's `.map` extension on Iterables naturally returns a `List`. Appending `.toList()` to the chain immediately allocates a second, shallow copy of the entire collection, which creates unnecessary GC pressure and CPU overhead for larger collections.
📊 Impact: Eliminates an `O(N)` allocation and array copy when processing ISAM operations in the JS backend.
🔬 Measurement: Verify build succeeds (`./gradlew :jvmMainClasses`) and `JsIsamOperations.kt` operates correctly without regression.

---
*PR created automatically by Jules for task [2879747929967581506](https://jules.google.com/task/2879747929967581506) started by @jnorthrup*