### PR TITLE
🛡️ Sentinel: [HIGH] Fix structural markdown injection in SQLite donor ingest

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/forge/donor/HermesDonorTrace.kt
@@ -67,8 +67,8 @@ object HermesDonorTrace {
                 while (rs.next()) {
                     hasWorkPackages = true
                     val id = rs.getString("id")
-                    val title = rs.getString("title")
-                    val body = rs.getString("body")
+                    val title = escapeMarkdown(rs.getString("title"))
+                    val body = escapeMarkdown(rs.getString("body"))
                     val parentIds = rs.getString("parent_ids")
 
                     // id needs to match "^([A-Z][0-9]+)$"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Structural Markdown injection via unsanitized task titles and bodies from SQLite DB.
🎯 Impact: Malicious actors could inject fake tasks, fake dependencies, or modify the Kanban board by exploiting the Markdown parser through SQLite donor ingest.
🔧 Fix: Wrapped the `title` and `body` fields extracted from the `tasks` table with the existing `escapeMarkdown()` function.
✅ Verification: Ran `HermesDonorTraceTest` explicitly testing `test ingest sqlite prevents structural injection in title and body`, which now passes.

---
*PR created automatically by Jules for task [5692668311452674958](https://jules.google.com/task/5692668311452674958) started by @jnorthrup*