### PR TITLE
⚡ Bolt: [performance improvement] Optimize JulesPatchContinuity list allocations and sequence overhead

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/jules/JulesPatchContinuity.kt
@@ -154,11 +154,18 @@ fun selectJulesPatchForDrain(causes: Iterable<JulesCause>): JulesPatchDrainSelec
         return JulesPatchDrainSelection.Selected(latest, reviewed = false)
     }
 
-    val retained = observations
-        .asSequence()
-        .filter { it.reviewCandidate && it.causalOrdinal < latest.causalOrdinal }
-        .maxWithOrNull(snapshotCausalOrder)
-        ?: return JulesPatchDrainSelection.ReviewRequired(latest, latest, latest.missingFromCandidate)
+    // Bolt: Replace sequence allocation with zero-allocation for loop
+    var retained: JulesCause.PatchSnapshotObserved? = null
+    for (item in observations) {
+        if (item.reviewCandidate && item.causalOrdinal < latest.causalOrdinal) {
+            if (retained == null || snapshotCausalOrder.compare(item, retained) > 0) {
+                retained = item
+            }
+        }
+    }
+    if (retained == null) {
+        return JulesPatchDrainSelection.ReviewRequired(latest, latest, latest.missingFromCandidate)
+    }
     return JulesPatchDrainSelection.ReviewRequired(
         retainedCandidate = retained,
         regressedLatest = latest,

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/JulesPatchContinuityStore.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/JulesPatchContinuityStore.kt
@@ -29,8 +29,15 @@ class JulesPatchContinuityStore(
         patches: Series<JulesRestClient.ActivityPatch>,
         priorCauses: Iterable<JulesCause>,
     ): List<JulesCause.PatchSnapshotObserved> {
-        var causalFacts = priorCauses.filterIsInstance<JulesCause.PatchSnapshotObserved>()
-        var appended = emptyList<JulesCause.PatchSnapshotObserved>()
+        // Bolt: Use ArrayList to avoid O(N^2) copying on append
+        val causalFacts = ArrayList<JulesCause.PatchSnapshotObserved>()
+        for (item in priorCauses) {
+            if (item is JulesCause.PatchSnapshotObserved) {
+                causalFacts.add(item)
+            }
+        }
+        val appended = ArrayList<JulesCause.PatchSnapshotObserved>()
+        val patchOrder = compareBy<JulesCause.PatchSnapshotObserved>({ it.causalOrdinal }, { it.activitySeq }, { it.artifactSeq })
         for (index in 0 until patches.size) {
             val patch = patches[index]
             val bytes = patch.patch.encodeToByteArray()
@@ -43,9 +50,15 @@ class JulesPatchContinuityStore(
             if (alreadyObserved) continue
 
             val touchedFiles = julesPatchFiles(patch.patch).filterNot(::isScratchPatchPath)
-            val retainedBefore = causalFacts.asSequence()
-                .filter { it.reviewCandidate && it.causalOrdinal < patch.causalOrdinal }
-                .maxWithOrNull(compareBy({ it.causalOrdinal }, { it.activitySeq }, { it.artifactSeq }))
+            // Bolt: Replace sequence allocation with zero-allocation for loop
+            var retainedBefore: JulesCause.PatchSnapshotObserved? = null
+            for (item in causalFacts) {
+                if (item.reviewCandidate && item.causalOrdinal < patch.causalOrdinal) {
+                    if (retainedBefore == null || patchOrder.compare(item, retainedBefore) > 0) {
+                        retainedBefore = item
+                    }
+                }
+            }
             val missing = retainedBefore?.touchedFiles
                 ?.filterNot(touchedFiles.toSet()::contains)
                 ?.distinct()
@@ -62,8 +75,8 @@ class JulesPatchContinuityStore(
                 activitySeq = patch.activitySeq,
             )
             boardStore.appendCause(sessionId, fact)
-            causalFacts = causalFacts + fact
-            appended = appended + fact
+            causalFacts.add(fact)
+            appended.add(fact)
         }
         return appended
     }
@@ -78,8 +91,14 @@ class JulesPatchContinuityStore(
         reports: Series<JulesRestClient.ActivityReport>,
         priorCauses: Iterable<JulesCause>,
     ): List<JulesCause.AgentReportObserved> {
-        var causalFacts = priorCauses.filterIsInstance<JulesCause.AgentReportObserved>()
-        var appended = emptyList<JulesCause.AgentReportObserved>()
+        // Bolt: Use ArrayList to avoid O(N^2) copying on append
+        val causalFacts = ArrayList<JulesCause.AgentReportObserved>()
+        for (item in priorCauses) {
+            if (item is JulesCause.AgentReportObserved) {
+                causalFacts.add(item)
+            }
+        }
+        val appended = ArrayList<JulesCause.AgentReportObserved>()
         for (index in 0 until reports.size) {
             val report = reports[index]
             val bytes = report.message.encodeToByteArray()
@@ -100,8 +119,8 @@ class JulesPatchContinuityStore(
                 activitySeq = report.activitySeq,
             )
             boardStore.appendCause(sessionId, fact)
-            causalFacts = causalFacts + fact
-            appended = appended + fact
+            causalFacts.add(fact)
+            appended.add(fact)
         }
         return appended
     }


### PR DESCRIPTION
💡 What: Optimized list allocations and lazy sequence evaluation overhead in `JulesPatchContinuityStore.kt` and `JulesPatchContinuity.kt`. Replaced O(N^2) list copying (`list + item`) with O(1) `ArrayList.add` appends and unrolled `.asSequence().filter{}.maxWithOrNull()` chains into standard `for` loops.
🎯 Why: `JulesPatchContinuityStore` processes streams of incremental patch events for causal tracking. Creating new list copies on every appended snapshot (`causalFacts = causalFacts + fact`) leads to O(N^2) GC pressure on long sessions. Lazy `.asSequence()` chains allocate multiple intermediate iterators and lambda objects which create unnecessary overhead for simple max-finding over standard Lists in hot paths.
📊 Impact: Eliminates O(N^2) list copying per batch. Reduces GC pressure by avoiding intermediate list allocations from `filterIsInstance` and sequence iteration.
🔬 Measurement: Verified the code compiles successfully (`./gradlew :jvmMainClasses`) and verified existing causal behavior tests pass (`./gradlew :jvmTest --tests 'borg.trikeshed.jules.*'`).

---
*PR created automatically by Jules for task [16530041317447847093](https://jules.google.com/task/16530041317447847093) started by @jnorthrup*