### PR TITLE
🎨 Palette: [UX improvement] Sync aria-current for duplicate nav buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -77,3 +77,7 @@
 ## 2024-08-24 - Dynamic ARIA Label Injection
 **Learning:** When dynamically rendering interactive lists in vanilla JS (like page trees, sheet references, or slash menus), screen reader context is lost if we only use CSS classes like `.active` to indicate state.
 **Action:** When creating elements with `document.createElement`, proactively attach explicit, descriptive `aria-label`s that encapsulate both the item's identity and its current state (e.g., `"Active page: Untitled"` or `"Navigate to parent sheet: ..."`).
+
+## 2025-02-23 - Synchronizing active states across duplicated navigation buttons
+**Learning:** When managing view state in a single-page application, ensure that all duplicate instances of navigation buttons for the active view (e.g., both topbar and sidebar buttons) consistently receive the `aria-current="page"` attribute and visual active state updates to prevent ambiguous states for screen reader users.
+**Action:** Always apply state changes to all instances of a duplicated control simultaneously, rather than just the primary one.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1317,16 +1317,26 @@
       .catch((err) => hostLogLine('! ' + err.message));
   });
 
-  const VIEWS = { doc: [docScrollEl, viewDocBtn], board: [boardScrollEl, viewBoardBtn], graph: [graphScrollEl, viewGraphBtn], sheet: [sheetScrollEl, viewSheetBtn], shape: [shapeScrollEl, viewShapeBtn], host: [hostScrollEl, viewHostBtn] };
+  const VIEWS = {
+    doc: { el: docScrollEl, btns: [viewDocBtn, document.getElementById('btn-home')] },
+    board: { el: boardScrollEl, btns: [viewBoardBtn, document.getElementById('btn-board')] },
+    graph: { el: graphScrollEl, btns: [viewGraphBtn, document.getElementById('btn-graph')] },
+    sheet: { el: sheetScrollEl, btns: [viewSheetBtn, document.getElementById('btn-sheet')] },
+    shape: { el: shapeScrollEl, btns: [viewShapeBtn] },
+    host: { el: hostScrollEl, btns: [viewHostBtn, document.getElementById('btn-host')] }
+  };
   function setView(view) {
     mutate((s) => { s.view = view; }, 'view');
-    for (const [k, [el, btn]] of Object.entries(VIEWS)) {
-      el.hidden = k !== view;
-      btn.classList.toggle('active', k === view);
-      if (k === view) {
-        btn.setAttribute('aria-current', 'page');
-      } else {
-        btn.removeAttribute('aria-current');
+    for (const [k, config] of Object.entries(VIEWS)) {
+      config.el.hidden = k !== view;
+      for (const btn of config.btns) {
+        if (!btn) continue;
+        btn.classList.toggle('active', k === view);
+        if (k === view) {
+          btn.setAttribute('aria-current', 'page');
+        } else {
+          btn.removeAttribute('aria-current');
+        }
       }
     }
     if (view === 'board') { renderBoard(); hydrateBoard(); }
@@ -1336,12 +1346,11 @@
     if (view === 'host') renderHost();
   }
 
-  for (const [k, [, btn]] of Object.entries(VIEWS)) btn.addEventListener('click', () => setView(k));
-  document.getElementById('btn-board').addEventListener('click', () => setView('board'));
-  document.getElementById('btn-graph').addEventListener('click', () => setView('graph'));
-  document.getElementById('btn-sheet').addEventListener('click', () => setView('sheet'));
-  document.getElementById('btn-host').addEventListener('click', () => setView('host'));
-  document.getElementById('btn-home').addEventListener('click', () => setView('doc'));
+  for (const [k, config] of Object.entries(VIEWS)) {
+    for (const btn of config.btns) {
+      if (btn) btn.addEventListener('click', () => setView(k));
+    }
+  }
   document.getElementById('btn-new-page').addEventListener('click', () => {
     newPage();
     renderAll();


### PR DESCRIPTION
💡 What: Refactored navigation view switching to synchronize `.active` classes and `aria-current="page"` attributes across all duplicated navigation controls (like identical sidebar and topbar buttons) for the currently active view.

🎯 Why: In the previous implementation, only the primary button in the topbar received the programmatic `aria-current="page"` attribute. Screen reader users exploring via the sidebar list of elements would lose the context of which view they were currently looking at.

📸 Before/After: Visual highlighting (`.active`) and DOM state was verified to accurately replicate across identical elements.

♿ Accessibility: Ensures correct programmatic state (`aria-current="page"`) is propagated to all instances representing a given navigation link to prevent ambiguity for screen reader users traversing different container regions.

---
*PR created automatically by Jules for task [6449805464969164506](https://jules.google.com/task/6449805464969164506) started by @jnorthrup*