### PR TITLE
🎨 Palette: Add active states to sidebar navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2024-05-25 - Syncing active states for duplicate navigation items
+**Learning:** When a single-page application has duplicate navigation buttons (e.g., both topbar and sidebar buttons for the same views), updating the active state (`aria-current="page"` and visual classes) on only one set of buttons leaves the other set in an ambiguous or incorrect state, confusing screen reader users navigating the DOM.
+**Action:** Ensure that view-switching logic globally queries and updates all duplicate instances of navigation buttons for the active view to maintain consistent `aria-current="page"` attributes and visual active states.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1320,6 +1320,8 @@
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
+
+    // Update topbar buttons
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
       btn.classList.toggle('active', k === view);
@@ -1327,6 +1329,27 @@
         btn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+      }
+    }
+
+    // Update sidebar navigation buttons
+    const sidebarMapping = {
+      'doc': 'btn-home',
+      'board': 'btn-board',
+      'graph': 'btn-graph',
+      'sheet': 'btn-sheet',
+      'host': 'btn-host'
+    };
+
+    for (const [v, btnId] of Object.entries(sidebarMapping)) {
+      const sbtn = document.getElementById(btnId);
+      if (sbtn) {
+        sbtn.classList.toggle('active', v === view);
+        if (v === view) {
+          sbtn.setAttribute('aria-current', 'page');
+        } else {
+          sbtn.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--hover-strong); font-weight: 500; }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
* 💡 What: Added visual active states and `aria-current="page"` attributes to sidebar navigation buttons to match the view state.
* 🎯 Why: To keep duplicate navigation UI (topbar and sidebar) consistent for both visual users and screen readers.
* 📸 Before/After: Before, only topbar buttons had active states. After, sidebar buttons update their state visually and semantically when switching views.
* ♿ Accessibility: Ensures screen readers announce the current active view correctly when navigating via the sidebar by adding `aria-current="page"`.

---
*PR created automatically by Jules for task [17480957366909985694](https://jules.google.com/task/17480957366909985694) started by @jnorthrup*