### PR TITLE
🎨 Palette: Synchronize active state for sidebar navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,6 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+## 2025-02-23 - Active states for duplicate navigation items
+**Learning:** When managing view state in a single-page application (like TrikeShed's frontend), ensure that all duplicate instances of navigation buttons for the active view (e.g., both topbar and sidebar buttons) consistently receive the `aria-current="page"` attribute and visual active state updates to prevent ambiguous states for screen reader users.
+**Action:** Synchronize the `active` class and `aria-current="page"` state for all duplicate navigation buttons across the interface when the active view changes.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,26 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = { doc: [docScrollEl, viewDocBtn, document.getElementById('btn-home')], board: [boardScrollEl, viewBoardBtn, document.getElementById('btn-board')], graph: [graphScrollEl, viewGraphBtn, document.getElementById('btn-graph')], sheet: [sheetScrollEl, viewSheetBtn, document.getElementById('btn-sheet')], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn, document.getElementById('btn-host')] };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
+    for (const [k, [el, btn, sidebarBtn]] of Object.entries(VIEWS)) {
       el.hidden = k !== view;
+
       btn.classList.toggle('active', k === view);
       if (k === view) {
         btn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+      }
+
+      if (sidebarBtn) {
+        sidebarBtn.classList.toggle('active', k === view);
+        if (k === view) {
+          sidebarBtn.setAttribute('aria-current', 'page');
+        } else {
+          sidebarBtn.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--hover-strong); font-weight: 500; }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
💡 What: Synchronized the active state (`.active` CSS class and `aria-current="page"`) for sidebar navigation items when switching views.
🎯 Why: Previously, only the topbar navigation items correctly received the `aria-current="page"` attribute when the view switched, leaving screen reader users unaware of the active view context when navigating the sidebar. Visually, the sidebar items also had no active state.
📸 Before/After: Visual active states now correctly apply to both the sidebar and the topbar in unison.
♿ Accessibility: Ensures `aria-current="page"` is consistently populated for duplicate navigation groups on view change.

---
*PR created automatically by Jules for task [18252850510239450495](https://jules.google.com/task/18252850510239450495) started by @jnorthrup*