### PR TITLE
⚡ Bolt: Remove redundant identity transform in readLines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,6 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+## 2026-10-31 - Avoid Redundant Map Transforms on Materialized Collections
+**Learning:** In Kotlin, chaining `.map { it }` on an already materialized collection (such as the `List<String>` returned by `Files.readAllLines`) is a redundant identity transform. It needlessly iterates over the original collection to allocate and populate a brand new `ArrayList`, wasting O(N) time and memory on the heap.
+**Action:** Remove `.map { it }` calls on methods or objects that already return a fully materialized `List`.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> = borg.trikeshed.userspace.nio.file.Files.readAllLines(Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` appended to `Files.readAllLines` in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 Why: `Files.readAllLines` already returns a `List<String>`. In Kotlin, appending `.map { it }` copies the entire list element-by-element into a brand new `ArrayList`, creating a completely unnecessary O(N) allocation that causes CPU overhead and Garbage Collection pressure during hot-path file I/O operations.
📊 Impact: This eliminates O(N) memory allocation and O(N) iteration time every single time a file is read.
🔬 Measurement: Verify using unit tests in `borg.trikeshed.common.*` and observe heap profiling during heavy I/O operations for zero allocation on the `readLines` return type.

---
*PR created automatically by Jules for task [12117129012017776157](https://jules.google.com/task/12117129012017776157) started by @jnorthrup*