### PR TITLE
🎨 Palette: Sync active states for duplicate navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2024-10-27 - Consistency across duplicate navigation items
+**Learning:** When managing view state in a single-page application, navigation buttons are sometimes duplicated (e.g., in a sidebar and a topbar). If active visual classes and accessibility attributes (like `aria-current="page"`) are only applied to one set of buttons, it creates an ambiguous and inconsistent state for screen reader users and sighted users relying on the secondary navigation.
+**Action:** Ensure that all duplicate instances of navigation buttons for the active view consistently receive the `aria-current="page"` attribute and visual active state updates to prevent ambiguous states.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1329,6 +1329,18 @@
         btn.removeAttribute('aria-current');
       }
     }
+    const sidebarBtns = { doc: 'btn-home', board: 'btn-board', graph: 'btn-graph', sheet: 'btn-sheet', host: 'btn-host' };
+    for (const [k, id] of Object.entries(sidebarBtns)) {
+      const sbBtn = document.getElementById(id);
+      if (sbBtn) {
+        sbBtn.classList.toggle('active', k === view);
+        if (k === view) {
+          sbBtn.setAttribute('aria-current', 'page');
+        } else {
+          sbBtn.removeAttribute('aria-current');
+        }
+      }
+    }
     if (view === 'board') { renderBoard(); hydrateBoard(); }
     if (view === 'graph') { setGraphMode(graphMode); }
     if (view === 'sheet') renderSheet();

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--accent-soft); color: var(--accent); }
+.sidebar-item.active .sidebar-item-icon { color: var(--accent); }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
💡 What: Added logic in `script.js` to synchronize the `.active` CSS class and `aria-current="page"` attribute for sidebar navigation buttons whenever the main view changes. Also added `.active` styling to `.sidebar-item`s in `styles.css`.
🎯 Why: Duplicate navigation buttons for the same view (e.g. sidebar vs topbar) were getting out of sync. This ensures users consistently know what view they are on, regardless of which navigation group they look at.
📸 Before/After: Sidebar items now show visual feedback (accent background) when their view is active.
♿ Accessibility: The `aria-current="page"` attribute is now properly set on all active navigation controls, resolving ambiguous states for screen reader users traversing the sidebar.

---
*PR created automatically by Jules for task [4631464799665027047](https://jules.google.com/task/4631464799665027047) started by @jnorthrup*