### PR TITLE
⚡ Bolt: [performance improvement] Eliminate O(N) intermediate allocation in KanbanGraph serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -244,3 +244,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-10-31 - Avoid Redundant Map Transforms on Materialized Collections
 **Learning:** In Kotlin, chaining `.map { it }` on an already materialized collection (such as the `List<String>` returned by `Files.readAllLines`) is a redundant identity transform. It needlessly iterates over the original collection to allocate and populate a brand new `ArrayList`, wasting O(N) time and memory on the heap.
 **Action:** Remove `.map { it }` calls on methods or objects that already return a fully materialized `List`.
+
+## 2024-05-30 - Avoid intermediate ArrayList allocations when mapping Series
+**Learning:** Chaining `.toList().map { ... }` on a `Series` collection creates an unnecessary intermediate `ArrayList` allocation.
+**Action:** Use `Series.map { ... }` directly (requires `import borg.trikeshed.lib.map`) to return a mapped List without an intermediate `ArrayList` copy.

--- a/src/commonMain/kotlin/borg/trikeshed/kanban/KanbanGraphConfix.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/KanbanGraphConfix.kt
@@ -2,6 +2,7 @@ package borg.trikeshed.kanban
 
 import borg.trikeshed.lib.toSeries
 import borg.trikeshed.lib.toList
+import borg.trikeshed.lib.map
 import borg.trikeshed.parse.json.JsonSupport
 
 /** Confix document for the orchestration graph; predicate bodies stay runtime-registered. */
@@ -9,9 +10,12 @@ object KanbanGraphConfix {
     fun toJson(graph: KanbanGraph): String = JsonSupport.stringify(linkedMapOf(
         "version" to 2,
         "boardId" to graph.boardId,
-        "lanes" to graph.lanes.toList().map { lane -> linkedMapOf("id" to lane.id, "title" to lane.title, "order" to lane.order, "role" to lane.role, "inputs" to lane.inputs, "outputs" to lane.outputs) },
-        "edges" to graph.edges.toList().map { edge -> linkedMapOf("id" to edge.id, "from" to edge.from, "to" to edge.to, "mode" to edge.mode.name, "group" to edge.group, "requiredBranches" to edge.requiredBranches, "maxIterations" to edge.maxIterations, "condition" to edge.condition?.let { mapOf("predicate" to it.predicate, "parameters" to it.parameters) }) },
-        "cards" to graph.cards.toList().map { card -> linkedMapOf("id" to card.id, "owner" to card.owner, "lane" to card.lane, "state" to card.state, "revision" to card.revision, "io" to card.io, "effects" to card.effects.toList()) },
+        // Bolt: Remove .toList() before map to prevent O(N) allocation
+        "lanes" to graph.lanes.map { lane -> linkedMapOf("id" to lane.id, "title" to lane.title, "order" to lane.order, "role" to lane.role, "inputs" to lane.inputs, "outputs" to lane.outputs) },
+        // Bolt: Remove .toList() before map to prevent O(N) allocation
+        "edges" to graph.edges.map { edge -> linkedMapOf("id" to edge.id, "from" to edge.from, "to" to edge.to, "mode" to edge.mode.name, "group" to edge.group, "requiredBranches" to edge.requiredBranches, "maxIterations" to edge.maxIterations, "condition" to edge.condition?.let { mapOf("predicate" to it.predicate, "parameters" to it.parameters) }) },
+        // Bolt: Remove .toList() before map to prevent O(N) allocation
+        "cards" to graph.cards.map { card -> linkedMapOf("id" to card.id, "owner" to card.owner, "lane" to card.lane, "state" to card.state, "revision" to card.revision, "io" to card.io, "effects" to card.effects.toList()) },
     ))
 
     fun fromJson(json: String): KanbanGraph {


### PR DESCRIPTION
* 💡 What: Removed `.toList()` before `.map` on `Series` instances in `KanbanGraphConfix.kt`.
* 🎯 Why: Chaining `.toList().map` on a `Series` creates an unnecessary intermediate `ArrayList` copy. Using the native `Series.map` avoids this overhead.
* 📊 Impact: Prevents O(N) extra memory allocation and copy for every lane, edge, and card during Kanban graph serialization.
* 🔬 Measurement: Observe reduced memory pressure and faster execution in hot paths serializing graphs.

---
*PR created automatically by Jules for task [2724661125945957886](https://jules.google.com/task/2724661125945957886) started by @jnorthrup*