### PR TITLE
⚡ Bolt: [performance improvement] Remove unnecessary identity mapping overhead on file reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-08-27 - Remove redundant map before toList on Files.readAllLines
+**Learning:** In Kotlin, using `.map { it }` on an already materialized collection (such as a `List` returned by `Files.readAllLines`) is a redundant identity transform that needlessly copies the entire list, wasting O(N) time and memory.
+**Action:** Remove it to return the original list directly.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform on the result of `Files.readAllLines(...)`.
🎯 Why: `Files.readAllLines` natively returns a `List<String>`. Applying `.map { it }` on this returned collection forces Kotlin to allocate a completely new `ArrayList` and iterate through the existing list to copy every single element into it without changing anything, creating unnecessary GC pressure and CPU overhead for no reason.
📊 Impact: Saves O(N) memory allocations and O(N) CPU time per file read operation by returning the initially allocated list directly rather than creating an exact shallow copy.
🔬 Measurement: Verified with `./gradlew jvmTest --tests '*FilesContractTest*' --no-daemon` assuring the read operations continue to work correctly and unmodified structurally.

---
*PR created automatically by Jules for task [9778445747226041844](https://jules.google.com/task/9778445747226041844) started by @jnorthrup*