### PR TITLE
🎨 Palette: Synchronize sidebar active states

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,19 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = { doc: [docScrollEl, viewDocBtn, document.getElementById('btn-home')], board: [boardScrollEl, viewBoardBtn, document.getElementById('btn-board')], graph: [graphScrollEl, viewGraphBtn, document.getElementById('btn-graph')], sheet: [sheetScrollEl, viewSheetBtn, document.getElementById('btn-sheet')], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn, document.getElementById('btn-host')] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, btn, sidebarBtn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
       btn.classList.toggle('active', k === view);
+      if (sidebarBtn) sidebarBtn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');
+        if (sidebarBtn) sidebarBtn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+        if (sidebarBtn) sidebarBtn.removeAttribute('aria-current');
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--hover-strong); font-weight: 500; }
+.sidebar-item.active .sidebar-item-icon { color: var(--accent); }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
💡 What: Updated the view navigation logic to also apply active visual states and aria attributes to the sidebar buttons, not just the topbar buttons. Added corresponding CSS for the active sidebar state.
🎯 Why: Single-page applications often use custom buttons to switch views instead of actual `<a>` tags with `href`s. While visual users see an active state (like a background color change), screen reader users hear no change in state unless explicitly announced, and visual users would previously lose their place in the sidebar navigation.
📸 Before/After: Sidebar items had no active visual state when switching views. Now they are bolded with a distinct background and accent icon color.
♿ Accessibility: Applied `aria-current="page"` to the active sidebar item dynamically so screen reader users are aware of their current navigation context.

---
*PR created automatically by Jules for task [17428175357654286191](https://jules.google.com/task/17428175357654286191) started by @jnorthrup*