### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/commonMain/kotlin/narchy/spacegraph/Graph.kt
+++ b/src/commonMain/kotlin/narchy/spacegraph/Graph.kt
@@ -85,7 +85,8 @@ class SpaceGraph(initial: GraphSpec = GraphSpec(), val historyLimit: Int = 128) 
     val canRedo get() = redo.isNotEmpty()
     fun node(id: String) = nodes[id]
     fun edge(id: String) = edges[id]
-    fun snapshot() = GraphSpec(nodes.values.toList().toSeries(), edges.values.toList().toSeries(), camera)
+    // Bolt: Use native toSeries to prevent O(N) allocation
+    fun snapshot() = GraphSpec(nodes.values.toSeries(), edges.values.toSeries(), camera)
     fun subscribe(listener: (GraphChange) -> Unit): () -> Unit { listeners.add(listener); return { listeners.remove(listener) } }
     fun execute(command: GraphCommand, recordHistory: Boolean = true) {
         val before = snapshot()
@@ -195,6 +196,7 @@ class GraphBuilder {
     fun edge(id: String, source: String, target: String, kind: EdgeKind = EdgeKind.Edge, data: NodeData = NodeData()) {
         edges.add(EdgeSpec(id, source, target, kind, data))
     }
-    fun build() = GraphSpec(nodes.toList().toSeries(), edges.toList().toSeries(), camera)
+    // Bolt: Use native toSeries to prevent O(N) allocation
+    fun build() = GraphSpec(nodes.toSeries(), edges.toSeries(), camera)
 }
 fun graph(build: GraphBuilder.() -> Unit) = GraphBuilder().apply(build).build()


### PR DESCRIPTION
💡 What: Replaced `.toList().toSeries()` with `.toSeries()` on already compatible collections in `Graph.kt`.
🎯 Why: Calling `.toList().toSeries()` creates a redundant intermediate `ArrayList`, which generates unnecessary GC pressure and allocates O(N) memory during spatial graph manipulation. The `nodes` and `edges` properties are already `MutableList` instances which are valid `Collection` implementations for the native `.toSeries()` extension in `Series.kt`.
📊 Impact: Eliminates O(N) heap allocations during `Graph.snapshot()` and `Graph.build()`.
🔬 Measurement: Verify using memory profiler on Graph operations or check via compilation that the methods resolve correctly to the `Collection<T>.toSeries()` extension.

---
*PR created automatically by Jules for task [3482889732697817115](https://jules.google.com/task/3482889732697817115) started by @jnorthrup*