### PR TITLE
🎨 Palette: Fix sheet tabs accessibility

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -926,7 +926,7 @@
       b.setAttribute('aria-selected', isActive ? 'true' : 'false');
       b.textContent = sh.title;
       const n = document.createElement('span'); n.className = 'sheet-count'; n.textContent = sh.rows.length + ' × ' + sh.columns.length; b.appendChild(n);
-      b.addEventListener('click', () => openSheet(sh.id));
+      b.addEventListener('click', () => { openSheet(sh.id); Array.from(sheetTabsEl.children).forEach(c => c.setAttribute('aria-selected', 'false')); b.setAttribute('aria-selected', 'true'); });
       sheetTabsEl.appendChild(b);
     });
     // breadcrumb = parent chain (zoom path)


### PR DESCRIPTION
💡 What: The UX enhancement added `aria-selected` property toggling to the dynamically generated sheet tabs, which ensures proper screen reader feedback.

🎯 Why: The dynamically generated sheet tabs only set the initial `aria-selected` state but did not toggle it on interaction, which left screen readers out-of-sync with the active tab. 

📸 Before/After: Visual changes were not made in this enhancement. 

♿ Accessibility: The sheet tabs are now properly identified as `role="tab"` and their state is properly toggled to provide accurate feedback.

---
*PR created automatically by Jules for task [17165305375167284602](https://jules.google.com/task/17165305375167284602) started by @jnorthrup*