### PR TITLE
⚡ Bolt: Remove redundant list allocation in readLines

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> = borg.trikeshed.userspace.nio.file.Files.readAllLines(Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` call in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt` that was operating on the returned list from `Files.readAllLines()`.

🎯 Why: Calling `.map { it }` on an already materialized standard library `List<String>` is an identity transform that needlessly copies the entire list. It forces an $O(N)$ iteration and an extra $O(N)$ memory allocation, wasting resources for zero functional benefit.

📊 Impact: Reduces memory allocation and CPU cycles when reading file contents. The speedup scales linearly with the size of the file being read. Eliminates unnecessary GC pressure from short-lived intermediate lists.

🔬 Measurement: Verified the optimization by successfully compiling (`./gradlew :jvmMainClasses --no-daemon`) and passing the associated common utilities tests (`./gradlew :jvmTest --tests 'borg.trikeshed.common.*' --no-daemon`).

---
*PR created automatically by Jules for task [13884604229327262440](https://jules.google.com/task/13884604229327262440) started by @jnorthrup*