### PR TITLE
⚡ Bolt: [performance improvement] Optimize LcncGraph mating points list manipulations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -259,3 +259,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-11-21 - Series collection return type mismatch
 **Learning:** In TrikeShed, `Series` implements the standard Kotlin `List` interface. The custom `.filter` extension natively returns a `Series`. Therefore, chaining `.toList()` or `.map { it }` on the result of `Series.filter { ... }` just to satisfy a `List` return type is an anti-pattern. It creates an unnecessary O(N) memory allocation and copy.
 **Action:** Return the `Series` directly whenever a `List` is expected instead of coercing it to an `ArrayList` via `.toList()` or `.map { it }`.
+
+## 2026-11-21 - Avoid intermediate List allocations when mapping and filtering Series
+**Learning:** In TrikeShed, using `(0 until series.size).map { series[it] }.filter { ... }.toSeries()` or `...plus(item).toSeries()` on a `Series` object creates expensive intermediate `ArrayList` allocations, wasting O(N) memory and time. The `Series` collection provides a zero-allocation `j` infix constructor for mapping/appending elements and a native `.filter` extension (which requires importing `borg.trikeshed.lib.filter`) that returns a filtered `Series` natively.
+**Action:** Use the `j` infix constructor (e.g., `(size + 1) j { i -> if (i < size) arr[i] else new_element }`) and native `.filter` extensions directly on `Series` collections to prevent intermediate List heap allocations.

--- a/append_journal.sh
+++ b/append_journal.sh
@@ -1,0 +1,4 @@
+echo "" >> .jules/bolt.md
+echo "## 2026-11-21 - Avoid intermediate List allocations when mapping and filtering Series" >> .jules/bolt.md
+echo "**Learning:** In TrikeShed, using \`(0 until series.size).map { series[it] }.filter { ... }.toSeries()\` or \`...plus(item).toSeries()\` on a \`Series\` object creates expensive intermediate \`ArrayList\` allocations, wasting O(N) memory and time. The \`Series\` collection provides a zero-allocation \`j\` infix constructor for mapping/appending elements and a native \`.filter\` extension (which requires importing \`borg.trikeshed.lib.filter\`) that returns a filtered \`Series\` natively." >> .jules/bolt.md
+echo "**Action:** Use the \`j\` infix constructor (e.g., \`(size + 1) j { i -> if (i < size) arr[i] else new_element }\`) and native \`.filter\` extensions directly on \`Series\` collections to prevent intermediate List heap allocations." >> .jules/bolt.md

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/LcncGraph.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/LcncGraph.kt
@@ -2,6 +2,7 @@ package borg.trikeshed.lcnc
 
 import borg.trikeshed.lib.Series
 import borg.trikeshed.lib.emptySeriesOf
+import borg.trikeshed.lib.filter
 import borg.trikeshed.lib.get
 import borg.trikeshed.lib.j
 import borg.trikeshed.lib.size
@@ -89,18 +90,21 @@ data class LcncConfixControls(
     fun addMatingPoint(point: LcncPatchMatingPoint): LcncConfixControls {
         point.validate()
         require((0 until matingPoints.size).none { matingPoints[it].id == point.id }) { "duplicate mating point: ${point.id}" }
-        return copy(matingPoints = (0 until matingPoints.size).map { matingPoints[it] }.plus(point).toSeries())
+        // Bolt: Use zero-allocation 'j' constructor instead of intermediate List allocations and copies via .map { ... }.plus(...).toSeries()
+        return copy(matingPoints = (matingPoints.size + 1) j { i -> if (i < matingPoints.size) matingPoints[i] else point })
     }
 
     fun updateMatingPoint(point: LcncPatchMatingPoint): LcncConfixControls {
         point.validate()
         require((0 until matingPoints.size).any { matingPoints[it].id == point.id }) { "unknown mating point: ${point.id}" }
-        return copy(matingPoints = (0 until matingPoints.size).map { if (matingPoints[it].id == point.id) point else matingPoints[it] }.toSeries())
+        // Bolt: Use zero-allocation 'j' constructor instead of intermediate List allocations via .map { ... }.toSeries()
+        return copy(matingPoints = matingPoints.size j { i -> if (matingPoints[i].id == point.id) point else matingPoints[i] })
     }
 
     fun removeMatingPoint(id: String): LcncConfixControls {
         require((0 until matingPoints.size).any { matingPoints[it].id == id }) { "unknown mating point: $id" }
-        return copy(matingPoints = (0 until matingPoints.size).map { matingPoints[it] }.filter { it.id != id }.toSeries())
+        // Bolt: Use native Series.filter directly to avoid intermediate List allocations via .map { ... }.filter { ... }.toSeries()
+        return copy(matingPoints = matingPoints.filter { it.id != id })
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced intermediate `List` allocations (via `(0 until size).map { ... }.plus(...).toSeries()` and `...filter{...}.toSeries()`) with the zero-allocation `j` constructor and native `Series.filter` when updating `matingPoints`.
🎯 Why: To reduce memory allocations and garbage collection pressure when executing hot paths involved with patching and maintaining the LCNC graph mating structures.
📊 Impact: Eliminates `O(N)` heap allocations per modification to the graph control's `matingPoints` Series structure.
🔬 Measurement: Verified by `LcncGraphTest`, `LcncProgramConfixTest`, and `LcncShakeDemoTest` which assert the correctness of manipulating `LcncGraph` structures.

---
*PR created automatically by Jules for task [17175416142296165738](https://jules.google.com/task/17175416142296165738) started by @jnorthrup*