### PR TITLE
🎨 Palette: Add aria-current to active page in sidebar

### DIFF
--- a/src/commonMain/resources/web/script.js
+++ b/src/commonMain/resources/web/script.js
@@ -288,6 +288,9 @@
       item.role = 'button';
       item.tabIndex = 0;
       item.setAttribute('aria-label', (isActive ? 'Active page: ' : 'Page: ') + (page.title || 'Untitled'));
+      if (isActive) {
+        item.setAttribute('aria-current', 'page');
+      }
       const toggle = document.createElement('span');
       toggle.className = 'tree-toggle';
       toggle.textContent = page.children && page.children.length ? '▾' : '▸';


### PR DESCRIPTION
💡 **What**: Added the `aria-current="page"` attribute to the active page item in the sidebar's page tree.

🎯 **Why**: To provide clear indication to screen readers about which page is currently active, improving the overall accessibility and user experience.

📸 **Before/After**: The active item now visually sets `aria-current="page"` when it has the `.active` class and removes it when it does not.

♿ **Accessibility**: This change implements the standard WAI-ARIA pattern for indicating the current item within a set of navigational links or items, directly improving the experience for users relying on assistive technologies.

---
*PR created automatically by Jules for task [11762756667968505334](https://jules.google.com/task/11762756667968505334) started by @jnorthrup*