### PR TITLE
🎨 Palette: [UX improvement] Synchronize active states across duplicate navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -126,3 +126,6 @@
 ## 2024-05-27 - Context-Specific ARIA Labels for generic buttons
 **Learning:** Adding ARIA labels to generic icon-only or poorly labeled buttons (like 'Fit') provides essential context for screen reader users, but adding ARIA labels that duplicate visible text (like 'Add a page') is redundant and violates WCAG 2.5.3 (Label in Name) best practices unless it provides significant extra context.
 **Action:** Before adding an ARIA label, verify the element's existing text content. Only add `aria-label` if the visible text is insufficient or absent (e.g., icon-only buttons), or if it adds crucial missing context.
+## 2026-09-09 - Synchronizing active states for duplicate navigation links in ModelMux
+**Learning:** When managing view state in a single-page application, updating the active state (such as the `aria-current="page"` attribute and visual active CSS class) on only one set of buttons using `document.querySelector` leaves duplicate navigation elements showing an incorrect, stale state to screen readers and visual users.
+**Action:** When managing view state changes dynamically, ensure the script iterates over *all* instances of the navigation buttons corresponding to that view using `document.querySelectorAll().forEach` to update `aria-current` synchronously.

--- a/src/commonMain/resources/web/mux.js
+++ b/src/commonMain/resources/web/mux.js
@@ -254,7 +254,7 @@
   document.addEventListener("visibilitychange",()=>{if(!document.hidden&&state.live)void poll(true);});
   window.addEventListener("resize",()=>{if(page==="stats")renderStats();});
   document.title=titles[page][0]+" | Forge";$("#pageTitle").textContent=titles[page][0];$("#eyebrow").textContent=titles[page][1];$("#breadcrumb").textContent="Workspace / "+titles[page][0];
-  $("#"+page+"View").hidden=false;document.querySelector('[data-page="'+page+'"]').setAttribute("aria-current","page");
+  $("#"+page+"View").hidden=false;document.querySelectorAll('[data-page="'+page+'"]').forEach(el=>el.setAttribute("aria-current","page"));
   html("#pageActions",page==="keys"?'<a href="/mux/stats">Quota activity '+icon("arrow-up-right")+'</a>':page==="stats"?btn("export-activity","Export activity","download"):'<button class="primary" data-action="new">'+icon("plus")+'New session</button>');
   render();void poll(true);
   async function loop(){await poll();setTimeout(loop,2000);}setTimeout(loop,2000);


### PR DESCRIPTION
💡 What: Modified the view transition logic in `mux.js` to use `querySelectorAll` and `.forEach` when applying the `aria-current="page"` attribute to navigation items.
🎯 Why: In UIs with duplicate navigation controls for the same view (e.g., both topbar and sidebar links), applying the active state to only the first matching element creates an ambiguous state for screen reader users and visual users navigating via the duplicate controls.
📸 Before/After: Before, `document.querySelector` left duplicate links without an active state. After, all links pointing to the active view receive the `aria-current="page"` attribute. (Verified via playwright script)
♿ Accessibility: Ensures that all navigation links corresponding to the active view correctly inform assistive technologies that they represent the current page.

---
*PR created automatically by Jules for task [6254983720265864588](https://jules.google.com/task/6254983720265864588) started by @jnorthrup*