### PR TITLE
⚡ Bolt: Remove redundant .map { it } on materialized list

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-10-25 - Avoid redundant identity maps on materialized collections
+**Learning:** In Kotlin, using `.map { it }` on an already materialized collection (such as a `List` returned by `Files.readAllLines`) is a redundant identity transform that needlessly copies the entire list, wasting O(N) time and memory.
+**Action:** Remove `.map { it }` to return the original list directly, saving memory allocations on hot paths.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)) // ⚡ Bolt: removed redundant .map { it } which allocates an intermediate ArrayList O(N)


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` call from the end of `Files.readAllLines(Paths.get(path))` in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.

🎯 Why: `Files.readAllLines` already returns a fully materialized `List<String>` (specifically, a newly allocated `ArrayList`). Calling `.map { it }` on this result pointlessly iterates through the entire list and creates a *second* copy of the list. By removing this identity map, we eliminate an unnecessary O(N) operation and an O(N) memory allocation, directly improving performance and reducing Garbage Collector pressure for file reading.

📊 Impact: Reduces intermediate memory allocation by 100% on the `readLines` path, avoiding a completely redundant O(N) iteration and `ArrayList` heap allocation. 

🔬 Measurement: Verify by executing `./gradlew :jvmTest --tests 'borg.trikeshed.common.*'`. The underlying test confirms that file line reading behavior remains unchanged while the execution trace will no longer include the intermediate collection copy overhead.

---
*PR created automatically by Jules for task [16165159785968055024](https://jules.google.com/task/16165159785968055024) started by @jnorthrup*