### PR TITLE
⚡ Bolt: Remove redundant identity map when reading file lines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2025-02-28 - Avoid identity mapping on materialized collections
+**Learning:** In Kotlin, calling `.map { it }` on a materialized collection (such as a `List` returned by `Files.readAllLines`) is a redundant identity transform that needlessly allocates a full copy of the entire list, wasting O(N) time and memory.
+**Action:** Return the original list directly instead of applying `.map { it }`.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> = borg.trikeshed.userspace.nio.file.Files.readAllLines(Paths.get(path))


### PR DESCRIPTION
💡 **What:** Removed a redundant `.map { it }` identity transform on the materialized list returned by `Files.readAllLines` in `borg.trikeshed.common.ReadLines.kt`.

🎯 **Why:** In Kotlin, mapping over an already materialized list with an identity function creates a full copy of the entire collection, allocating an intermediate `ArrayList` and incurring an O(N) penalty in both time and memory.

📊 **Impact:** Reduces heap allocation and garbage collection pressure when reading file lines, ensuring the underlying list is returned directly with zero-copy overhead.

🔬 **Measurement:** Verify tests under `borg.trikeshed.common.*` to ensure file reading behaves identically, with zero logic changes.

---
*PR created automatically by Jules for task [14967606488063377663](https://jules.google.com/task/14967606488063377663) started by @jnorthrup*