### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix DoS via pipe buffer deadlock and ProcessBuilder leak in FunnelMergeBranchesCli

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -67,3 +67,8 @@
 **Vulnerability:** ProcessBuilder in `OroborosDaemon.kt` inherited the host process environment variables by default when spawning `git fetch` and `git rev-parse`, potentially leaking daemon secrets like API keys to git credential helpers or pre-commit hooks.
 **Learning:** Process spawns, even for trusted binaries like `git`, must explicitly clear the environment and use a whitelisted environment to prevent accidental leakages through credential helpers or hooks.
 **Prevention:** Always explicitly call `environment().clear()` and populate it with `GuestEnvironment.curated()` before starting any process with `ProcessBuilder`.
+
+## 2024-05-28 - [Denial of Service and Env Leak in FunnelMergeBranchesCli]
+**Vulnerability:** Found `waitFor()` being called on a `Process` without a timeout and while synchronously reading from the process `InputStream` in `gitIn` and `gradle` functions of `FunnelMergeBranchesCli.kt`. The `ProcessBuilder` was also inheriting the host environment variables, potentially leaking secrets to arbitrary processes.
+**Learning:** `Process.waitFor()` without a timeout and synchronous reading before it guarantees a pipe buffer deadlock DoS if the process hangs or fills the buffer. Inherited `ProcessBuilder` environments leak sensitive host daemon secrets.
+**Prevention:** Always read process streams asynchronously (e.g., using `CompletableFuture.supplyAsync`), use bounded `waitFor(timeout, TimeUnit)` with forceful termination `destroyForcibly()` on timeout, and always explicitly clear and populate `environment()` with `GuestEnvironment.curated()`.

--- a/src/jvmMain/kotlin/borg/trikeshed/cas/FunnelMergeBranchesCli.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/cas/FunnelMergeBranchesCli.kt
@@ -229,17 +229,31 @@ class FunnelMergeBranchesCli(private val repoDir: File, private val since: Strin
 
     private fun gitIn(dir: File, vararg args: String): Pair<Int, String> {
         val pb = ProcessBuilder(listOf("git") + args).directory(dir).redirectErrorStream(true)
+        pb.environment().apply { clear(); putAll(borg.trikeshed.graal.subvm.GuestEnvironment.curated()) }
         val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        return proc.waitFor() to out
+        val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { proc.inputStream.bufferedReader().readText() }
+        val finished = proc.waitFor(5, java.util.concurrent.TimeUnit.MINUTES)
+        if (!finished) {
+            proc.destroyForcibly()
+            proc.waitFor()
+        }
+        val out = runCatching { outAsync.get() }.getOrDefault("")
+        return proc.exitValue() to out
     }
 
     private fun gradle(dir: File, task: String): Pair<Int, String> {
         val gradlew = File(dir, "gradlew")
         val pb = ProcessBuilder(if (gradlew.canExecute()) "./gradlew" else "gradle", task, "--console=plain", "-q")
             .directory(dir).redirectErrorStream(true)
+        pb.environment().apply { clear(); putAll(borg.trikeshed.graal.subvm.GuestEnvironment.curated()) }
         val proc = pb.start()
-        val out = proc.inputStream.bufferedReader().readText()
-        return proc.waitFor() to out
+        val outAsync = java.util.concurrent.CompletableFuture.supplyAsync { proc.inputStream.bufferedReader().readText() }
+        val finished = proc.waitFor(15, java.util.concurrent.TimeUnit.MINUTES)
+        if (!finished) {
+            proc.destroyForcibly()
+            proc.waitFor()
+        }
+        val out = runCatching { outAsync.get() }.getOrDefault("")
+        return proc.exitValue() to out
     }
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `Process.waitFor()` was called in `FunnelMergeBranchesCli.kt` without a timeout, and while reading synchronously from `InputStream`, allowing a hanging subprocess or a filled pipe buffer to cause a DoS deadlock. Additionally, `ProcessBuilder` was inheriting the entire daemon environment (including secrets).
🎯 **Impact:** Potential thread starvation and DoS, as well as leaking API keys from the daemon environment to subprocesses.
🔧 **Fix:** Changed stream reading to `CompletableFuture.supplyAsync()`, used bounded `waitFor(timeout)` followed by `destroyForcibly()` and another `waitFor()` to prevent `IllegalThreadStateException`, and explicitly cleared `environment()` to only populate `GuestEnvironment.curated()`.
✅ **Verification:** Verified compilation via `./gradlew :jvmMainClasses` completes without issue.

---
*PR created automatically by Jules for task [15533929294936202228](https://jules.google.com/task/15533929294936202228) started by @jnorthrup*