### PR TITLE
🎨 Palette: [Accessibility] Add aria-current and active states to sidebar navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2024-05-27 - Synchronizing active states for duplicate navigation elements
+**Learning:** In single-page applications, it's common to have multiple sets of navigation elements (e.g., a topbar and a sidebar) that switch to the same views. Applying `aria-current="page"` and visual `.active` classes to only one set leaves users navigating via the other set without clear feedback on the current active view, creating ambiguous states for screen reader users and keyboard navigators.
+**Action:** When managing view state, ensure that *all* instances of navigation buttons for the active view consistently receive the `aria-current="page"` attribute and visual active state updates, rather than just the primary or most visible set.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1318,10 +1318,21 @@
   });
 
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const SIDEBAR_VIEWS = { doc: 'btn-home', board: 'btn-board', graph: 'btn-graph', sheet: 'btn-sheet', host: 'btn-host' };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
+      btn.classList.toggle('active', k === view);
+      if (k === view) {
+        btn.setAttribute('aria-current', 'page');
+      } else {
+        btn.removeAttribute('aria-current');
+      }
+    }
+    for (const [k, id] of Object.entries(SIDEBAR_VIEWS)) {
+      const btn = document.getElementById(id);
+      if (!btn) continue;
       btn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');


### PR DESCRIPTION
**💡 What:** 
Added logic to `setView` to dynamically toggle the `aria-current="page"` attribute and the `.active` CSS class on the left sidebar navigation items (Home, Board, Graph, Sheet, Host) when the user switches views, keeping them synchronized with the main topbar navigation.

**🎯 Why:** 
In single-page applications, when multiple identical navigation controls (like a topbar and a sidebar) switch the same views, assistive technologies rely on `aria-current` to identify the active state. Previously, only the topbar received these updates, leaving screen reader users navigating via the sidebar unaware of which view was currently active.

**📸 Before/After:** 
_Before:_ Clicking "Graph" in the sidebar changed the view and highlighted the topbar "Graph" button, but the sidebar button remained unstyled and lacked an `aria-current` attribute.
_After:_ Clicking "Graph" highlights both the topbar and sidebar buttons, and correctly applies `aria-current="page"` to both.

**♿ Accessibility:** 
Improves screen reader context by explicitly declaring the currently active SPA view on all associated navigation triggers, addressing a common ambiguity for non-visual users.

---
*PR created automatically by Jules for task [8447647767196904215](https://jules.google.com/task/8447647767196904215) started by @jnorthrup*