### PR TITLE
⚡ Bolt: optimize `retained` iteration in JulesPatchContinuity

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
@@ -154,11 +154,18 @@ fun selectJulesPatchForDrain(causes: Iterable<JulesCause>): JulesPatchDrainSelec
         return JulesPatchDrainSelection.Selected(latest, reviewed = false)
     }
 
-    val retained = observations
-        .asSequence()
-        .filter { it.reviewCandidate && it.causalOrdinal < latest.causalOrdinal }
-        .maxWithOrNull(snapshotCausalOrder)
-        ?: return JulesPatchDrainSelection.ReviewRequired(latest, latest, latest.missingFromCandidate)
+    var retained: JulesCause.PatchSnapshotObserved? = null
+    for (obs in observations) {
+        if (obs.reviewCandidate && obs.causalOrdinal < latest.causalOrdinal) {
+            if (retained == null || snapshotCausalOrder.compare(obs, retained) > 0) {
+                retained = obs
+            }
+        }
+    }
+
+    if (retained == null) {
+        return JulesPatchDrainSelection.ReviewRequired(latest, latest, latest.missingFromCandidate)
+    }
     return JulesPatchDrainSelection.ReviewRequired(
         retainedCandidate = retained,
         regressedLatest = latest,


### PR DESCRIPTION
💡 **What**: Replaced the sequence filter and `maxWithOrNull` block in `JulesPatchContinuity.kt`'s `selectJulesPatchForDrain` function with a zero-allocation `for` loop.
🎯 **Why**: Eliminate intermediate Kotlin `Sequence`, `FilteringSequence`, and iterator allocations in a loop path, reducing unnecessary GC overhead.
📊 **Impact**: Micro-optimization reducing heap allocation and sequence initialization costs. Negligible logic change but strictly zero-allocation inside the loop now.
🔬 **Measurement**: Evaluated via JVM compilation (`./gradlew :jvmMainClasses`) and domain test suites (`./gradlew :jvmTest --tests 'borg.trikeshed.jules.*'`). Behavior verified strictly functionally equivalent to prior implementation.

---
*PR created automatically by Jules for task [12863590164673699289](https://jules.google.com/task/12863590164673699289) started by @jnorthrup*