### PR TITLE
⚡ Bolt: Remove intermediate list allocations when creating Series from Arrays/Collections

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -244,3 +244,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-10-31 - Avoid Redundant Map Transforms on Materialized Collections
 **Learning:** In Kotlin, chaining `.map { it }` on an already materialized collection (such as the `List<String>` returned by `Files.readAllLines`) is a redundant identity transform. It needlessly iterates over the original collection to allocate and populate a brand new `ArrayList`, wasting O(N) time and memory on the heap.
 **Action:** Remove `.map { it }` calls on methods or objects that already return a fully materialized `List`.
+
+## 2024-06-01 - Avoid intermediate ArrayList allocations when converting to Series
+**Learning:** In TrikeShed, calling `.toList().toSeries()` or `.asList().toSeries()` on an Array, List, or vararg array creates an unnecessary intermediate `ArrayList` allocation. Native `.toSeries()` extensions exist for these collection types.
+**Action:** Call `.toSeries()` directly on arrays, lists, and collections without chaining `.toList()` or `.asList()` first to eliminate O(N) heap allocations.

--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxElement.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxElement.kt
@@ -24,7 +24,7 @@ typealias HtxExchangeResult = Join<HtxExchangeState, HtxFrames>
 
 fun emptyHtxFrames(): HtxFrames = emptySeriesOf()
 
