### PR TITLE
🎨 Palette: Synchronize sidebar navigation active states

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1318,15 +1318,20 @@
   });
 
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const SIDEBAR_BTNS = { doc: document.getElementById('btn-home'), board: document.getElementById('btn-board'), graph: document.getElementById('btn-graph'), sheet: document.getElementById('btn-sheet'), host: document.getElementById('btn-host') };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
       btn.classList.toggle('active', k === view);
+      const sideBtn = SIDEBAR_BTNS[k];
+      if (sideBtn) sideBtn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');
+        if (sideBtn) sideBtn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+        if (sideBtn) sideBtn.removeAttribute('aria-current');
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }


### PR DESCRIPTION
💡 What: The UX enhancement added `aria-current="page"` and visual `.active` class synchronization to the sidebar navigation buttons when changing views.
🎯 Why: Without this, users relying on screen readers wouldn't know which sidebar view was actively selected (and keyboard focus / CSS highlights were missing for mouse users).
📸 Before/After: Sidebar buttons like "Sheet" or "Board" now display a gray active background and appropriate ARIA roles when activated.
♿ Accessibility: Ensures WCAG compliance by explicitly announcing the active state to screen readers on custom single-page app navigations.

---
*PR created automatically by Jules for task [15969824106785082289](https://jules.google.com/task/15969824106785082289) started by @jnorthrup*