### PR TITLE
🎨 Palette: Add aria-current to active view navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -68,3 +68,6 @@
 **Learning:** For elements handling drag-and-drop file ingestions natively created as semantic `role="button"` placeholders like `.drop-zone` in index.html templates, ensuring they receive `:focus-visible` styling is crucial for keyboard users attempting to access upload functions.
 **Action:** Always add interactive form and UI upload containers defined with tabindex to the globally applied `:focus-visible` CSS selector lists.
 >>>>>>> theirs
+## 2025-02-23 - Announcing active states for single-page application navigation
+**Learning:** Single-page applications often use custom buttons to switch views instead of actual `<a>` tags with `href`s. While visual users see an active state (like a background color change), screen reader users hear no change in state unless explicitly announced.
+**Action:** When building custom view switchers (like tabs or navigation sidebar items) that aren't native links, always apply `aria-current="page"` via JavaScript when the view changes.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1123,7 +1123,15 @@
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) { el.hidden = k !== view; btn.classList.toggle('active', k === view); }
+    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+      el.hidden = k !== view;
+      btn.classList.toggle('active', k === view);
+      if (k === view) {
+        btn.setAttribute('aria-current', 'page');
+      } else {
+        btn.removeAttribute('aria-current');
+      }
+    }
     if (view === 'board') renderBoard();
     if (view === 'graph') { setGraphMode(graphMode); }
     if (view === 'sheet') renderSheet();


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the active view button in the topbar (Document, Board, Graph, etc.).
🎯 Why: Without this, screen reader users cannot tell which view they are currently on when navigating through the buttons.
📸 Before/After: Visuals are unchanged. The underlying DOM now sets `aria-current="page"` on the active button and removes it from the rest.
♿ Accessibility: Improves accessibility by adhering to WCAG guidelines for current state announcement.

---
*PR created automatically by Jules for task [9360916549134348095](https://jules.google.com/task/9360916549134348095) started by @jnorthrup*