### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant identity map on `Files.readAllLines`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-11-20 - Avoid redundant identity mapping on already materialized collections
+**Learning:** In Kotlin, using `.map { it }` on an already materialized collection (such as a `List` returned by `Files.readAllLines`) is a redundant identity transform. It needlessly copies the entire list, allocating an intermediate `ArrayList` and wasting O(N) time and memory.
+**Action:** Remove redundant `.map { it }` calls after functions that already return materialized collections to return the original list directly without extra overhead.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` call from the `readLines` method in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 Why: `Files.readAllLines` already returns a fully materialized `List<String>`. Chaining `.map { it }` immediately after creates a complete, unnecessary copy of the list. This allocates an intermediate `ArrayList` and traverses the list, causing an $O(N)$ penalty in time and heap allocation. 
📊 Impact: Eliminates the unnecessary $O(N)$ list cloning overhead in `readLines`. This will reduce memory allocation, lower GC pressure, and marginally speed up file I/O operations across the JVM backend. 
🔬 Measurement: Verified the code compiles successfully (`./gradlew :jvmMainClasses`) and passes all relevant usages inside the repository (e.g. `WikiNodesMechanicsTest`, `OroborosDaemonCycleTraceTest`, `ConfixCborBoundaryTest`, etc).

---
*PR created automatically by Jules for task [2426821052458345611](https://jules.google.com/task/2426821052458345611) started by @jnorthrup*