### PR TITLE
⚡ Bolt: Remove redundant .map { it } after Files.readAllLines

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,5 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+// Optimization: Removed redundant .map { it } to avoid copying the entire list in O(N) time and memory.
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform at the end of the `Files.readAllLines()` call in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 Why: In Kotlin, calling `.map { it }` on a standard materialized collection like `List` creates a completely new `ArrayList`, iterating over the original list and copying every element in O(N) time and memory. Since `readAllLines` already allocates and returns a fresh `List<String>`, performing an identity map immediately after is completely unnecessary and wastes resources, particularly for large files. 
📊 Impact: Saves O(N) time and O(N) memory allocation per invocation of `readLines`. Removes a full unnecessary array copy of all lines in the file.
🔬 Measurement: Verified the change compiles successfully and passes all related unit tests (`./gradlew :jvmTest --tests 'borg.trikeshed.common.*'`).

Signed-off-by: Bolt ⚡

---
*PR created automatically by Jules for task [9878319700432528623](https://jules.google.com/task/9878319700432528623) started by @jnorthrup*