### PR TITLE
⚡ Bolt: [performance improvement] optimize sequence pipelines in Hermes Python Port

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/hermes/HermesPythonPort.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/hermes/HermesPythonPort.kt
@@ -91,15 +91,26 @@ data class HermesPortInventory(
         val facts = ArrayList<HermesOntologyFact>(modules.size * 2)
         val orderedModules = modules.values.toTypedArray().apply { sortBy { it.name } }
         for (module in orderedModules) {
-            val roots = module.blockedBy.asSequence().filter { it in banlist }.toSortedSet()
+            // ⚡ Bolt: Replaced `.asSequence().filter { ... }.toSortedSet()` and chained sequence operations with direct iteration.
+            // Avoids O(N) intermediate wrapper allocations (Sequence, Iterator, lambda instances) per module,
+            // significantly reducing garbage collection pressure during frequent ontology regeneration.
+            val roots = sortedSetOf<String>()
+            for (blocked in module.blockedBy) {
+                if (blocked in banlist) roots.add(blocked)
+            }
             if (roots.isEmpty()) {
                 facts += HermesOntologyFact(HermesOntologyKind.READY, if (module.sleeved) "sleeve" else "upstream", module.name)
             } else {
-                roots.forEach { blocker -> facts += HermesOntologyFact(HermesOntologyKind.BLOCKED, blocker, module.name) }
+                for (blocker in roots) {
+                    facts += HermesOntologyFact(HermesOntologyKind.BLOCKED, blocker, module.name)
+                }
             }
-            val deferred = module.deferredImports.asSequence().map { it.substringBefore('.') }
-                .filter { it in banlist }.toSortedSet()
-            deferred.forEach { blocker ->
+            val deferred = sortedSetOf<String>()
+            for (imp in module.deferredImports) {
+                val prefix = imp.substringBefore('.')
+                if (prefix in banlist) deferred.add(prefix)
+            }
+            for (blocker in deferred) {
                 facts += HermesOntologyFact(HermesOntologyKind.DEFERRED, blocker, module.name)
             }
         }


### PR DESCRIPTION
💡 **What:** Replaced `.asSequence().filter { ... }.toSortedSet()` pipelines inside a hot loop with standard `for` loops in `HermesPythonPort.kt`.
🎯 **Why:** To eliminate O(N) intermediate wrapper allocations (Sequence, Iterator, and lambda instances) per module. This code runs frequently during ontology regeneration, so reducing GC pressure is a measurable win.
📊 **Impact:** Reduces object allocations linearly based on the number of Python modules and dependencies, mitigating garbage collection pressure on the JVM without changing the resulting set structures.
🔬 **Measurement:** Verify by running `./gradlew :jvmTest --tests 'borg.trikeshed.hermes.HermesPythonPortTest'`. Profiling `ontology` access will show reduced object churn.

---
*PR created automatically by Jules for task [15631060595953214877](https://jules.google.com/task/15631060595953214877) started by @jnorthrup*