### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix process pipe buffer DoS vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,7 @@
 **Vulnerability:** The `generateKey()` method in `Rfc6455Handshake.kt` used a highly predictable linear shift-XOR algorithm seeded by the system clock (`Clock.System.now().toEpochMilliseconds()`) to generate the `Sec-WebSocket-Key`.
 **Learning:** Using predictable, time-based PRNGs for cryptographic nonces like `Sec-WebSocket-Key` makes the handshake susceptible to prediction or replay attacks. While the RFC 6455 states this key is not meant for authentication, it is meant to prove the request is actually a WebSocket request and to prevent caching proxy issues, so it should still be robustly random.
 **Prevention:** Always use standard, secure-by-default libraries for random number generation (e.g., `kotlin.random.Random.Default.nextBytes` or `SecureRandom`) instead of rolling custom cryptographic algorithms or using simple PRNGs.
+## 2026-08-28 - Pipe Buffer Deadlock DoS
+**Vulnerability:** Reading a process output stream synchronously before calling waitFor can cause the process to hang indefinitely if the output pipe buffer fills up, creating a DoS via pipe buffer deadlock.
+**Learning:** This pipe buffer deadlock pattern occurs when stdout/stderr is read synchronously and blocks because the child process hangs, preventing the parent from reaching the bounded waitFor timeout logic.
+**Prevention:** When enforcing bounded timeouts on child processes, always read the input stream asynchronously (using async or CompletableFuture) so the main thread can proceed to execute waitFor(timeout).

--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -1310,9 +1310,13 @@ object OroborosDaemon {
 
         suspend fun command(vararg args: String): String = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             val p = ProcessBuilder(*args).directory(repoDir).redirectErrorStream(true).start()
+            val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { p.inputStream.bufferedReader().readText().trim() }
             val finished = p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)
-            if (!finished) p.destroyForcibly()
-            p.inputStream.bufferedReader().readText().trim()
+            if (!finished) {
+                p.destroyForcibly()
+                return@withContext ""
+            }
+            outAsync.get()
         }
 
         val local = command("git", "rev-parse", "HEAD")

--- a/src/jvmMain/kotlin/borg/trikeshed/forge/server/PatchWire.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/server/PatchWire.kt
@@ -254,8 +254,11 @@ class ProjectScopes(
         for (cmd in attempts) {
             val ok = runCatching {
                 val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
-                p.inputStream.readBytes()
-                p.waitFor() == 0
+                val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { p.inputStream.readBytes() }
+                val finished = p.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
+                if (!finished) p.destroyForcibly()
+                outAsync.get()
+                finished && p.exitValue() == 0
             }.getOrDefault(false)
             if (ok && dest.isDirectory) return dest
             dest.deleteRecursively()

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
@@ -210,7 +210,10 @@ object HeatSoak {
     fun classHistogram(n: Int): String = runCatching {
         val jcmd = java.io.File(System.getProperty("java.home"), "bin/jcmd").path
         val p = ProcessBuilder(jcmd, ProcessHandle.current().pid().toString(), "GC.class_histogram").redirectErrorStream(true).start()
-        val lines = p.inputStream.bufferedReader().readLines(); p.waitFor()
+        val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { p.inputStream.bufferedReader().readLines() }
+        val finished = p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+        if (!finished) p.destroyForcibly()
+        val lines = outAsync.get()
         "\n── class histogram (live, top $n) ──\n" + lines.take(n + 3).joinToString("\n") { it.take(140) }
     }.getOrElse { "\n── class histogram unavailable: $it" }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Pipe Buffer Deadlock DoS
🎯 **Impact:** If a child process generated unexpected output that filled the stdout/stderr OS pipe buffer, it would hang while trying to write. Because the parent JVM thread was synchronously blocked inside `Process.waitFor(...)` and not draining the buffer, both the parent and child process would hang indefinitely, bypassing the intended timeout mechanisms and creating a Denial of Service.
🔧 **Fix:** Refactored `ProcessBuilder` execution blocks in `OroborosDaemon.kt`, `PatchWire.kt`, and `HeatSoak.kt`. Input streams are now read asynchronously (using `CompletableFuture.supplyAsync` or coroutines) *before* calling `waitFor`. This guarantees the parent thread evaluates the timeout while the background thread drains the pipe buffer.
✅ **Verification:** Compiled the module successfully and initiated background tests.

---
*PR created automatically by Jules for task [9936734963835218111](https://jules.google.com/task/9936734963835218111) started by @jnorthrup*