### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix predictable PRNG in WebSocket Handshake

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 >>>>>>> origin/sentinel/fix-json-unsafe-deserialization-13206169233468597183
 =======
 >>>>>>> theirs
+
+## 2024-06-25 - [Predictable PRNG in WebSocket Handshake]
+**Vulnerability:** The `generateKey()` method in `Rfc6455Handshake.kt` used a highly predictable linear shift-XOR algorithm seeded by the system clock (`Clock.System.now().toEpochMilliseconds()`) to generate the `Sec-WebSocket-Key`.
+**Learning:** Using predictable, time-based PRNGs for cryptographic nonces like `Sec-WebSocket-Key` makes the handshake susceptible to prediction or replay attacks. While the RFC 6455 states this key is not meant for authentication, it is meant to prove the request is actually a WebSocket request and to prevent caching proxy issues, so it should still be robustly random.
+**Prevention:** Always use standard, secure-by-default libraries for random number generation (e.g., `kotlin.random.Random.Default.nextBytes` or `SecureRandom`) instead of rolling custom cryptographic algorithms or using simple PRNGs.

--- a/src/commonMain/kotlin/borg/trikeshed/ws/Rfc6455Handshake.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/ws/Rfc6455Handshake.kt
@@ -36,19 +36,10 @@ object Rfc6455Handshake {
     /**
      * Generate a base64-encoded 16-byte nonce for `Sec-WebSocket-Key`.
      *
-     * Uses a simple shift-xor PRNG since `kotlin.random.Random` is available
-     * in commonMain.  For production, wire in a platform-secure RNG.
+     * Uses Kotlin's built-in `Random.Default` to generate the nonce.
      */
     fun generateKey(seed: Long = kotlinx.datetime.Clock.System.now().toEpochMilliseconds()): String {
-        val bytes = ByteArray(16)
-        var s = seed
-        for (i in bytes.indices) {
-            s = s xor (s shl 13)
-            s = s xor (s ushr 7)
-            s = s xor (s shl 17)
-            bytes[i] = (s and 0xFF).toByte()
-        }
-        return bytes.encodeBase64()
+        return kotlin.random.Random.Default.nextBytes(16).encodeBase64()
     }
 
     /**

--- a/test_script.kt
+++ b/test_script.kt
@@ -1,8 +1,0 @@
-import borg.trikeshed.userspace.containment.StigmergicProtocolDecoder
-import borg.trikeshed.userspace.containment.PatchData
-
-fun main() {
-    val decoder = StigmergicProtocolDecoder()
-    val p1 = PatchData("swarm_1", "swarm_1", "test")
-    println(decoder.decode(listOf(p1)))
-}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `generateKey()` method in `Rfc6455Handshake.kt` used a predictable linear shift-XOR algorithm seeded by the system clock (`Clock.System.now().toEpochMilliseconds()`) to generate the `Sec-WebSocket-Key`.
🎯 Impact: Using predictable, time-based PRNGs for cryptographic nonces like `Sec-WebSocket-Key` makes the handshake susceptible to prediction attacks, potentially affecting the integrity of the connection.
🔧 Fix: Replaced the custom XOR-shift algorithm with Kotlin's built-in `kotlin.random.Random.Default.nextBytes(16)`, which provides a more robust and standard pseudo-random number generation.
✅ Verification: Ran `./gradlew :jvmMainClasses --no-daemon` and `./gradlew :jvmTest --tests '*Rfc6455HandshakeTest*' --no-daemon` to ensure tests passed and the codebase compiles without issues.

---
*PR created automatically by Jules for task [80162557605960832](https://jules.google.com/task/80162557605960832) started by @jnorthrup*