### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS via pipe buffer deadlock in ProcessBuilder waitFor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `generateKey()` method in `Rfc6455Handshake.kt` used a highly predictable linear shift-XOR algorithm seeded by the system clock (`Clock.System.now().toEpochMilliseconds()`) to generate the `Sec-WebSocket-Key`.
 **Learning:** Using predictable, time-based PRNGs for cryptographic nonces like `Sec-WebSocket-Key` makes the handshake susceptible to prediction or replay attacks. While the RFC 6455 states this key is not meant for authentication, it is meant to prove the request is actually a WebSocket request and to prevent caching proxy issues, so it should still be robustly random.
 **Prevention:** Always use standard, secure-by-default libraries for random number generation (e.g., `kotlin.random.Random.Default.nextBytes` or `SecureRandom`) instead of rolling custom cryptographic algorithms or using simple PRNGs.
+
+## 2024-05-24 - [Denial of Service via Pipe Buffer Deadlock]
+**Vulnerability:** Calling `Process.waitFor()` before fully reading the child process's standard output/error (or reading synchronously before `waitFor()` without a timeout).
+**Learning:** If a child process writes more data to standard output/error than the OS pipe buffer can hold, it will block until the buffer is drained. If the parent thread is simultaneously blocked on `waitFor()` waiting for the child to exit (or blocked on a synchronous stream read while the child hangs), it creates a deadlock or thread starvation, leading to a Denial of Service.
+**Prevention:** Always read process streams asynchronously (e.g., via Kotlin coroutines `async` or Java `CompletableFuture`) while the main thread safely awaits the process completion using a bounded `waitFor(timeout)` call. If a timeout occurs, terminate the process aggressively via `destroyForcibly()`.

