### PR TITLE
⚡ Bolt: Remove redundant .toList() before .toSeries() to avoid intermediate array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -179,3 +179,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-08-25 - Avoid redundant identity maps on Sequence before materialization
 **Learning:** In Kotlin, using `.map { it }` on a `Sequence` (e.g. `text.lineSequence().map { it }.toList()`) is a redundant identity transform. It needlessly allocates an intermediate `TransformingSequence` wrapper around the sequence just to apply a no-op identity function, increasing heap allocations in hot paths.
 **Action:** Remove redundant `.map { it }` calls before `.toList()` on Sequences (or simply use `.lines()` for strings).
+
+## 2026-08-25 - Avoid intermediate .toList() when constructing Series
+**Learning:** Calling `.toList().toSeries()` on an `Array`, `List`, or `Set` creates an unnecessary intermediate `ArrayList` allocation. The TrikeShed codebase provides native `.toSeries()` extensions for these collection types that avoid this overhead.
+**Action:** When constructing a `Series` from an existing array or collection, use `.toSeries()` directly without chaining `.toList()` in between.

--- a/src/commonMain/kotlin/borg/trikeshed/collections/associative/FunnelHashIndex.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/collections/associative/FunnelHashIndex.kt
@@ -64,7 +64,7 @@ class FunnelHashIndex<K : Any> internal constructor(
         fun <K : Any> build(keys: Series<K>, seed: Long, slack: Double = 0.20): FunnelHashIndex<K> {
             val d = slack.coerceIn(0.05, 0.50)
             val b = betaFor(d)
-            if (keys.size == 0) return FunnelHashIndex(keys, seed, emptyArray<Level>().toList().toSeries(), d, b)
+            if (keys.size == 0) return FunnelHashIndex(keys, seed, emptyArray<Level>().toSeries(), d, b)
 
             val minCap = (keys.size / (1.0 - d)).toInt().coerceAtLeast(MIN_CAPACITY)
             var capacity = MIN_CAPACITY
@@ -168,7 +168,7 @@ class FunnelHashIndex<K : Any> internal constructor(
                 builtLevels.add(level)
             }
 
-            return FunnelHashIndex(keys, seed, builtLevels.toList().toSeries(), d, b)
+            return FunnelHashIndex(keys, seed, builtLevels.toSeries(), d, b)
         }
 
         private fun calculateBaseCapacity(n: Int): Int {

--- a/src/commonMain/kotlin/modelmux/ModelMux.kt
+++ b/src/commonMain/kotlin/modelmux/ModelMux.kt
@@ -225,7 +225,7 @@ class ModelMux internal constructor(
      * ranking, which is the only selection this method makes.
      */
     fun route(action: AcpAction, vararg requiredCaps: String): RouteResult {
-        val result = router.route(models, action, requiredCaps.toList().toSeries())
+        val result = router.route(models, action, requiredCaps.toSeries())
         if (result.a.size > 0) {
             val chosen = result.a[0]
             val event = ModelSelectionEvent.ModelSelected(
@@ -563,7 +563,7 @@ class ModelMux internal constructor(
     fun listModels(vararg cap: String): Series<AcpModelCard> {
         val cards = models.α { it.b }
         if (cap.isEmpty()) return cards
-        val capSeries = cap.toList().toSeries()
+        val capSeries = cap.toSeries()
         return filtered(cards, capSeries)
     }
 
@@ -663,7 +663,7 @@ class ModelMuxBuilder(private val keyMux: KeyMux) {
          */
         wireModel: String? = null,
     ): ModelMuxBuilder = apply {
-        val capSeries = caps.toList().toSeries()
+        val capSeries = caps.toSeries()
         val action = if ("chat" in caps) "chat" else if ("embed" in caps) "embed" else "complete"
         val tags = buildList {
             if (provider != null) add("provider" j provider)

--- a/src/jvmMain/kotlin/borg/trikeshed/relaxfactory/RelaxHttpServerJvm.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/relaxfactory/RelaxHttpServerJvm.kt
@@ -81,7 +81,7 @@ class RelaxHttpServerJvm(
                 alpnProtocols = arrayOf(
                     TlsApplicationProtocol.HTTP_1_1,
                     TlsApplicationProtocol.H2
-                ).toList().toSeries()
+                ).toSeries()
             )
 
             // Open the HTX Reactor via the NioSupervisor.


### PR DESCRIPTION
💡 What: Removed intermediate `.toList()` method calls before `.toSeries()` on Arrays, Lists, and varargs across `FunnelHashIndex.kt`, `ModelMux.kt` and `RelaxHttpServerJvm.kt`.
🎯 Why: Calling `.toList().toSeries()` on Arrays or Sets constructs a completely unnecessary intermediate `ArrayList` which is immediately discarded. Native `.toSeries()` extensions exist for these types in TrikeShed, allowing direct, zero-allocation wrapping.
📊 Impact: Avoids unnecessary O(N) memory allocations and GC pressure on hot paths when converting varargs and arrays to `Series`.
🔬 Measurement: Verify compilation and tests pass successfully, especially `FunnelHashIndexTest` and `ModelMuxTest`.

---
*PR created automatically by Jules for task [15664182334725267166](https://jules.google.com/task/15664182334725267166) started by @jnorthrup*