### PR TITLE
🎨 Palette: Sync aria-current on duplicate navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2025-02-23 - Syncing aria-current on duplicate navigation elements
+**Learning:** When managing view state in a single-page application, duplicate instances of navigation buttons for the active view (e.g., both topbar and sidebar buttons) must consistently receive the `aria-current="page"` attribute. Otherwise, screen reader users might encounter ambiguous states where one button indicates it's the current page while its duplicate does not.
+**Action:** Always refactor view-switching logic to apply state changes to all instances of navigation buttons for a given view, rather than just the primary ones.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,26 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = {
+    doc: [docScrollEl, [viewDocBtn, document.getElementById('btn-home')]],
+    board: [boardScrollEl, [viewBoardBtn, document.getElementById('btn-board')]],
+    graph: [graphScrollEl, [viewGraphBtn, document.getElementById('btn-graph')]],
+    sheet: [sheetScrollEl, [viewSheetBtn, document.getElementById('btn-sheet')]],
+    shape: [shapeScrollEl, [viewShapeBtn]],
+    host: [hostScrollEl, [viewHostBtn, document.getElementById('btn-host')]]
+  };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, btns]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
-      btn.classList.toggle('active', k === view);
-      if (k === view) {
-        btn.setAttribute('aria-current', 'page');
-      } else {
-        btn.removeAttribute('aria-current');
+      for (const btn of btns) {
+        if (!btn) continue;
+        btn.classList.toggle('active', k === view);
+        if (k === view) {
+          btn.setAttribute('aria-current', 'page');
+        } else {
+          btn.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }
@@ -1336,12 +1346,11 @@
     if (view === 'host') renderHost();
   }
 
-  for (const [k, [, btn]] of Object.entries(VIEWS)) btn.addEventListener('click', () => setView(k));
-  document.getElementById('btn-board').addEventListener('click', () => setView('board'));
-  document.getElementById('btn-graph').addEventListener('click', () => setView('graph'));
-  document.getElementById('btn-sheet').addEventListener('click', () => setView('sheet'));
-  document.getElementById('btn-host').addEventListener('click', () => setView('host'));
-  document.getElementById('btn-home').addEventListener('click', () => setView('doc'));
+  for (const [k, [, btns]] of Object.entries(VIEWS)) {
+    for (const btn of btns) {
+      if (btn) btn.addEventListener('click', () => setView(k));
+    }
+  }
   document.getElementById('btn-new-page').addEventListener('click', () => {
     newPage();
     renderAll();


### PR DESCRIPTION
💡 What: Refactored the `VIEWS` object and `setView` function in `script.js` to support iterating over arrays of duplicate navigation buttons (e.g., topbar and sidebar buttons) for a single view.
🎯 Why: Duplicate buttons need their active and `aria-current` states synced simultaneously so screen reader users hear accurate indications of the current active page, regardless of which menu they navigate. 
📸 Before/After: Before, sidebar buttons would not indicate they were the active page when their view was active. After, both topbar and sidebar buttons correctly receive `aria-current="page"`.
♿ Accessibility: Fixes ambiguous active view indications for screen reader users by properly tracking and announcing the current page on all relevant interactive navigation elements.

---
*PR created automatically by Jules for task [5674151201601486281](https://jules.google.com/task/5674151201601486281) started by @jnorthrup*