### PR TITLE
🎨 Palette: Sync active states for duplicate navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2025-02-23 - Announcing active states for single-page application navigation
+**Learning:** Single-page applications often use custom buttons to switch views instead of actual `<a>` tags with `href`s. While visual users see an active state (like a background color change), screen reader users hear no change in state unless explicitly announced.
+**Action:** When building custom view switchers (like tabs or navigation sidebar items) that aren't native links, always apply `aria-current="page"` via JavaScript when the view changes. Ensure this is applied consistently across all duplicate navigational elements controlling the same view state (e.g., topbar and sidebar buttons) to prevent ambiguous states for screen reader users.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,21 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
+  const SIDEBAR_BTNS = { doc: document.getElementById('btn-home'), board: document.getElementById('btn-board'), graph: document.getElementById('btn-graph'), sheet: document.getElementById('btn-sheet'), host: document.getElementById('btn-host') };
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
+      const sbtn = SIDEBAR_BTNS[k];
       btn.classList.toggle('active', k === view);
+      if (sbtn) sbtn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');
+        if (sbtn) sbtn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+        if (sbtn) sbtn.removeAttribute('aria-current');
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }


### PR DESCRIPTION
💡 What: Updated `script.js` to synchronize the `.active` class and `aria-current="page"` attribute to the sidebar navigation buttons whenever the active view changes.
🎯 Why: Previously, only the topbar navigation buttons had their active states managed by JavaScript. This left the parallel sidebar navigation buttons in an ambiguous state, particularly for screen reader users who rely on programmatic state indicators. 
📸 Before/After: Captured via UI testing video.
♿ Accessibility: Ensures that `aria-current="page"` is consistently applied to all duplicate instances of view-controlling navigation buttons, restoring context for screen reader users.

---
*PR created automatically by Jules for task [11912243228218524737](https://jules.google.com/task/11912243228218524737) started by @jnorthrup*