### PR TITLE
🛡️ Sentinel: [Medium] Fix subprocess timeout DoS vulnerability

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/jules/JulesDrainDedupeCli.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/JulesDrainDedupeCli.kt
@@ -6,6 +6,7 @@ import borg.trikeshed.jules.JulesCause
 import borg.trikeshed.parse.json.JsonSupport
 import keymux.KeyMux
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -252,33 +253,50 @@ object JulesDrainDedupeCli {
         System.getenv("TRIKESHED_HOME") ?: File(System.getProperty("user.home"), ".local/forge").path
 
     private suspend fun git(repoDir: File, vararg args: String): List<String> = withContext(Dispatchers.IO) {
-        val pb = ProcessBuilder("git", *args)
-        pb.directory(repoDir)
-        pb.redirectErrorStream(true)
-        val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readLines()
-        proc.waitFor()
-        out
+        kotlinx.coroutines.coroutineScope {
+            val pb = ProcessBuilder("git", *args)
+            pb.directory(repoDir)
+            pb.redirectErrorStream(true)
+            val proc = pb.start()
+            val outDeferred = this.async { proc.inputStream.bufferedReader().readLines() }
+            if (!proc.waitFor(1, java.util.concurrent.TimeUnit.HOURS)) {
+                proc.destroyForcibly()
+                error("Process timed out")
+            }
+            outDeferred.await()
+        }
     }
 
     private suspend fun gitWithExit(repoDir: File, vararg args: String): Pair<Int, String> = withContext(Dispatchers.IO) {
-        val pb = ProcessBuilder("git", *args)
-        pb.directory(repoDir)
-        pb.redirectErrorStream(true)
-        val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        val exit = proc.waitFor()
-        Pair(exit, out)
+        kotlinx.coroutines.coroutineScope {
+            val pb = ProcessBuilder("git", *args)
+            pb.directory(repoDir)
+            pb.redirectErrorStream(true)
+            val proc = pb.start()
+            val outDeferred = this.async { proc.inputStream.bufferedReader().readText() }
+            if (!proc.waitFor(1, java.util.concurrent.TimeUnit.HOURS)) {
+                proc.destroyForcibly()
+                error("Process timed out")
+            }
+            val exit = proc.exitValue()
+            Pair(exit, outDeferred.await())
+        }
     }
 
     private suspend fun gitJava(repoDir: File, cp: String, mainClass: String, vararg args: String): Pair<Int, String> = withContext(Dispatchers.IO) {
-        val pb = ProcessBuilder("java", "-cp", cp, mainClass, *args)
-        pb.directory(repoDir)
-        pb.redirectErrorStream(true)
-        val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        val exit = proc.waitFor()
-        Pair(exit, out)
+        kotlinx.coroutines.coroutineScope {
+            val pb = ProcessBuilder("java", "-cp", cp, mainClass, *args)
+            pb.directory(repoDir)
+            pb.redirectErrorStream(true)
+            val proc = pb.start()
+            val outDeferred = this.async { proc.inputStream.bufferedReader().readText() }
+            if (!proc.waitFor(1, java.util.concurrent.TimeUnit.HOURS)) {
+                proc.destroyForcibly()
+                error("Process timed out")
+            }
+            val exit = proc.exitValue()
+            Pair(exit, outDeferred.await())
+        }
     }
 
     private fun requireCanonicalRepository(dir: File) {

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/JulesSettlementCli.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/JulesSettlementCli.kt
@@ -9,6 +9,7 @@ import borg.trikeshed.utils.kanban.JulesBoardStore
 import borg.trikeshed.utils.kanban.forForgeDir
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -657,12 +658,18 @@ object JulesSettlementCli {
     }
 
     private suspend fun git(repoDir: File, vararg args: String): CommandResult = withContext(Dispatchers.IO) {
-        val process = ProcessBuilder(listOf("git") + args)
-            .directory(repoDir)
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        CommandResult(process.waitFor(), output)
+        kotlinx.coroutines.coroutineScope {
+            val process = ProcessBuilder(listOf("git") + args)
+                .directory(repoDir)
+                .redirectErrorStream(true)
+                .start()
+            val outputDeferred = this.async { process.inputStream.bufferedReader().use { it.readText() } }
+            if (!process.waitFor(1, java.util.concurrent.TimeUnit.HOURS)) {
+                process.destroyForcibly()
+                error("Process timed out")
+            }
+            CommandResult(process.exitValue(), outputDeferred.await())
+        }
     }
 
     private fun receiptJson(


### PR DESCRIPTION
🚨 Severity: Medium
💡 Vulnerability: Denial of Service (DoS). Subprocess streams were read synchronously before invoking a bounded timeout (`process.waitFor`). If the subprocess hangs without closing its stdout, the reading thread blocks indefinitely, rendering the timeout check unreachable and leading to resource exhaustion.
🎯 Impact: Attackers or unexpected system states could cause background git processes (or other processes) to hang forever, starving the application of threads and memory over time.
🔧 Fix: Wrapped the stream I/O inside a `kotlinx.coroutines.async` block within a `coroutineScope`. The `waitFor` with a 1-hour timeout now executes concurrently with the read operation, safely destroying the process if the timeout expires.

---
*PR created automatically by Jules for task [15884209401585346165](https://jules.google.com/task/15884209401585346165) started by @jnorthrup*