### PR TITLE
⚡ Bolt: Remove redundant list allocation in readLines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,12 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-11-01 - Prevent `ConcurrentModificationException` during Iterable mutation iteration
+**Learning:** Calling `.toList().forEach()` on a mutable list of callbacks/listeners creates a defensive copy of the list. Removing `.toList()` when the underlying collection is modified during iteration (e.g. by a subscriber unsubscribing itself during the `observe` or `update` callback) will result in a `ConcurrentModificationException`.
+**Action:** Retain `.toList()` defensive copying for lists of subscribers, callbacks, and dynamically modified endpoint collections when they are iterated.
+
+
+## 2026-11-02 - Remove redundant `.map { it }` on materialized collections
+**Learning:** Using `.map { it }` on an already materialized list, such as the output of `Files.readAllLines`, is an unnecessary identity transform that needlessly copies the entire list. This increases memory allocation and wastes CPU cycles.
+**Action:** Remove redundant `.map { it }` transformations on materialized collections when returning the original collection is semantically identical.

--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> = borg.trikeshed.userspace.nio.file.Files.readAllLines(Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` chained after `Files.readAllLines` in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.

🎯 Why: `Files.readAllLines()` naturally returns a `List<String>`. Kotlin's `map { it }` performs a full identity transform, needlessly iterating the entire list and allocating a fresh intermediate `ArrayList` containing the exact same elements. This causes an unnecessary O(N) memory allocation and wastes CPU cycles.

📊 Impact: Reduces memory overhead and GC pressure when reading files, as the intermediate copy is entirely eliminated. Time complexity is reduced by removing the secondary O(N) iteration entirely.

🔬 Measurement: Run unit tests `./gradlew :jvmMainClasses :jvmTest --tests 'borg.trikeshed.parse.confix.ConfixSerializationBoundaryTest' --no-daemon` and observe standard heap profiling to verify zero redundant array allocations from file reads.

---
*PR created automatically by Jules for task [17089873818167771253](https://jules.google.com/task/17089873818167771253) started by @jnorthrup*