### PR TITLE
🎨 Palette: Consistent active state indicators for all navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,7 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+
+## 2024-09-04 - Consistent active states for duplicate navigation
+**Learning:** Single-page applications sometimes duplicate primary navigation items across different UI regions (e.g. topbar and sidebar) to support responsive layouts or quick access. If only one set receives `.active` and `aria-current="page"` updates on view change, screen reader users interacting with the duplicate set are left without context about the current active view, and visual users see no selected state indicator.
+**Action:** When managing view state in JavaScript, ensure all duplicate instances of navigation buttons for the active view consistently receive the `aria-current="page"` attribute and visual active state CSS class updates.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1318,6 +1318,13 @@
   });
 
   const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const SIDEBAR_BTNS = {
+    doc: document.getElementById('btn-home'),
+    board: document.getElementById('btn-board'),
+    graph: document.getElementById('btn-graph'),
+    sheet: document.getElementById('btn-sheet'),
+    host: document.getElementById('btn-host')
+  };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
     for (const [k, [el, btn]] of Object.entries(VIEWS)) {
@@ -1327,6 +1334,13 @@
         btn.setAttribute('aria-current', 'page');
       } else {
         btn.removeAttribute('aria-current');
+      }
+    }
+    for (const [k, btn] of Object.entries(SIDEBAR_BTNS)) {
+      if (btn) {
+        btn.classList.toggle('active', k === view);
+        if (k === view) btn.setAttribute('aria-current', 'page');
+        else btn.removeAttribute('aria-current');
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -82,6 +82,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   user-select: none;
 }
 .sidebar-item:hover { background: var(--hover); }
+.sidebar-item.active { background: var(--hover-strong); font-weight: 500; }
 .sidebar-item-icon {
   width: 20px;
   text-align: center;


### PR DESCRIPTION
💡 What: Added programmatic (`aria-current="page"`) and visual (`.active`) active state synchronization for the sidebar navigation buttons.
🎯 Why: Previously, only the topbar navigation buttons received active states upon view change. The duplicate set of navigation buttons in the sidebar lacked these indicators, leaving screen reader users without semantic context about the current active view, and visual users without a selected state indicator.
📸 Before/After: Before, clicking a sidebar button successfully changed the view, but the button visually remained unselected and unannounced. After, the `.active` styling and `aria-current="page"` accurately reflect the view context.
♿ Accessibility: Ensures that users navigating via assistive technologies receive correct, synced state changes, irrespective of whether they interact with the topbar or sidebar UI region.

---
*PR created automatically by Jules for task [2051654551536943700](https://jules.google.com/task/2051654551536943700) started by @jnorthrup*