### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded waitFor Denial of Service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `generateKey()` method in `Rfc6455Handshake.kt` used a highly predictable linear shift-XOR algorithm seeded by the system clock (`Clock.System.now().toEpochMilliseconds()`) to generate the `Sec-WebSocket-Key`.
 **Learning:** Using predictable, time-based PRNGs for cryptographic nonces like `Sec-WebSocket-Key` makes the handshake susceptible to prediction or replay attacks. While the RFC 6455 states this key is not meant for authentication, it is meant to prove the request is actually a WebSocket request and to prevent caching proxy issues, so it should still be robustly random.
 **Prevention:** Always use standard, secure-by-default libraries for random number generation (e.g., `kotlin.random.Random.Default.nextBytes` or `SecureRandom`) instead of rolling custom cryptographic algorithms or using simple PRNGs.
+
+## 2024-05-27 - [Denial of Service via Unbounded waitFor and synchronous pipe reading]
+**Vulnerability:** Found `waitFor()` being called on a `Process` without a timeout and while synchronously reading from the process `InputStream` in `CouchWal.java`, `PanamaKanbanMovie.kt`, and `HeatSoak.kt`.
+**Learning:** `Process.waitFor()` without a timeout can lead to Denial of Service (DoS) if the subprocess hangs. Further, reading the input stream synchronously on the main thread before calling `waitFor` can block indefinitely if the process fills the OS pipe buffer or simply hangs, preventing the timeout from ever being reached.
+**Prevention:** Always read process streams asynchronously (e.g., using `CompletableFuture.supplyAsync`) to prevent pipe buffer deadlocks, and explicitly use bounded `waitFor(timeout, TimeUnit)` with forceful termination `destroyForcibly()` on timeout.

--- a/src/jvmMain/java/borg/trikeshed/couch/wal/CouchWal.java
+++ b/src/jvmMain/java/borg/trikeshed/couch/wal/CouchWal.java
@@ -40,15 +40,25 @@ public class CouchWal {
 
         Process process = builder.start();
 
-        // Log output
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                System.out.println(line);
+        // Log output asynchronously
+        java.util.concurrent.CompletableFuture<Void> outputReader = java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException e) {
+                // Ignore stream closed errors if killed
             }
-        }
+        });
 
-        int exitCode = process.waitFor();
+        boolean finished = process.waitFor(1, java.util.concurrent.TimeUnit.HOURS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new RuntimeException("Gradle build process timed out");
+        }
+        outputReader.join();
+        int exitCode = process.exitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Gradle build failed with exit code: " + exitCode);
         }

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/movie/PanamaKanbanMovie.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/movie/PanamaKanbanMovie.kt
@@ -237,8 +237,15 @@ object PanamaKanbanMovie {
             "-crf", "23", outputFile.absolutePath
         ).directory(File(".")).redirectErrorStream(true).start()
         
-        val output = process.inputStream.bufferedReader().readText()
-        process.waitFor()
+        val outputDeferred = java.util.concurrent.CompletableFuture.supplyAsync {
+            process.inputStream.bufferedReader().readText()
+        }
+        val finished = process.waitFor(1, java.util.concurrent.TimeUnit.HOURS)
+        if (!finished) {
+            process.destroyForcibly()
+            error("ffmpeg process timed out")
+        }
+        val output = outputDeferred.get()
         
         // Cleanup temp frames
         Thread { tempDir.deleteRecursively() }.start()

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
@@ -210,7 +210,13 @@ object HeatSoak {
     fun classHistogram(n: Int): String = runCatching {
         val jcmd = java.io.File(System.getProperty("java.home"), "bin/jcmd").path
         val p = ProcessBuilder(jcmd, ProcessHandle.current().pid().toString(), "GC.class_histogram").redirectErrorStream(true).start()
-        val lines = p.inputStream.bufferedReader().readLines(); p.waitFor()
+        val linesDeferred = java.util.concurrent.CompletableFuture.supplyAsync { p.inputStream.bufferedReader().readLines() }
+        val finished = p.waitFor(1, java.util.concurrent.TimeUnit.HOURS)
+        if (!finished) {
+            p.destroyForcibly()
+            error("jcmd process timed out")
+        }
+        val lines = linesDeferred.get()
         "\n── class histogram (live, top $n) ──\n" + lines.take(n + 3).joinToString("\n") { it.take(140) }
     }.getOrElse { "\n── class histogram unavailable: $it" }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Processes were launched with `ProcessBuilder` and their streams read synchronously, followed by an unbounded `waitFor()`. If the child process hung or filled the OS pipe buffer, it would block the parent thread indefinitely, leading to resource starvation and DoS.
🎯 Impact: Thread starvation, application freeze, Denial of Service via resource exhaustion.
🔧 Fix: Adopted bounded `process.waitFor(1, TimeUnit.HOURS)` with forced termination upon timeout, and shifted `InputStream` reading to asynchronous `CompletableFuture`s to avoid pipe buffer deadlocks.
✅ Verification: Successfully compiled `CouchWal.java` and ran unit tests (e.g. `HeatSoakTest`), verifying stability.

---
*PR created automatically by Jules for task [7322400207564221716](https://jules.google.com/task/7322400207564221716) started by @jnorthrup*