### PR TITLE
⚡ Bolt: Remove redundant `map { it }` identity transform

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-10-26 - Avoid O(N) allocation on materialized collections
+**Learning:** In Kotlin, using `.map { it }` on an already materialized collection (such as a `List` returned by `Files.readAllLines`) is a redundant identity transform that needlessly copies the entire list, wasting O(N) time and memory.
+**Action:** Remove it to return the original list directly.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
**💡 What**: Removed a redundant `.map { it }` identity transform on the result of `Files.readAllLines` in `ReadLines.kt`.
**🎯 Why**: `Files.readAllLines` already allocates and returns a new `List<String>`. Chaining `.map { it }` forces Kotlin to iterate over that entire list again to allocate and populate a brand new `ArrayList` with the exact same strings, wasting memory and CPU cycles needlessly.
**📊 Impact**: Saves an $O(N)$ list allocation and a full pass of execution overhead every time a file's lines are read into memory.
**🔬 Measurement**: To verify, checking memory profiles will show zero allocations of intermediate ArrayLists from this line. You can confirm tests pass by running `./gradlew :jvmTest --tests '*FilesTest'`.

---
*PR created automatically by Jules for task [5919844668792147379](https://jules.google.com/task/5919844668792147379) started by @jnorthrup*