### PR TITLE
⚡ Bolt: Remove redundant identity `.map { it }` allocation from readAllLines

### DIFF
--- a/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt
@@ -10,4 +10,6 @@ actual fun readLinesSeq(path: String): Sequence<String> {
     }
 }
 
-actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path)).map { it }
+// ⚡ Bolt: Removed redundant `.map { it }` which unnecessarily allocated an O(N) copy of the entire list.
+// returning the result of Files.readAllLines directly avoids this overhead.
+actual fun readLines(path: String): List<String> =borg.trikeshed.userspace.nio.file.Files.readAllLines( Paths.get(path))


### PR DESCRIPTION
💡 What: Removed a redundant `.map { it }` identity transform on the result of `Files.readAllLines` in `src/jvmMain/kotlin/borg/trikeshed/common/ReadLines.kt`.
🎯 Why: `Files.readAllLines` natively returns a `List<String>`. Appending `.map { it }` needlessly iterated over the entire list to allocate a second, completely identical `ArrayList` copy, unnecessarily increasing heap allocation overhead and GC pressure.
📊 Impact: Eliminates an $O(N)$ memory allocation and an $O(N)$ execution step on the critical path of reading file lines into memory.
🔬 Measurement: Code can be measured by inspecting the heap profile during heavy file reads; no secondary `ArrayList` copy will be materialized. Tested by running `readLines` tests.

---
*PR created automatically by Jules for task [13984665341473829744](https://jules.google.com/task/13984665341473829744) started by @jnorthrup*