-fun htxFrames(vararg frames: HtxFrame): HtxFrames = frames.asList().toSeries()
+fun htxFrames(vararg frames: HtxFrame): HtxFrames = frames.toSeries() // Bolt: Use .toSeries() directly to avoid intermediate List allocation
 
 fun HtxExchangeResult(
     state: HtxExchangeState,

--- a/src/commonMain/kotlin/borg/trikeshed/htx/HtxRequest.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/htx/HtxRequest.kt
@@ -17,7 +17,7 @@ typealias HtxBody = ByteSeries
 
 fun emptyHtxHeaders(): HtxHeaders = emptySeriesOf()
 fun emptyHtxBody(): HtxBody = ByteSeries(byteArrayOf())
-fun htxHeaders(vararg headers: HtxHeader): HtxHeaders = headers.asList().toSeries()
+fun htxHeaders(vararg headers: HtxHeader): HtxHeaders = headers.toSeries() // Bolt: Use .toSeries() directly to avoid intermediate List allocation
 
 enum class HtxScheme {
     HTTP,

--- a/src/commonMain/kotlin/borg/trikeshed/modelmux/ProviderRegistry.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/modelmux/ProviderRegistry.kt
@@ -2,6 +2,7 @@ package borg.trikeshed.modelmux
 
 import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.j
+import borg.trikeshed.lib.toSeries
 
 class ProviderRegistry {
     private val providers = mutableMapOf<String, ModelProvider>()
@@ -28,6 +29,6 @@ class ProviderRegistry {
         }
     }
 
-    fun descriptors(): Series<ProviderDescriptor> = descriptors.values.toList().let { list -> list.size j list::get }
+    fun descriptors(): Series<ProviderDescriptor> = descriptors.values.toSeries() // Bolt: Use native Collection.toSeries() instead of intermediate list copy
 }
 

--- a/src/commonMain/kotlin/borg/trikeshed/reactor/TlsEndpoint.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/reactor/TlsEndpoint.kt
@@ -36,7 +36,7 @@ typealias TlsCodecResult = Join<TlsFlowState, TlsFrames>
 
 fun emptyTlsFrames(): TlsFrames = emptySeriesOf()
 
-fun tlsFrames(vararg frames: TlsChannelFrame): TlsFrames = frames.asList().toSeries()
+fun tlsFrames(vararg frames: TlsChannelFrame): TlsFrames = frames.toSeries() // Bolt: Use .toSeries() directly to avoid intermediate List allocation
 
 fun TlsCodecResult(
     state: TlsFlowState,

--- a/src/commonTest/kotlin/borg/trikeshed/hermes/HermesOntologySpineTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/hermes/HermesOntologySpineTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class HermesOntologySpineTest {
-    private fun facts(vararg facts: HermesOntologyFact) = facts.toList().toSeries()
+    private fun facts(vararg facts: HermesOntologyFact) = facts.toSeries() // Bolt: Use .toSeries() directly to avoid intermediate List allocation
 
     @Test
     fun semanticAperturesZoomKindThenRootThenPackage() {

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/LcncFanInTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/LcncFanInTest.kt
@@ -32,7 +32,7 @@ class LcncFanInTest {
     )
 
     private fun program(vararg nodes: LcncNode, wires: List<LcncWire>) =
-        LcncProgram("fanin", nodes.toList().toSeries(), wires.toSeries())
+        LcncProgram("fanin", nodes.toSeries() /* Bolt: Use .toSeries() directly to avoid intermediate List allocation */, wires.toSeries())
 
     // ── fan-in ────────────────────────────────────────────────────────────
 

--- a/src/commonTest/kotlin/borg/trikeshed/lcnc/LcncSubprogramRecursionTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lcnc/LcncSubprogramRecursionTest.kt
@@ -21,7 +21,7 @@ class LcncSubprogramRecursionTest {
     )
 
     private fun program(vararg nodes: LcncNode, wires: List<LcncWire> = emptyList()) =
-        LcncProgram("prog", nodes.toList().toSeries(), wires.toSeries())
+        LcncProgram("prog", nodes.toSeries() /* Bolt: Use .toSeries() directly to avoid intermediate List allocation */, wires.toSeries())
 
     @Test
     fun subprogramNodeRunsItsInnerProgramAndKeepsLocalsInvisible() = runBlocking {

--- a/src/commonTest/kotlin/borg/trikeshed/lib/cascade/TrieTest.kt
+++ b/src/commonTest/kotlin/borg/trikeshed/lib/cascade/TrieTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 /** Ports the assertions of the retired collections.associative.trie.{Trie,RadixTree} onto cascade.Trie. */
 class TrieTest {
     private val d = Int.MIN_VALUE
-    private fun k(vararg s: String) = s.toList().toSeries()
+    private fun k(vararg s: String) = s.toSeries() // Bolt: Use .toSeries() directly to avoid intermediate List allocation
 
     @Test
     fun segmentTrie() {

--- a/src/jvmTest/kotlin/borg/trikeshed/forge/server/LcncRdfWireTest.kt
+++ b/src/jvmTest/kotlin/borg/trikeshed/forge/server/LcncRdfWireTest.kt
@@ -21,7 +21,7 @@ class LcncRdfWireTest {
     private val wire = LcncRdfWire(productions = { emptyList() }, causalRules = { emptyList() }, facts = { emptyList() })
 
     private fun program(vararg nodes: LcncNode, wires: List<LcncWire> = emptyList()) =
-        LcncProgram("t", nodes.toList().toSeries(), wires.toSeries())
+        LcncProgram("t", nodes.toSeries() /* Bolt: Use .toSeries() directly to avoid intermediate List allocation */, wires.toSeries())
 
     private fun post(path: String, body: String) = runBlocking { wire.route("POST", path, body, null)!! }
 


### PR DESCRIPTION
💡 What: Removed chained `.toList().toSeries()` and `.asList().toSeries()` calls on arrays and varargs. Replaced them with direct `.toSeries()` calls using native Collection/Array extensions.
🎯 Why: Chaining `.toList()` before `.toSeries()` creates a redundant, intermediate `ArrayList` on the heap, copying all elements just to immediately wrap them in a Series. Direct `.toSeries()` avoids this overhead.
📊 Impact: Eliminates O(N) heap allocations for every Series created from varargs/arrays.
🔬 Measurement: Verify through source code structure and successful execution of test suite using `./gradlew :jvmTest`.

---
*PR created automatically by Jules for task [16839499248199591096](https://jules.google.com/task/16839499248199591096) started by @jnorthrup*