--- a/plan.md
+++ b/plan.md
@@ -1,81 +1,12 @@
-Wait, what if `TrikeShedGraalVfs` doesn't have an `instanceId` yet?
-I need to add `instanceId: String = "global"` to the constructor, and pass it from `GraalBtrfsSupervisor`.
-And I need a `private val canonicalizer = borg.trikeshed.userspace.containment.createFusePathCanonicalizer(instanceId)`.
-
-In `relativeOf`:
-```kotlin
-    private fun relativeOf(path: Path): String {
-        val absolute = toAbsolutePath(path)
-        val text = absolute.toString().replace('\\', '/')
-        require(text.startsWith('/')) { "VFS path did not normalize absolute: $path" }
-        val relative = text.removePrefix("/").trimEnd('/')
-        require(relative.split('/').none { it == ".." }) { "VFS traversal rejected: $path" }
-
-        if (relative.isEmpty()) return ""
-        val segments = relative.split('/')
-        if (segments.size > 1 && (segments[0] == "workspace" || segments[0] == "tmp")) {
-            val unmasked = canonicalizer.resolveOriginal(segments[1]) ?: segments[1]
-            val originalSegments = segments.toMutableList()
-            originalSegments[1] = unmasked
-            return originalSegments.joinToString("/")
-        }
-
-        return relative
-    }
-```
-
-In `newDirectoryStream`:
-```kotlin
-    override fun newDirectoryStream(path: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> {
-        val relative = relativeOf(path)
-        val children = btrfs.listDirectory(liveSubvolume, relative) ?: throw java.nio.file.NotDirectoryException(path.toString())
-        val parent = toAbsolutePath(path)
-        return object : DirectoryStream<Path> {
-            private var open = true
-            override fun iterator(): MutableIterator<Path> {
-                check(open) { "directory stream closed" }
-                val maskedChildren = if (relative == "workspace" || relative == "tmp") {
-                    children.map { childName ->
-                        val childRelative = if (relative.isEmpty()) childName else "$relative/$childName"
-                        val isDir = btrfs.isDirectory(liveSubvolume, childRelative)
-                        canonicalizer.canonicalizePath(childName, isDir)
-                    }
-                } else {
-                    children
-                }
-                val accepted = maskedChildren.asSequence().map(parent::resolve).filter { child -> filter.accept(child) }.iterator()
-                return object : MutableIterator<Path> {
-                    override fun hasNext(): Boolean = accepted.hasNext()
-                    override fun next(): Path = accepted.next()
-                    override fun remove(): Unit = throw UnsupportedOperationException("read-only iterator")
-                }
-            }
-            override fun close() { open = false }
-        }
-    }
-```
-
-Wait, `canonicalizer.canonicalizePath(childName, isDir)` stores the mapping in `canonicalizer` so `resolveOriginal` can work later!
-So when `relativeOf` calls `resolveOriginal`, it will find it!
-This requires that the guest lists the directory BEFORE accessing it. But that's standard semantics! If the guest somehow magically guesses `dir_xxxx`, it's not mapped unless it listed it first?
-Actually, what if the guest accesses it without listing?
-If the guest accesses it without listing, `resolveOriginal` will return null, so it will fall back to `segments[1]`.
-Then BTRFS will look for `dir_xxxx`. It won't find it, because BTRFS has `remote_probe_pending_hold_swarm`.
-But the guest can't magically guess `dir_xxxx` anyway. It will list it first.
-
-Wait! What if the host puts a file, then the guest reads it. The host doesn't use `canonicalizer`!
-Yes, the host uses `GraalBtrfsSupervisor.put("workspace/remote_probe_pending_hold_swarm/file.txt", bytes)`.
-`GraalBtrfsSupervisor` uses `vfs.put`.
-`vfs.put` uses `relativeOf`.
-If `relativeOf` sees `remote_probe_pending_hold_swarm` (which is NOT a hash), `resolveOriginal` returns null. So it falls back to `remote_probe_pending_hold_swarm`.
-BTRFS stores it under `workspace/remote_probe_pending_hold_swarm/file.txt`.
-Then the guest runs `ls /workspace`.
-`newDirectoryStream` lists `"workspace"`.
-BTRFS returns `["remote_probe_pending_hold_swarm"]`.
-`newDirectoryStream` masks it using `canonicalizePath("remote_probe_pending_hold_swarm", isDir)`. This populates the `canonicalizer` map with `dir_0a4f91e -> remote_probe_pending_hold_swarm`.
-It yields `/workspace/dir_0a4f91e` to the guest.
-The guest accesses `/workspace/dir_0a4f91e/file.txt`.
-`relativeOf` sees `dir_0a4f91e`. It calls `resolveOriginal("dir_0a4f91e")`, which returns `remote_probe_pending_hold_swarm`.
-It resolves the path to `workspace/remote_probe_pending_hold_swarm/file.txt`.
-BTRFS reads the file!
-It works flawlessly!
+1. **Fix `QaLaguna.kt` Deadlock Risk:**
+   - In `src/jvmMain/kotlin/borg/trikeshed/jules/QaLaguna.kt`, `conflictFiles` launches a git process and calls `p.waitFor(10_000)` *before* reading `inputStream`. If git produces a large output, it blocks writing to the OS pipe until the buffer is read, but the caller thread is blocked on `waitFor`.
+   - Update it to use `coroutineScope`, an `async` block for reading `readText()`, bounded `waitFor(10_000, TimeUnit.MILLISECONDS)` with `destroyForcibly()` if it timeouts, and then `await()`.
+2. **Fix `HeatSoak.kt` Deadlock Risk:**
+   - In `src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt`, `classHistogram` calls `readLines()` synchronously before `waitFor()`. If the process hangs, `readLines()` blocks indefinitely.
+   - Update it to read asynchronously via `CompletableFuture.supplyAsync`, call bounded `waitFor(5, TimeUnit.SECONDS)` with `destroyForcibly()`, and `get()` the result.
+3. **Verify Changes:**
+   - Compile JVM targets: `./gradlew :jvmMainClasses --no-daemon` to ensure correct syntax.
+4. **Complete pre-commit steps:**
+   - Pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit PR:**
+   - Create a PR using `submit` tool to address this DoS / Thread Starvation deadlock security issue.

