### PR TITLE
🎨 Palette: [UX improvement] Global drag affordance on drop zone

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -126,3 +126,7 @@
 ## 2024-05-27 - Context-Specific ARIA Labels for generic buttons
 **Learning:** Adding ARIA labels to generic icon-only or poorly labeled buttons (like 'Fit') provides essential context for screen reader users, but adding ARIA labels that duplicate visible text (like 'Add a page') is redundant and violates WCAG 2.5.3 (Label in Name) best practices unless it provides significant extra context.
 **Action:** Before adding an ARIA label, verify the element's existing text content. Only add `aria-label` if the visible text is insufficient or absent (e.g., icon-only buttons), or if it adds crucial missing context.
+
+## 2026-09-07 - Bridging global drag events to local drop zones
+**Learning:** When an application has a specific drop zone but allows users to drag files anywhere over the window to initiate a drop, failing to provide a global 'dragover' visual affordance on the drop zone leaves users uncertain if their action is valid until they precisely hover over the target.
+**Action:** Bind global 'dragover', 'dragleave', and 'drop' events to the document to add a temporary visual active state class to the specific drop zone element, providing immediate feedback.

--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -1220,8 +1220,9 @@
     Promise.all([...files].map((f) => SHAPE_MEDIA.test(f.name) ? f.arrayBuffer().then((b) => shapeOfBoxes(f.name, b)) : SHAPE_TEXT.test(f.name) ? f.text().then((t) => shapeOf(f.name, t)) : tikaIngest(f)))
       .then((docs) => { shapeDocs.push(...docs); shapePick = null; setView('shape'); });
   }
-  document.addEventListener('dragover', (e) => e.preventDefault());
-  document.addEventListener('drop', (e) => { e.preventDefault(); if (e.dataTransfer.files.length) shapeIngest(e.dataTransfer.files); });
+  document.addEventListener('dragover', (e) => { e.preventDefault(); if (dropZoneEl) dropZoneEl.classList.add('drag-active'); });
+  document.addEventListener('dragleave', (e) => { if (!e.relatedTarget && dropZoneEl) dropZoneEl.classList.remove('drag-active'); });
+  document.addEventListener('drop', (e) => { e.preventDefault(); if (dropZoneEl) dropZoneEl.classList.remove('drag-active'); if (e.dataTransfer.files.length) shapeIngest(e.dataTransfer.files); });
   fileInputEl.addEventListener('change', () => { shapeIngest(fileInputEl.files); fileInputEl.value = ''; });
 
   // ── Render: host (the sub-VM substrate — borg.trikeshed.vm) ─────────

--- a/src/commonMain/resources/web/styles.css
+++ b/src/commonMain/resources/web/styles.css
@@ -114,7 +114,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   text-align: center;
   transition: all 0.2s;
 }
-.drop-zone:hover, .drop-zone:focus-visible {
+.drop-zone:hover, .drop-zone:focus-visible, .drop-zone.drag-active {
   border-color: var(--accent);
   background: var(--accent-soft);
   outline: none;


### PR DESCRIPTION
💡 **What:** Added a visual affordance to the sidebar `dropZoneEl` that triggers when users drag files *anywhere* over the document window, rather than only when precisely hovering over the drop zone.

🎯 **Why:** Previously, the `drop-zone` only had a `:hover` state. However, the app accepts a global document `drop` event for ingestions. Users had no visual indication that their file drag was valid until they dropped it or precisely hovered the sidebar element, leading to uncertainty. Bridging global `dragover` events to the local `dropZoneEl` solves this.

📸 **Before/After:**
- **Before:** Dragging a file over the main document area provided no visual feedback on the drop zone.
- **After:** Dragging a file anywhere over the document window temporarily highlights the drop zone with dashed borders and an active background color, fading out on `dragleave` or `drop`.

♿ **Accessibility:** Reuses existing CSS `.drop-zone:hover` styling, keeping visual language consistent without adding confusing duplicate design tokens.

---
*PR created automatically by Jules for task [8211653703641973153](https://jules.google.com/task/8211653703641973153) started by @jnorthrup*