### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant identity map on file lines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-10-25 - Avoid redundant identity maps on already materialized lists
+**Learning:** Using `.map { it }` on a `List` (like the result of `Files.readAllLines`) just forces Kotlin to allocate a completely new `ArrayList` and iterate over every element to perform an identity mapping, wasting O(N) memory and time.
+**Action:** Remove trailing `.map { it }` calls when the original collection is already the expected type.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> = borg.trikeshed.userspace.nio.file.Files.readAllLines(Paths.get(path))


### PR DESCRIPTION
💡 **What**: Removed `.map { it }` from the `readLines` function in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 **Why**: `Files.readAllLines` already returns a `List<String>`. Calling `.map { it }` forces Kotlin to instantiate a brand-new `ArrayList` and iterate through all lines of the file merely to do an identity transform, causing unnecessary garbage collection pressure and an O(N) penalty. 
📊 **Impact**: Reduces CPU and memory overhead during file reads by skipping a redundant O(N) list copy.
🔬 **Measurement**: Verified by ensuring the code continues to compile correctly and `FilesTest` runs successfully without failures. Run `./gradlew :jvmMainClasses --no-daemon` and `./gradlew :jvmTest --tests 'borg.trikeshed.common.*' --no-daemon` to confirm.

---
*PR created automatically by Jules for task [16172767021023886607](https://jules.google.com/task/16172767021023886607) started by @jnorthrup*