### PR TITLE
⚡ Bolt: Remove redundant Sequence wrapper in CAS merge fast-path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -175,3 +175,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2024-05-18 - Zero-allocation store.ids() iteration
 **Learning:** In TrikeShed, `database.store.all()` materializes a full list of documents in memory. To avoid this allocation when only IDs are needed, use `database.store.ids()`. This returns a custom `Join<Int, (Int) -> String>` type where `.a` represents the size and `.b(i)` is the element getter.
 **Action:** Iterate using `for (i in 0 until ids.a) { val id = ids.b(i) ... }` to achieve zero-allocation ID scanning instead of chained `.map` over `.all()`.
+
+## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
+**Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
+**Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).

--- a/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/cas/FunnelResidualMerge.kt
@@ -556,7 +556,7 @@ object FunnelResidualMerge {
         for (s in 0 until sources.size) {
             val spine = sources[s]
             val text = sourceTexts[s]
-            val lines = text.lineSequence().map { it }.toList()
+            val lines = text.lineSequence().toList()
             val sourceResiduals = residuals[s]
 
             val changes = mutableListOf<borg.trikeshed.pijul.Change>()


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform inside `FunnelResidualMerge.kt`'s hot path.
🎯 Why: `.map { it }` on a `Sequence` needlessly allocates a `TransformingSequence` wrapper and forces a no-op lambda evaluation for every element before collection. This wastes CPU and heap allocations.
📊 Impact: Micro-optimization that removes 1 object allocation and N identity method evaluations per parallel merge pass.
🔬 Measurement: Verify tests compile and pass successfully, confirming that `text.lineSequence().toList()` performs identically in logic but faster.

---
*PR created automatically by Jules for task [3852178755134423116](https://jules.google.com/task/3852178755134423116) started by @jnorthrup*