### PR TITLE
🎨 Palette: Add explicit ARIA labels to dynamically generated interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -74,3 +74,6 @@
 >>>>>>> theirs
 =======
 >>>>>>> theirs
+## 2024-08-24 - Dynamic ARIA Label Injection
+**Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
+**Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -251,9 +251,11 @@
     pageTreeEl.innerHTML = '';
     state.pages.forEach((page) => {
       const item = document.createElement('div');
-      item.className = 'page-tree-item' + (page.id === state.activePageId ? ' active' : '');
+      const isActive = page.id === state.activePageId;
+      item.className = 'page-tree-item' + (isActive ? ' active' : '');
       item.role = 'button';
       item.tabIndex = 0;
+      item.setAttribute('aria-label', (isActive ? 'Active page: ' : 'Page: ') + (page.title || 'Untitled'));
       const toggle = document.createElement('span');
       toggle.className = 'tree-toggle';
       toggle.textContent = page.children && page.children.length ? '▾' : '▸';
@@ -490,7 +492,9 @@
     );
     items.forEach((d, i) => {
       const item = document.createElement('button');
-      item.className = 'slash-item' + (i === activeSlashIndex ? ' active' : '');
+      const isActive = i === activeSlashIndex;
+      item.className = 'slash-item' + (isActive ? ' active' : '');
+      item.setAttribute('aria-label', d.name + ' command' + (isActive ? ' (currently selected)' : '') + ': ' + d.desc);
       const icon = document.createElement('span');
       icon.className = 'slash-item-icon';
       icon.textContent = d.icon;
@@ -939,7 +943,9 @@
     const chain = []; let p = cur; while (p) { chain.unshift(p); p = p.parent ? sheetById[p.parent] : null; }
     chain.forEach((sh, i) => {
       if (i) sheetCrumbsEl.appendChild(document.createTextNode(' / '));
-      const b = document.createElement('button'); b.textContent = sh.id.split('/').pop() || sh.title;
+      const title = sh.id.split('/').pop() || sh.title;
+      const b = document.createElement('button'); b.textContent = title;
+      b.setAttribute('aria-label', 'Navigate to parent sheet: ' + title);
       b.addEventListener('click', () => openSheet(sh.id)); sheetCrumbsEl.appendChild(b);
     });
     sheetWrapEl.appendChild(buildSheetTable(cur, 0));


### PR DESCRIPTION
💡 **What:**
Added dynamic, descriptive `aria-label` attributes to custom UI components (`page-tree-item`, `slash-item`, `sheet-crumbs`) constructed in JavaScript. 

🎯 **Why:**
Previously, these elements relied solely on visual CSS classes (like `.active`) to communicate state and purpose. Screen reader users would hear non-descriptive text without knowing if an item was currently selected or what action it performed. 

📸 **Before/After:**
*Before:* `<div class="page-tree-item active" role="button" tabindex="0">...</div>` (Screen reader only announces visible text).
*After:* `<div class="page-tree-item active" role="button" tabindex="0" aria-label="Active page: Welcome to Forge">...</div>` (Screen reader announces exact state and title).

♿ **Accessibility:**
Significantly improves context for assistive technologies interacting with custom list/navigation elements in the workspace shell.

---
*PR created automatically by Jules for task [6941831429787618130](https://jules.google.com/task/6941831429787618130) started by @jnorthrup*