### PR TITLE
⚡ Bolt: Remove redundant list allocation in readLines

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform on the `List<String>` returned by `Files.readAllLines` in `ReadLines.kt`.
🎯 Why: In Kotlin, calling `.map` on a materialized `List` allocates a completely new `ArrayList` and iterates through the original collection to copy every element. This was causing an unnecessary O(N) memory allocation and CPU overhead every time a file was read via `readLines`.
📊 Impact: Eliminates an O(N) list allocation and copying step in the critical file reading path, improving memory usage and reducing GC pressure.
🔬 Measurement: Verified by running Gradle tests; correct functionality is preserved as the returned type natively satisfies the `List<String>` interface.

---
*PR created automatically by Jules for task [16127802584372370913](https://jules.google.com/task/16127802584372370913) started by @jnorthrup*