### PR TITLE
🎨 Palette: Sync active state and aria-current on duplicate navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,7 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+
+## 2025-05-20 - Syncing active states on duplicate navigation buttons
+**Learning:** When managing view state in a single-page application, duplicate instances of navigation buttons for the active view (e.g., both topbar and sidebar buttons) can result in ambiguous states for screen reader users if they do not consistently reflect the active state.
+**Action:** Ensure that all corresponding navigation elements receive the `aria-current="page"` attribute and visual active state updates simultaneously when the view changes.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1320,13 +1320,17 @@
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, topBtn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
-      btn.classList.toggle('active', k === view);
-      if (k === view) {
-        btn.setAttribute('aria-current', 'page');
-      } else {
-        btn.removeAttribute('aria-current');
+      const sideBtnId = 'btn-' + (k === 'doc' ? 'home' : k);
+      const sideBtn = document.getElementById(sideBtnId);
+      for (const btn of (sideBtn ? [topBtn, sideBtn] : [topBtn])) {
+        btn.classList.toggle('active', k === view);
+        if (k === view) {
+          btn.setAttribute('aria-current', 'page');
+        } else {
+          btn.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }


### PR DESCRIPTION
**💡 What**
Synchronized the `.active` visual state and `aria-current="page"` accessibility attribute between duplicate topbar and sidebar view navigation buttons in `script.js`.

**🎯 Why**
Previously, only the topbar navigation buttons had their active states dynamically updated by `setView()`. When a user switched to a view (e.g. 'Board'), the topbar 'Board' button updated visually and announced correctly to screen readers. However, the exact same 'Board' option in the sidebar remained untouched. This caused ambiguity for screen reader users traversing the UI, as the active state wasn't consistently reflected across all identical navigation items. 

**📸 Before/After**
Before: Clicking "Board" left the sidebar item un-styled and un-announced.
After: Clicking "Board" updates both the topbar button and the sidebar `.sidebar-item` with active styling and `aria-current="page"`. (See attached frontend verification video/screenshot).

**♿ Accessibility**
Ensures all navigation items pointing to the active view consistently receive the `aria-current="page"` attribute, providing robust state announcements for screen reader users regardless of which menu they are navigating.

---
*PR created automatically by Jules for task [11623088566429376151](https://jules.google.com/task/11623088566429376151) started by @jnorthrup*