### PR TITLE
⚡ Bolt: Avoid intermediate Sequence allocations before terminal operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,6 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+## 2026-08-26 - Eliminate intermediate allocations with LinkedHashSet for distinct collections
+**Learning:** When refactoring Kotlin `.asSequence().filter { ... }.distinct().toList()` chains to eliminate intermediate sequence and iterator allocations, a naive `ArrayList` approach requires an O(N) `.contains()` check or leaves duplicates.
+**Action:** Use a `LinkedHashSet` within the direct iteration loop to preserve insertion order while guaranteeing element uniqueness in O(1) time before finalizing `.toList()`.

--- a/src/commonMain/kotlin/borg/trikeshed/btrfs/UserspaceBtrfs.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/btrfs/UserspaceBtrfs.kt
@@ -142,11 +142,16 @@ class UserspaceBtrfs(val rootDir: String, val fileOps: FileOperations) {
             if (sv.entries[directory]?.isDir != true) return null
         }
         val prefix = if (directory.isEmpty()) "" else "$directory/"
-        return sv.entries.keys.asSequence()
-            .filter { it.startsWith(prefix) && it != directory }
-            .map { it.removePrefix(prefix).substringBefore('/') }
-            .filter { it.isNotEmpty() }
-            .distinct().sorted().toList()
+        val result = LinkedHashSet<String>()
+        for (key in sv.entries.keys) {
+            if (key.startsWith(prefix) && key != directory) {
+                val mapped = key.removePrefix(prefix).substringBefore('/')
+                if (mapped.isNotEmpty()) result.add(mapped)
+            }
+        }
+        val sortedList = result.toMutableList()
+        sortedList.sort()
+        return sortedList
     }
 
     fun isDirectory(subvol: String, path: String = ""): Boolean {

--- a/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/InMemoryFileOperations.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/userspace/nio/file/spi/InMemoryFileOperations.kt
@@ -52,12 +52,20 @@ class InMemoryFileOperations(
 
     override fun listDir(path: String): List<String> {
         val prefix = path.trimEnd('/') + "/"
-        return (files.keys.asSequence() + dirs.asSequence())
-            .filter { it.startsWith(prefix) }
-            .map { it.removePrefix(prefix).substringBefore('/') }
-            .filter { it.isNotEmpty() }
-            .distinct()
-            .toList()
+        val result = LinkedHashSet<String>()
+        for (key in files.keys) {
+            if (key.startsWith(prefix)) {
+                val mapped = key.removePrefix(prefix).substringBefore('/')
+                if (mapped.isNotEmpty()) result.add(mapped)
+            }
+        }
+        for (key in dirs) {
+            if (key.startsWith(prefix)) {
+                val mapped = key.removePrefix(prefix).substringBefore('/')
+                if (mapped.isNotEmpty()) result.add(mapped)
+            }
+        }
+        return result.toList()
     }
 
     override fun write(filename: String, bytes: ByteArray) {

--- a/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHost.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/couch/viewserver/GraalVmCursorHost.kt
@@ -77,13 +77,15 @@ class RowVecProxy(private val row: RowVec) : ProxyObject, ProxyHashMap {
         throw UnsupportedOperationException("Cursor proxy is read-only")
     }
 
-    override fun getHashEntriesIterator(): Any =
-        ProxyIterator.from(
-            metaList.indices.asSequence()
-                .map { i -> metaNames[i] to row.a.let { s -> (s as Series<Any?>).getOrNull(i) } }
-                .map { (n, v) -> ProxyArray.fromArray(n, v) }
-                .iterator()
-        )
+    override fun getHashEntriesIterator(): Any {
+        val entries = ArrayList<Any>(metaList.size)
+        for (i in metaList.indices) {
+            val n = metaNames[i]
+            val v = row.a.let { s -> (s as Series<Any?>).getOrNull(i) }
+            entries.add(ProxyArray.fromArray(n, v))
+        }
+        return ProxyIterator.from(entries.iterator())
+    }
 }
 
 class CursorProxy(private val cursor: Cursor) : ProxyArray {

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/TrikeShedGraalVfs.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/TrikeShedGraalVfs.kt
@@ -145,7 +145,14 @@ class TrikeShedGraalVfs(
                 } else {
                     children
                 }
-                val accepted = maskedChildren.asSequence().map(parent::resolve).filter { child -> filter.accept(child) }.iterator()
+                val acceptedList = ArrayList<Path>()
+                for (childName in maskedChildren) {
+                    val childPath = parent.resolve(childName)
+                    if (filter.accept(childPath)) {
+                        acceptedList.add(childPath)
+                    }
+                }
+                val accepted = acceptedList.iterator()
                 return object : MutableIterator<Path> {
                     override fun hasNext(): Boolean = accepted.hasNext()
                     override fun next(): Path = accepted.next()

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/JulesConductor.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/JulesConductor.kt
@@ -52,10 +52,12 @@ class JulesConductor(
             cards.putAll(durable.first)
         }
         val sessions = client.listSessions(source)
-        val settledQueueSessions = durable?.second.orEmpty().asSequence()
-            .filter { it.receipt?.isImmutableSettlement() == true }
-            .mapNotNull { it.sessionId }
-            .toSet()
+        val settledQueueSessions = mutableSetOf<String>()
+        for (record in durable?.second.orEmpty()) {
+            if (record.receipt?.isImmutableSettlement() == true) {
+                record.sessionId?.let { settledQueueSessions.add(it) }
+            }
+        }
         fun hasImmutableSettlement(sessionId: String, card: JulesSessionCard?): Boolean =
             card?.causes?.any { it is JulesCause.WorkDrained && it.receipt?.isImmutableSettlement() == true } == true ||
                 sessionId in settledQueueSessions


### PR DESCRIPTION
💡 What: Replaced `.asSequence().map { ... }.filter { ... }.toList()` and similar chains with direct eager iterations using `ArrayList` or `LinkedHashSet`.
🎯 Why: In Kotlin hot paths, the object allocation overhead for the `Sequence` wrapper and its stateful lazy iterators outweighs the cost of direct collection when the collection is ultimately materialized into a list or iterator anyway. Removing them decreases memory allocations and Garbage Collection pressure.
📊 Impact: Decreases allocation rates for collection-processing hot paths (like scanning GraalVFS masked children and caching BTRFS manifests).
🔬 Measurement: Verified with targeted test suite runs passing cleanly.

---
*PR created automatically by Jules for task [7716736111111624820](https://jules.google.com/task/7716736111111624820) started by @jnorthrup*