### PR TITLE
🎨 Palette: [Synchronized duplicate navigation states]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2025-02-23 - Synchronized Duplicate Navigation Active States
+**Learning:** When an SPA provides multiple ways to navigate to the same view (e.g., topbar and sidebar navigation buttons), failing to synchronize their visual active states and `aria-current="page"` attributes leaves screen reader users with ambiguous or conflicting state information.
+**Action:** Ensure all duplicate instances of navigation buttons for the active view consistently receive visual active state updates and the `aria-current="page"` attribute.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,23 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = {
+    doc: [docScrollEl, [viewDocBtn, document.getElementById('btn-home')]],
+    board: [boardScrollEl, [viewBoardBtn, document.getElementById('btn-board')]],
+    graph: [graphScrollEl, [viewGraphBtn, document.getElementById('btn-graph')]],
+    sheet: [sheetScrollEl, [viewSheetBtn, document.getElementById('btn-sheet')]],
+    shape: [shapeScrollEl, [viewShapeBtn]],
+    host: [hostScrollEl, [viewHostBtn, document.getElementById('btn-host')]]
+  };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, btns]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
-      btn.classList.toggle('active', k === view);
+      btns.forEach(btn => { if (btn) btn.classList.toggle('active', k === view); });
       if (k === view) {
-        btn.setAttribute('aria-current', 'page');
+        btns.forEach(btn => { if (btn) btn.setAttribute('aria-current', 'page'); });
       } else {
-        btn.removeAttribute('aria-current');
+        btns.forEach(btn => { if (btn) btn.removeAttribute('aria-current'); });
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }
@@ -1336,12 +1343,7 @@
     if (view === 'host') renderHost();
   }
 
-  for (const [k, [, btn]] of Object.entries(VIEWS)) btn.addEventListener('click', () => setView(k));
-  document.getElementById('btn-board').addEventListener('click', () => setView('board'));
-  document.getElementById('btn-graph').addEventListener('click', () => setView('graph'));
-  document.getElementById('btn-sheet').addEventListener('click', () => setView('sheet'));
-  document.getElementById('btn-host').addEventListener('click', () => setView('host'));
-  document.getElementById('btn-home').addEventListener('click', () => setView('doc'));
+  for (const [k, [, btns]] of Object.entries(VIEWS)) btns.forEach(btn => { if (btn) btn.addEventListener('click', () => setView(k)); });
   document.getElementById('btn-new-page').addEventListener('click', () => {
     newPage();
     renderAll();

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--hover-strong); font-weight: 500; }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
💡 **What:** Refactored the view-switching logic to correctly synchronize the visual active states (CSS class `.active`) and screen reader state attributes (`aria-current="page"`) for duplicate navigation buttons across the interface (specifically between the topbar and the sidebar).
🎯 **Why:** Because the SPA has multiple access points for the same view, clicking a view button in one location previously left the duplicate buttons in an ambiguous, unsynchronized state, leading to a degraded experience for screen reader users and inconsistent visual indicators for sighted users.
📸 **Before/After:** Included screenshots of synchronized states via Playwright verification (e.g., both the sidebar "Board" and topbar "Board" buttons receiving active focus simultaneously).
♿ **Accessibility:** Applied `aria-current="page"` properly and consistently to all components linking to the actively displayed view so that screen readers correctly announce the user's location, regardless of which UI element they interact with.

---
*PR created automatically by Jules for task [13061811296034537326](https://jules.google.com/task/13061811296034537326) started by @jnorthrup*