### PR TITLE
🎨 Palette: Add alt text to dynamic gallery images

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,7 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+
+## 2024-11-20 - Alt text for dynamically created images
+**Learning:** Dynamically created image elements (e.g., via `document.createElement("img")`) often miss the `alt` attribute, breaking accessibility for screen reader users.
+**Action:** Always add an `alt` attribute using `setAttribute("alt", ...)` when dynamically creating image elements, using a meaningful title or a fallback.

--- a/src/jsMain/kotlin/borg/trikeshed/forge/gallery/GalleryRenderer.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/forge/gallery/GalleryRenderer.kt
@@ -54,8 +54,10 @@ class GalleryRenderer {
     private fun renderImageCard(item: dynamic): Element {
         val el = createBaseCard(item)
         val imgUrl = item.objectUrl as? String ?: ""
+        val altText = item.title as? String ?: "Image"
         val img = document.createElement("img")
         img.setAttribute("src", imgUrl)
+        img.setAttribute("alt", altText)
         img.setAttribute("style", "max-width: 100%; height: auto;")
         el.appendChild(img)
         return el


### PR DESCRIPTION
💡 What: Added an `alt` attribute to dynamically created `<img/>` elements in the Gallery UI.
🎯 Why: Without an `alt` attribute, dynamically generated images fail accessibility checks and provide poor experience for screen reader users since they will lack meaningful context on what is being displayed in the image card.
📸 Before/After: Before this change, the `renderImageCard` injected `<img>` tags strictly using just the `src` and `style` inline attributes. With this change, they receive an `alt` attribute derived from `item.title` (or the default "Image").
♿ Accessibility: Improved screen reader announcements for gallery image cards.

---
*PR created automatically by Jules for task [15620175637245280240](https://jules.google.com/task/15620175637245280240) started by @jnorthrup*