### PR TITLE
⚡ Bolt: Remove redundant identity transform in ReadLines.kt

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,4 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed an unnecessary `.map { it }` identity transform in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 Why: The change eliminates redundant O(N) intermediate `ArrayList` allocation and avoids a wasteful collection copy during sequence processing, optimizing memory overhead in hot paths.
📊 Impact: Eliminates O(N) allocation overhead for file line reads and improves execution speed by preventing unnecessary object creations.
🔬 Measurement: Compile the project and ensure `ConfixSerializationBoundaryTest`, `ConfixCborBoundaryTest`, `OroborosDaemonCycleTraceTest`, and `WikiNodesMechanicsTest` pass to verify correctness.

---
*PR created automatically by Jules for task [13708267626491998687](https://jules.google.com/task/13708267626491998687) started by @jnorthrup*