### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via pipe deadlock in FunnelMergeBranchesCli

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -67,3 +67,8 @@
 **Vulnerability:** ProcessBuilder in `OroborosDaemon.kt` inherited the host process environment variables by default when spawning `git fetch` and `git rev-parse`, potentially leaking daemon secrets like API keys to git credential helpers or pre-commit hooks.
 **Learning:** Process spawns, even for trusted binaries like `git`, must explicitly clear the environment and use a whitelisted environment to prevent accidental leakages through credential helpers or hooks.
 **Prevention:** Always explicitly call `environment().clear()` and populate it with `GuestEnvironment.curated()` before starting any process with `ProcessBuilder`.
+
+## 2024-09-09 - [Denial of Service via Pipe Buffer Deadlock in CLI Tools]
+**Vulnerability:** The `FunnelMergeBranchesCli` spawned `git` and `gradle` child processes with synchronous `readText()` on `inputStream` followed by unbounded `waitFor()`.
+**Learning:** Even in CLI scripts or internal tools, OS pipe buffer deadlocks can cause the entire tool to hang indefinitely if a child process produces more output than the pipe buffer limit while the parent thread is blocked reading synchronously or waiting.
+**Prevention:** Ensure all `ProcessBuilder` spawns, regardless of the context (daemon or CLI), use asynchronous stream reading (`CompletableFuture.supplyAsync`) and bounded `waitFor(timeout)` with forceful termination.

--- a/src/jvmMain/kotlin/borg/trikeshed/cas/FunnelMergeBranchesCli.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/cas/FunnelMergeBranchesCli.kt
@@ -230,8 +230,13 @@ class FunnelMergeBranchesCli(private val repoDir: File, private val since: Strin
     private fun gitIn(dir: File, vararg args: String): Pair<Int, String> {
         val pb = ProcessBuilder(listOf("git") + args).directory(dir).redirectErrorStream(true)
         val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        return proc.waitFor() to out
+        val outFuture = java.util.concurrent.CompletableFuture.supplyAsync { proc.inputStream.bufferedReader().readText() }
+        val finished = proc.waitFor(5, java.util.concurrent.TimeUnit.MINUTES)
+        if (!finished) {
+            proc.destroyForcibly()
+            return -1 to "Error: git command timed out"
+        }
+        return proc.exitValue() to outFuture.get()
     }
 
     private fun gradle(dir: File, task: String): Pair<Int, String> {
@@ -239,7 +244,12 @@ class FunnelMergeBranchesCli(private val repoDir: File, private val since: Strin
         val pb = ProcessBuilder(if (gradlew.canExecute()) "./gradlew" else "gradle", task, "--console=plain", "-q")
             .directory(dir).redirectErrorStream(true)
         val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        return proc.waitFor() to out
+        val outFuture = java.util.concurrent.CompletableFuture.supplyAsync { proc.inputStream.bufferedReader().readText() }
+        val finished = proc.waitFor(5, java.util.concurrent.TimeUnit.MINUTES)
+        if (!finished) {
+            proc.destroyForcibly()
+            return -1 to "Error: gradle command timed out"
+        }
+        return proc.exitValue() to outFuture.get()
     }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `FunnelMergeBranchesCli` spawned `git` and `gradle` child processes with synchronous `readText()` on `inputStream` followed by an unbounded `waitFor()`. If the child process output filled the OS pipe buffer, or the child process hung, it would cause a Denial of Service (DoS) via thread starvation/deadlock.
🎯 Impact: The CLI tool could hang indefinitely, blocking whatever workflow invoked it (e.g., CI/CD pipelines, background daemon merges).
🔧 Fix: Implemented `CompletableFuture.supplyAsync` for asynchronous stream reading and added a bounded 5-minute timeout to `waitFor()`. If the timeout is reached, the process is forcefully terminated using `destroyForcibly()`.
✅ Verification: Compiled successfully using `./gradlew :jvmMainClasses` and ran relevant CAS tests using `./gradlew :jvmTest`.

---
*PR created automatically by Jules for task [9143613773321957751](https://jules.google.com/task/9143613773321957751) started by @jnorthrup*