### PR TITLE
🎨 Palette: [UX improvement] Fix aria-current state across duplicate navigation items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -126,3 +126,6 @@
 ## 2024-05-27 - Context-Specific ARIA Labels for generic buttons
 **Learning:** Adding ARIA labels to generic icon-only or poorly labeled buttons (like 'Fit') provides essential context for screen reader users, but adding ARIA labels that duplicate visible text (like 'Add a page') is redundant and violates WCAG 2.5.3 (Label in Name) best practices unless it provides significant extra context.
 **Action:** Before adding an ARIA label, verify the element's existing text content. Only add `aria-label` if the visible text is insufficient or absent (e.g., icon-only buttons), or if it adds crucial missing context.
+## $(date +%Y-%m-%d) - Synchronizing active states for duplicate navigation items
+**Learning:** When managing view state in a single-page application, ensure that all duplicate instances of navigation buttons for the active view (e.g., both topbar and sidebar buttons) consistently receive the `aria-current="page"` attribute and visual active state updates to prevent ambiguous states for screen reader users.
+**Action:** Use `document.querySelectorAll` instead of `document.querySelector` to apply state changes to all instances of a duplicated control simultaneously, rather than just the primary one.

--- a/src/commonMain/resources/web/mux.js
+++ b/src/commonMain/resources/web/mux.js
@@ -254,7 +254,7 @@
   document.addEventListener("visibilitychange",()=>{if(!document.hidden&&state.live)void poll(true);});
   window.addEventListener("resize",()=>{if(page==="stats")renderStats();});
   document.title=titles[page][0]+" | Forge";$("#pageTitle").textContent=titles[page][0];$("#eyebrow").textContent=titles[page][1];$("#breadcrumb").textContent="Workspace / "+titles[page][0];
-  $("#"+page+"View").hidden=false;document.querySelector('[data-page="'+page+'"]').setAttribute("aria-current","page");
+  $("#"+page+"View").hidden=false;document.querySelectorAll('[data-page="'+page+'"]').forEach(el=>el.setAttribute("aria-current","page"));
   html("#pageActions",page==="keys"?'<a href="/mux/stats">Quota activity '+icon("arrow-up-right")+'</a>':page==="stats"?btn("export-activity","Export activity","download"):'<button class="primary" data-action="new">'+icon("plus")+'New session</button>');
   render();void poll(true);
   async function loop(){await poll();setTimeout(loop,2000);}setTimeout(loop,2000);


### PR DESCRIPTION
💡 What: Changed the view switching logic in `mux.js` to use `querySelectorAll` instead of `querySelector` when updating the `aria-current="page"` attribute.
🎯 Why: If there are multiple instances of a navigation link to the current page (e.g. desktop sidebar vs top menu), only the first one found in the DOM was being marked as active. This left other duplicates in an ambiguous state for screen reader users and keyboard navigation.
📸 Before/After: (Not a visual change, structural accessibility improvement)
♿ Accessibility: Ensures that screen readers can correctly identify the currently active page from any duplicated navigation menu on the interface.

---
*PR created automatically by Jules for task [12266718353262853661](https://jules.google.com/task/12266718353262853661) started by @jnorthrup*