### PR TITLE
🎨 Palette: Announce active states for sidebar navigation

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1320,13 +1320,19 @@
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
+    const SIDEBAR_BTNS = { doc: 'btn-home', board: 'btn-board', graph: 'btn-graph', sheet: 'btn-sheet', host: 'btn-host' };
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+      const sidebarBtnId = SIDEBAR_BTNS[k];
+      const sidebarBtn = sidebarBtnId ? document.getElementById(sidebarBtnId) : null;
       el.hidden = k !== view;
       btn.classList.toggle('active', k === view);
+      if (sidebarBtn) sidebarBtn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');
+        if (sidebarBtn) sidebarBtn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+        if (sidebarBtn) sidebarBtn.removeAttribute('aria-current');
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }


### PR DESCRIPTION
💡 **What:** Added logic to sync the `active` class and `aria-current="page"` attributes to the sidebar navigation buttons (`#btn-home`, `#btn-board`, etc.) whenever the main view changes.
🎯 **Why:** While the topbar buttons received proper active states, the duplicate navigation buttons in the sidebar did not. This created an ambiguous state for screen reader users and keyboard navigators interacting with the sidebar, as they wouldn't know which page they were currently on.
♿ **Accessibility:** Screen readers will now announce "current page" when focusing on the active sidebar navigation item, significantly improving orientation within the single-page application.

---
*PR created automatically by Jules for task [9417121923487732280](https://jules.google.com/task/9417121923487732280) started by @jnorthrup*