### PR TITLE
⚡ Bolt: Avoid materializing full Document lists when only IDs are needed

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/server/ProjectMiner.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/server/ProjectMiner.kt
@@ -72,11 +72,19 @@ class ProjectMiner(
         runs[name] = prog
         val kind = scopes.list().firstOrNull { it.name == name }?.kind ?: pdb.kind
 
-        val ids = pdb.store.all()
-            .map { it.id }
-            .filter { id -> id.substringAfterLast('.', "").lowercase() in MINEABLE }
-            .filter { id -> !id.endsWith(".extract.md") }
-        val already = pdb.store.all().map { it.id }.filter { it.endsWith(".extract.md") }.toSet()
+        // ⚡ Bolt: Use store.ids() instead of store.all() to avoid materializing full Document instances in memory.
+        val storeIds = pdb.store.ids()
+        val ids = mutableListOf<String>()
+        val already = mutableSetOf<String>()
+        for (i in 0 until storeIds.a) {
+            val id = storeIds.b(i)
+            if (id.endsWith(".extract.md")) {
+                already.add(id)
+            } else if (id.substringAfterLast('.', "").lowercase() in MINEABLE) {
+                ids.add(id)
+            }
+        }
+
         val work = ids.filter { "$it.extract.md" !in already }.take(cap)
         prog.total = work.size
         var mintedRun = 0


### PR DESCRIPTION
💡 What: Replaced `pdb.store.all().map { it.id }` with the zero-allocation `pdb.store.ids()` view and iterated through it directly without materializing `Document` lists.

🎯 Why: Calling `.all()` fetches and allocates full `Document` objects for every document in the store, just to extract the `id` field. In a project database context, this consumes excessive memory overhead and GC pressure.

📊 Impact: Reduces intermediate object allocations to zero during the ID mapping phase of `ProjectMiner.mine`. This heavily reduces heap pressure, especially on large workspaces. 

🔬 Measurement: Verify using memory profiling during extraction runs or observe improvements in the throughput of `ProjectMiner.mine`.

---
*PR created automatically by Jules for task [2626960090454815760](https://jules.google.com/task/2626960090454815760) started by @jnorthrup*