### PR TITLE
🛡️ Sentinel: [HIGH] Fix environment variable leak in ProcessBuilder

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -62,3 +62,8 @@
 **Vulnerability:** Found `waitFor()` being called on a `Process` without a timeout and while synchronously reading from the process `InputStream` in `CouchWal.java`, `PanamaKanbanMovie.kt`, and `HeatSoak.kt`.
 **Learning:** `Process.waitFor()` without a timeout can lead to Denial of Service (DoS) if the subprocess hangs. Further, reading the input stream synchronously on the main thread before calling `waitFor` can block indefinitely if the process fills the OS pipe buffer or simply hangs, preventing the timeout from ever being reached.
 **Prevention:** Always read process streams asynchronously (e.g., using `CompletableFuture.supplyAsync`) to prevent pipe buffer deadlocks, and explicitly use bounded `waitFor(timeout, TimeUnit)` with forceful termination `destroyForcibly()` on timeout.
+
+## 2024-05-27 - ProcessBuilder Environment Leak in OroborosDaemon
+**Vulnerability:** ProcessBuilder in `OroborosDaemon.kt` inherited the host process environment variables by default when spawning `git fetch` and `git rev-parse`, potentially leaking daemon secrets like API keys to git credential helpers or pre-commit hooks.
+**Learning:** Process spawns, even for trusted binaries like `git`, must explicitly clear the environment and use a whitelisted environment to prevent accidental leakages through credential helpers or hooks.
+**Prevention:** Always explicitly call `environment().clear()` and populate it with `GuestEnvironment.curated()` before starting any process with `ProcessBuilder`.

--- a/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/daemon/OroborosDaemon.kt
@@ -2450,8 +2450,9 @@ object OroborosDaemon {
     internal suspend fun preflight(repoDir: File): Boolean {
         // git fetch origin master (best-effort, 5s timeout)
         val fetchOk = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            val fetch = ProcessBuilder("git", "fetch", "origin", "master", "--dry-run")
-                .directory(repoDir).start()
+            val builder = ProcessBuilder("git", "fetch", "origin", "master", "--dry-run").directory(repoDir)
+            builder.environment().apply { clear(); putAll(borg.trikeshed.graal.subvm.GuestEnvironment.curated()) }
+            val fetch = builder.start()
             val finished = fetch.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
             if (!finished) fetch.destroyForcibly()
             finished && fetch.exitValue() == 0
@@ -2459,7 +2460,9 @@ object OroborosDaemon {
         if (!fetchOk) return true // offline is OK, we'll poll anyway
 
         suspend fun command(vararg args: String): String = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            val p = ProcessBuilder(*args).directory(repoDir).redirectErrorStream(true).start()
+            val builder = ProcessBuilder(*args).directory(repoDir).redirectErrorStream(true)
+            builder.environment().apply { clear(); putAll(borg.trikeshed.graal.subvm.GuestEnvironment.curated()) }
+            val p = builder.start()
             val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { p.inputStream.bufferedReader().readText().trim() }
             val finished = p.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)
             if (!finished) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `ProcessBuilder` implicitly inherited the host process environment variables when executing tools like `git fetch` in `OroborosDaemon.kt`, which could accidentally leak daemon secrets and API keys to git credential helpers or spawned sub-processes.
🎯 Impact: Untrusted git hooks or credential helpers could exfiltrate host environment variables.
🔧 Fix: Explicitly called `builder.environment().clear()` and populated the environment with `GuestEnvironment.curated()` (a safe, whitelisted environment map) before calling `builder.start()`.
✅ Verification: `jvmMainClasses` compiles successfully, and `jvmTest` passes.

---
*PR created automatically by Jules for task [2123232868921710926](https://jules.google.com/task/2123232868921710926) started by @jnorthrup*