### PR TITLE
⚡ Bolt: [performance improvement] optimize sequence anti-pattern in rete working memory query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -133,3 +133,6 @@
 **Learning:** Calling `.toList()` on an `Iterable` that is already a collection (like a `List`) creates a full copy, allocating an intermediate `ArrayList` and incurring an O(N) penalty.
 **Action:** When a function accepts an `Iterable<T>` but needs a `List<T>` (e.g. for indexed access or multiple iterations), use safe casting to avoid the copy if it's already a list: `iterable as? List<T> ?: iterable.toList()`.
 >>>>>>> theirs
+## 2026-08-25 - Avoid Sequence Overhead Before Terminal List Operations
+**Learning:** In Kotlin hot paths, using `.asSequence()` on a collection is only beneficial when followed by short-circuiting operations. Chaining `.asSequence()` before operations that ultimately collect into a list (like `.toList()` or `.sortedWith()`) is a performance anti-pattern. The object allocation overhead for the `Sequence` wrapper and its stateful lazy iterators outweighs the cost of eager direct collection.
+**Action:** When eliminating intermediate allocations caused by chained collection operations (like `.asSequence().map { ... }.filter { ... }.sortedWith(...)`), replace the sequence chain with a direct `for` loop that conditionally appends to an `ArrayList` and sorts in-place. Do not wrap collections in sequences just to immediately collect them back into a list.

--- a/src/commonMain/kotlin/borg/trikeshed/dag/ReteWorkingMemory.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/dag/ReteWorkingMemory.kt
@@ -70,10 +70,15 @@ class ReteWorkingMemory {
     fun query(
         board: BlackboardContext,
         facet: Pair<String, Any?>,
-    ): List<ReteStoredFact> = current.entries()
-        .asSequence()
-        .map { it.second }
-        .filter { it.factId.partitionId == board.id && it.fields[facet.first] == facet.second }
-        .sortedWith(compareBy({ it.factId.partitionId }, { it.factId.localId }))
-        .toList()
+    ): List<ReteStoredFact> {
+        val results = ArrayList<ReteStoredFact>()
+        for (entry in current.entries()) {
+            val fact = entry.second
+            if (fact.factId.partitionId == board.id && fact.fields[facet.first] == facet.second) {
+                results.add(fact)
+            }
+        }
+        results.sortWith(compareBy({ it.factId.partitionId }, { it.factId.localId }))
+        return results
+    }
 }


### PR DESCRIPTION
💡 **What:** Optimized `ReteWorkingMemory.query` by replacing the lazy `.asSequence()` collection pipeline with a direct `for` loop and in-place `ArrayList` accumulation.
🎯 **Why:** The query method was using `.asSequence()` but ultimately collecting into a list via `.sortedWith()`. This is a performance anti-pattern because the overhead of sequence instantiation and lazy iterators outweighs the cost of direct collection, leading to unnecessary CPU overhead and garbage collection pressure in a hot path.
📊 **Impact:** Eliminates intermediate `Sequence`, iterator, and intermediate `List` allocations per query.
🔬 **Measurement:** Verify by running the `borg.trikeshed.dag.ReteWorkingMemoryTest` or performing a JVM allocation profile on the Rete query execution path.

---
*PR created automatically by Jules for task [17460665153341668083](https://jules.google.com/task/17460665153341668083) started by @jnorthrup*