### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant list allocation in readLines

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,5 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+// ⚡ Bolt: Removed redundant `.map { it }` to avoid an unnecessary O(N) allocation.
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform after calling `Files.readAllLines` in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.

🎯 Why: `Files.readAllLines` natively returns a `List<String>`. In Kotlin, chaining `.map { it }` on an already materialized collection needlessly iterates the entire collection and allocates an entirely new `ArrayList` just to apply an identity function.

📊 Impact: Avoids an unnecessary O(N) memory allocation and full collection iteration on the JVM path every time a file is read into memory, reducing GC pressure.

🔬 Measurement: Verified compilation with `./gradlew :jvmMainClasses`. No functional changes were introduced.

---
*PR created automatically by Jules for task [6972947778644321564](https://jules.google.com/task/6972947778644321564) started by @jnorthrup*