### PR TITLE
🎨 Palette: Improve accessibility of sheet-ref toggle button

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -881,6 +881,8 @@
           ref.innerHTML = '<span>' + (sheetExpanded[key] ? '▾' : '▸') + '</span><span>▦ ' + (child ? child.title.split('/').pop() : cell.sheet) + '</span>' +
             '<span class="sheet-count">' + (child ? child.rows.length + ' rows' : '') + '</span>';
           ref.title = 'Click: expand in place · Open: zoom into ' + cell.sheet;
+          ref.setAttribute('aria-expanded', sheetExpanded[key] ? 'true' : 'false');
+          ref.setAttribute('aria-label', (sheetExpanded[key] ? 'Collapse ' : 'Expand ') + (child ? child.title.split('/').pop() : cell.sheet));
           ref.addEventListener('click', (ev) => {
             ev.stopPropagation();
             sheetExpanded[key] = !sheetExpanded[key];


### PR DESCRIPTION
💡 What: Added `aria-expanded` and a descriptive `aria-label` to the `.sheet-ref` button (used for expanding and collapsing nested sheets in the sheet view).
🎯 Why: Screen reader users need to know whether the nested sheet is expanded or collapsed. The label makes the action ("Expand [Sheet Name]" or "Collapse [Sheet Name]") explicit.
📸 Before/After: The button previously relied solely on visual chevrons ('▾' / '▸') inside `<span>`s, leaving assistive tech without semantic context of its state. Now, it has `aria-expanded="true/false"` and a dynamic `aria-label`.
♿ Accessibility: Improved screen reader navigation for nested tree grid data in the sheet view.

---
*PR created automatically by Jules for task [4757694846494415838](https://jules.google.com/task/4757694846494415838) started by @jnorthrup*