### PR TITLE
⚡ Bolt: Remove redundant map allocations in ReadLines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,6 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+## 2026-10-26 - Avoid redundant `.map { it }` on JVM ReadLines actuals
+**Learning:** In Kotlin, using `.map { it }` on a collection (e.g., `Files.readAllLines(path).map { it }`) is a redundant identity transform. It needlessly allocates a full copy of the list, increasing heap allocations and GC pressure in hot paths.
+**Action:** Remove redundant `.map { it }` calls to directly return the list and avoid the O(N) allocation overhead.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 **What:** Removed a redundant `.map { it }` identity transform when calling `Files.readAllLines(path)` in the JVM `ReadLines` actual.

🎯 **Why:** `Files.readAllLines(path)` already returns a `java.util.List<String>`, which seamlessly fulfills Kotlin's read-only `List<String>` return type requirement. Adding `.map { it }` creates an entirely new `ArrayList` containing the same elements, introducing an unnecessary O(N) allocation and increasing garbage collection overhead in hot paths.

📊 **Impact:** Reduces object allocations by a full list copy for every invocation of `readLines` on the JVM.

🔬 **Measurement:** Verify tests run successfully using `./gradlew :jvmMainClasses :jvmTest --tests 'borg.trikeshed.common.FilesTest*' --no-daemon`. Profiling a file read before and after will show one fewer `ArrayList` allocation per invocation.

---
*PR created automatically by Jules for task [1347311716355117455](https://jules.google.com/task/1347311716355117455) started by @jnorthrup*