### PR TITLE
⚡ Bolt: Remove `.asSequence()` allocation overhead in critical paths

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/jules/JulesRestClient.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/JulesRestClient.kt
@@ -212,18 +212,21 @@ class JulesRestClient(
     suspend fun activityTimeline(sessionId: String): ActivityTimeline {
         val raw = activityMaps(sessionId)
         val activityList = raw.mapIndexed { seq, m -> activityInfo(seq, m) }
-        val reportList = activityList.asSequence()
-            .filter { it.kind == "agentMessaged" && it.message.isNotEmpty() }
-            .mapIndexed { causalOrdinal, activity ->
-                ActivityReport(
-                    activityId = activity.id,
-                    activitySeq = activity.seq,
-                    causalOrdinal = causalOrdinal,
-                    createTime = activity.createTime,
-                    message = activity.message,
+        val reportList = ArrayList<ActivityReport>()
+        var causalOrdinal = 0
+        for (activity in activityList) {
+            if (activity.kind == "agentMessaged" && activity.message.isNotEmpty()) {
+                reportList.add(
+                    ActivityReport(
+                        activityId = activity.id,
+                        activitySeq = activity.seq,
+                        causalOrdinal = causalOrdinal++,
+                        createTime = activity.createTime,
+                        message = activity.message,
+                    )
                 )
             }
-            .toList()
+        }
         val activityPatches = raw.flatMapIndexed { seq, m ->
             val activityId = requireNotNull(
                 m["name"]?.toString()?.substringAfterLast('/')?.takeIf { it.isNotBlank() },

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/FlywheelDriver.kt
@@ -541,13 +541,13 @@ class FlywheelDriver(
             // Older drains predate WorkQueued. A later seed using that fallback
             // `session:<id>` identity would otherwise submit an already-drained
             // session as fresh Jules work. A real rework needs a new work id.
-            val closedSessionWorkIds = pendingCandidates.asSequence()
-                .filter { entry ->
-                    entry.workId.startsWith("session:") &&
-                        conductor.cards[entry.workId.removePrefix("session:")]?.drained == true
+            val closedSessionWorkIds = HashSet<String>()
+            for (entry in pendingCandidates) {
+                if (entry.workId.startsWith("session:") &&
+                    conductor.cards[entry.workId.removePrefix("session:")]?.drained == true) {
+                    closedSessionWorkIds.add(entry.workId)
                 }
-                .map { it.workId }
-                .toSet()
+            }
             val newlyReported = closedSessionWorkIds.count { reportedClosedSessionQueueEntries.add(it) }
             if (newlyReported != 0) {
                 println("[FLYWHEEL] DISPATCH-SKIP $newlyReported already-closed session queue item(s)")


### PR DESCRIPTION
💡 **What**: Replaced `.asSequence().filter { ... }.map { ... }.toList()` chains with direct `for` loops that conditionally add items to destination collections (ArrayList/HashSet) in `JulesRestClient.kt` and `FlywheelDriver.kt`.

🎯 **Why**: In Kotlin, adding `.asSequence()` before operations that ultimately collect back into a list/set is a performance anti-pattern. While sequences avoid intermediate collection allocations, they do so by allocating stateful lazy iterators and decorator sequence objects for every step. In hot paths, this object allocation and virtual dispatch overhead often outweighs the cost of direct collection.

📊 **Impact**: Reduces GC pressure by eliminating the instantiation of `Sequence` wrappers and their associated stateful iterators on every call to `activityTimeline` and the Flywheel dispatch loop.

🔬 **Measurement**: Verify via memory profiler. The `closedSessionWorkIds` and `reportList` creation will now show zero Sequence-related object allocations.

---
*PR created automatically by Jules for task [14739859870274764639](https://jules.google.com/task/14739859870274764639) started by @jnorthrup*