--- a/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/graal/subvm/demo/HeatSoak.kt
@@ -210,7 +210,13 @@ object HeatSoak {
     fun classHistogram(n: Int): String = runCatching {
         val jcmd = java.io.File(System.getProperty("java.home"), "bin/jcmd").path
         val p = ProcessBuilder(jcmd, ProcessHandle.current().pid().toString(), "GC.class_histogram").redirectErrorStream(true).start()
-        val lines = p.inputStream.bufferedReader().readLines(); p.waitFor()
+        val future = java.util.concurrent.CompletableFuture.supplyAsync {
+            p.inputStream.bufferedReader().readLines()
+        }
+        if (!p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+            p.destroyForcibly()
+        }
+        val lines = runCatching { future.get(1, java.util.concurrent.TimeUnit.SECONDS) }.getOrDefault(emptyList())
         "\n── class histogram (live, top $n) ──\n" + lines.take(n + 3).joinToString("\n") { it.take(140) }
     }.getOrElse { "\n── class histogram unavailable: $it" }
 

--- a/src/jvmMain/kotlin/borg/trikeshed/jules/QaLaguna.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/jules/QaLaguna.kt
@@ -1,5 +1,6 @@
 package borg.trikeshed.jules
 
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 
@@ -121,15 +122,17 @@ object QaLaguna {
     /** Files with unresolved conflict markers. */
     private suspend fun conflictFiles(repoDir: File): List<String> {
         suspend fun git(vararg args: String): List<String> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            val p = ProcessBuilder("git", *args)
-                .directory(repoDir)
-                .redirectErrorStream(true)
-                .start()
-            if (!p.waitFor(10_000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
-                p.destroy()
+            kotlinx.coroutines.coroutineScope {
+                val p = ProcessBuilder("git", *args)
+                    .directory(repoDir)
+                    .redirectErrorStream(true)
+                    .start()
+                val outDeferred = this.async { p.inputStream.bufferedReader().readText() }
+                if (!p.waitFor(10_000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                    p.destroyForcibly()
+                }
+                outDeferred.await().trim().lines().filter { it.isNotBlank() }
             }
-            p.inputStream.bufferedReader().readText().trim().lines()
-                .filter { it.isNotBlank() }
         }
         val unmerged = git("diff", "--name-only", "--diff-filter=U")
         val marked = git("grep", "-l", "^<<<<<<< ", "--").filter { path ->

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,17 +1,89 @@
-1. **Create `DeterministicFormatter` interface/object:**
-   - Location: `src/commonMain/kotlin/borg/trikeshed/userspace/containment/DeterministicFormatter.kt`
-   - Purpose: Normalize whitespace, blank lines, and file endings in patch strings.
-   - Requirements:
-     - Remove trailing whitespaces
-     - Collapse multiple blank lines into a single blank line
-     - Ensure exactly one trailing newline at the end of the file.
-     - (Maybe convert tabs to spaces, but let's check what formatting rules are implicitly needed. The prompt mentions "deterministic whitespace/ordering normalization applied to patch source before AST lint").
+1. **Identify Vulnerability:** Review `JvmVitals.kt`, `QaLaguna.kt`, `JulesSettlementCli.kt`, and `JulesDrainDedupeCli.kt` where `Process.waitFor()` is called. These instances synchronously block on `waitFor()` before completely reading the process streams or read streams synchronously before calling `waitFor()`, which can lead to Denial of Service via pipe buffer deadlock (a known issue recorded in `.jules/sentinel.md`).
 
-2. **Create `DeterministicFormatterTest` class:**
-   - Location: `src/commonTest/kotlin/borg/trikeshed/userspace/containment/DeterministicFormatterTest.kt`
-   - Purpose: Verify that the `DeterministicFormatter` correctly formats strings according to rules.
+2. **Fix `JvmVitals.kt`:** Modify the timeout and thread logic.
+3. **Fix `QaLaguna.kt`:** Read `inputStream` using `async` or an asynchronous thread while using `withTimeout` for `waitFor()`.
+4. **Fix `JulesSettlementCli.kt` and `JulesDrainDedupeCli.kt`**: ensure streams are consumed asynchronously before `waitFor()`. Wait, in `JulesDrainDedupeCli.kt` and `JulesSettlementCli.kt`, they are using `this.async` from a coroutine scope. It is already reading asynchronously. In `JvmVitals.kt`, they are reading it in a thread. In `QaLaguna.kt`:
+```kotlin
+        suspend fun git(vararg args: String): List<String> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            val p = ProcessBuilder("git", *args)
+                .directory(repoDir)
+                .redirectErrorStream(true)
+                .start()
+            if (!p.waitFor(10_000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                p.destroy()
+            }
+            p.inputStream.bufferedReader().readText().trim().lines()
+                .filter { it.isNotBlank() }
+        }
+```
+In `QaLaguna.kt`, `readText()` is called *after* `waitFor()`. If the process writes more than the pipe buffer size to stdout/stderr, it blocks trying to write to the pipe. But `QaLaguna.kt` is blocked on `waitFor()`, waiting for the process to exit. Deadlock.
 
-3. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+Let's check `HeatSoak.kt`:
+```kotlin
+    fun classHistogram(n: Int): String = runCatching {
+        val jcmd = java.io.File(System.getProperty("java.home"), "bin/jcmd").path
+        val p = ProcessBuilder(jcmd, ProcessHandle.current().pid().toString(), "GC.class_histogram").redirectErrorStream(true).start()
+        val lines = p.inputStream.bufferedReader().readLines(); p.waitFor()
+        "\n── class histogram (live, top $n) ──\n" + lines.take(n + 3).joinToString("\n") { it.take(140) }
+    }.getOrElse { "\n── class histogram unavailable: $it" }
+```
+Here it synchronously reads all lines *before* calling `waitFor()`. This doesn't deadlock because `readLines()` consumes the pipe, allowing the process to finish and exit, then `waitFor()` returns. But there is no timeout on `waitFor()` here, which is another issue ("Denial of Service via Unbounded waitFor"). Wait, no, `readLines()` will block if the process hangs and keeps the stream open without outputting.
 
-4. **Verify GATE condition:**
-   - `./gradlew jvmMainClasses --console=plain`
+Let's check `JvmVitals.kt` line 258:
+```kotlin
+            try {
+                val pid = ProcessHandle.current().pid()
+                val javaExe = ProcessHandle.current().info().command().orElse("java")
+                val dir = javaExe.substringBeforeLast('/', "")
+                val jcmd = if (dir.isNotEmpty()) "$dir/jcmd" else "jcmd"
+                val p = ProcessBuilder(jcmd, pid.toString(), "GC.class_histogram")
+                    .redirectErrorStream(true).start()
+                val out = java.util.concurrent.atomic.AtomicReference("")
+                val reader = Thread { runCatching { out.set(p.inputStream.bufferedReader().readText()) } }
+                reader.isDaemon = true
+                reader.name = "jvmvitals-class-histogram-reader"
+                reader.start()
+                reader.join(JCMD_TIMEOUT_MS)
+                // The worker kills the child on timeout — the main thread never calls waitFor/destroy.
+```
+This looks ok because it joins the reader thread with a timeout.
+
+Let's fix `QaLaguna.kt`.
+And `HeatSoak.kt`.
+
+Wait, the memory prompt says:
+* When enforcing process timeouts in Kotlin coroutines (e.g., `process.waitFor(1, TimeUnit.HOURS)`) to prevent DoS, never synchronously read the process's `InputStream` (via `readText()` or `readLines()`) beforehand, as it blocks indefinitely if the child process hangs without closing its output. Instead, use a `coroutineScope`, wrap the stream read in an `async` block, execute the bounded `waitFor`, and then `await()` the result.
+* When enforcing process timeouts in non-coroutine Java/Kotlin contexts to prevent DoS via pipe buffer deadlocks, never synchronously read the process's `InputStream`. Instead, use `java.util.concurrent.CompletableFuture.supplyAsync` (or `runAsync`) to read the stream asynchronously, execute a bounded `waitFor`, and then `get()` the result.
+
+So for `QaLaguna.kt`:
+```kotlin
+        suspend fun git(vararg args: String): List<String> = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            kotlinx.coroutines.coroutineScope {
+                val p = ProcessBuilder("git", *args)
+                    .directory(repoDir)
+                    .redirectErrorStream(true)
+                    .start()
+                val outDeferred = this.async { p.inputStream.bufferedReader().readText() }
+                if (!p.waitFor(10_000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                    p.destroyForcibly()
+                }
+                outDeferred.await().trim().lines().filter { it.isNotBlank() }
+            }
+        }
+```
+
+For `HeatSoak.kt`:
+```kotlin
+    fun classHistogram(n: Int): String = runCatching {
+        val jcmd = java.io.File(System.getProperty("java.home"), "bin/jcmd").path
+        val p = ProcessBuilder(jcmd, ProcessHandle.current().pid().toString(), "GC.class_histogram").redirectErrorStream(true).start()
+        val future = java.util.concurrent.CompletableFuture.supplyAsync {
+            p.inputStream.bufferedReader().readLines()
+        }
+        if (!p.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+            p.destroyForcibly()
+        }
+        val lines = runCatching { future.get(1, java.util.concurrent.TimeUnit.SECONDS) }.getOrDefault(emptyList())
+        "\n── class histogram (live, top $n) ──\n" + lines.take(n + 3).joinToString("\n") { it.take(140) }
+    }.getOrElse { "\n── class histogram unavailable: $it" }
+```


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When reading a process stream synchronously *before* `waitFor()` (or waiting for process exit before fully reading streams), a pipe buffer deadlock and thread starvation can occur if the subprocess hangs or outputs more data than the OS pipe buffer can hold.
🎯 Impact: Denial of Service (DoS). The calling thread becomes permanently stuck, and the subprocess lingers.
🔧 Fix: Adopted asynchronous stream reading via Kotlin's `async` and Java's `CompletableFuture` alongside bounded `waitFor()` calls with `destroyForcibly()` to safely timeout.
✅ Verification: Ran JVM compilation and test suite (HeatSoakTest, QaLagunaTest) successfully.

---
*PR created automatically by Jules for task [18380543544369340595](https://jules.google.com/task/18380543544369340595) started by @jnorthrup*