### PR TITLE
🎨 Palette: Announce active state on sidebar navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2024-05-25 - Synchronize aria-current on duplicated navigation buttons
+**Learning:** When a single-page application has duplicate navigation buttons representing the same view (e.g., a topbar menu and a sidebar menu), updating the active state (such as the `aria-current="page"` attribute and visual active CSS class) on only one set of buttons leaves the other set showing an incorrect, stale state to screen readers and visual users.
+**Action:** When managing view state changes dynamically, ensure the script iterates over *all* instances of the navigation buttons corresponding to that view (e.g., using an array `[topbarBtn, sidebarBtn]`) and updates `aria-current` and active classes synchronously.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,27 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = {
+    doc: [docScrollEl, viewDocBtn, document.getElementById('btn-home')],
+    board: [boardScrollEl, viewBoardBtn, document.getElementById('btn-board')],
+    graph: [graphScrollEl, viewGraphBtn, document.getElementById('btn-graph')],
+    sheet: [sheetScrollEl, viewSheetBtn, document.getElementById('btn-sheet')],
+    shape: [shapeScrollEl, viewShapeBtn, null],
+    host: [hostScrollEl, viewHostBtn, document.getElementById('btn-host')]
+  };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, btn, sidebarBtn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
-      btn.classList.toggle('active', k === view);
-      if (k === view) {
-        btn.setAttribute('aria-current', 'page');
-      } else {
-        btn.removeAttribute('aria-current');
+
+      const buttons = [btn, sidebarBtn].filter(Boolean);
+      for (const b of buttons) {
+        b.classList.toggle('active', k === view);
+        if (k === view) {
+          b.setAttribute('aria-current', 'page');
+        } else {
+          b.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }


### PR DESCRIPTION
💡 What: Synchronized the active state (`aria-current="page"` and `.active` CSS class) on the sidebar navigation buttons (Home, Board, Graph, etc.) alongside the topbar buttons when switching views.

🎯 Why: The view state switcher (`setView`) was only updating the `aria-current` and active class on the topbar navigation items. Screen reader users exploring the sidebar would not hear which view was currently active because the sidebar items were missing `aria-current="page"`. Visual users also lacked a clear highlight state on the sidebar.

📸 Before/After: Before, clicking a view only highlighted the topbar. After, both the sidebar and topbar buttons synchronize correctly to highlight the currently active view. 

♿ Accessibility: Ensures that duplicate navigation lists pointing to the same active view accurately convey the active state (`aria-current="page"`) to assistive technologies simultaneously.

---
*PR created automatically by Jules for task [16899461393671200881](https://jules.google.com/task/16899461393671200881) started by @jnorthrup*