### PR TITLE
⚡ Bolt: [performance improvement] Avoid .view.toList() coercion on Series to satisfy List returns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -259,3 +259,7 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2026-11-21 - Series collection return type mismatch
 **Learning:** In TrikeShed, `Series` implements the standard Kotlin `List` interface. The custom `.filter` extension natively returns a `Series`. Therefore, chaining `.toList()` or `.map { it }` on the result of `Series.filter { ... }` just to satisfy a `List` return type is an anti-pattern. It creates an unnecessary O(N) memory allocation and copy.
 **Action:** Return the `Series` directly whenever a `List` is expected instead of coercing it to an `ArrayList` via `.toList()` or `.map { it }`.
+
+## 2024-06-05 - Avoid .view.toList() coercion on Series to satisfy List returns
+**Learning:** In TrikeShed, Series implements List. Coercing a filtered Series to a List via .view.toList() is unnecessary and causes O(N) allocation.
+**Action:** Return the Series directly instead of calling .view.toList().

--- a/src/commonMain/kotlin/borg/trikeshed/kanban/KanbanGraph.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/kanban/KanbanGraph.kt
@@ -107,7 +107,7 @@ data class KanbanGraph(
     fun edgesInGroup(group: String?): List<KanbanEdge> =
         if (group == null) emptyList()
         // Bolt: Removed redundant identity map to avoid O(N) allocation
-        else edges.filter { it.group == group }.view.toList()
+        else edges.filter { it.group == group }
 }
 
 fun interface KanbanPredicate { fun test(card: KanbanCardState, edge: KanbanEdge): Boolean }


### PR DESCRIPTION
💡 What: Removed an unnecessary `.view.toList()` call on a `Series` in `KanbanGraph.kt` when the method already returns a `List`.
🎯 Why: `Series` implements the `List` interface natively. Calling `.view.toList()` forces the creation of an entirely new `ArrayList` copy, generating pure memory garbage (O(N) allocation) for no functional benefit.
📊 Impact: Eliminates an O(N) list allocation whenever `KanbanGraph.edges(group)` is called.
🔬 Measurement: Verify by checking that `KanbanGraph.edges(group)` returns a `Series` directly rather than an `ArrayList`.

---
*PR created automatically by Jules for task [14540632816750638158](https://jules.google.com/task/14540632816750638158) started by @jnorthrup*