### PR TITLE
⚡ Bolt: [performance improvement] Eliminate filterIsInstance ArrayList allocations in DocumentSurfacePage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -263,3 +263,6 @@ The code looks correct and fully optimized. The tests passed on the relevant par
 ## 2024-06-05 - Avoid .view.toList() coercion on Series to satisfy List returns
 **Learning:** In TrikeShed, Series implements List. Coercing a filtered Series to a List via .view.toList() is unnecessary and causes O(N) allocation.
 **Action:** Return the Series directly instead of calling .view.toList().
+## 2025-02-28 - Avoid intermediate ArrayList allocations with filterIsInstance
+**Learning:** By default, `Iterable.filterIsInstance<T>()` iterates over the entire collection and allocates a new `ArrayList` containing the filtered items.
+**Action:** Replace `for (item in list.filterIsInstance<T>())` with a standard `for (item in list)` loop containing an `if (item is T)` check to eliminate intermediate allocations. Similarly, replace `.filterIsInstance<T>().firstOrNull { ... }` with `.firstOrNull { it is T && ... } as? T`.

--- a/src/jsMain/kotlin/borg/trikeshed/docs/DocumentSurfacePage.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/docs/DocumentSurfacePage.kt
@@ -138,9 +138,12 @@ object DocumentSurfacePage {
      * exactly as they are using it.
      */
     private suspend fun refreshBlocks() {
-        for (spec in blocks.filterIsInstance<RunBlock.Spec>()) {
-            val state = RunBlock.state(getJson(headUrl(spec))) ?: continue
-            if (runStates.put(spec.ordinal, state) != state) repaint(spec, state)
+        // Bolt: avoid intermediate ArrayList allocation from filterIsInstance
+        for (spec in blocks) {
+            if (spec is RunBlock.Spec) {
+                val state = RunBlock.state(getJson(headUrl(spec))) ?: continue
+                if (runStates.put(spec.ordinal, state) != state) repaint(spec, state)
+            }
         }
     }
 
@@ -161,7 +164,8 @@ object DocumentSurfacePage {
      * resolves; another tab reads the same run off the board.
      */
     private suspend fun press(ordinal: Int?, rebuild: Boolean) {
-        val spec = blocks.filterIsInstance<RunBlock.Spec>().firstOrNull { it.ordinal == ordinal } ?: return
+        // Bolt: avoid intermediate ArrayList allocation from filterIsInstance
+        val spec = blocks.firstOrNull { it is RunBlock.Spec && it.ordinal == ordinal } as? RunBlock.Spec ?: return
         val prior = runStates[spec.ordinal]
         val (url, body) = if (rebuild) (RunBlock.rebuildRequest(prior) ?: return) else RunBlock.buildRequest(spec)
         val pending = RunBlock.pending(prior)


### PR DESCRIPTION
💡 **What**: Removed intermediate `ArrayList` allocations caused by `Iterable.filterIsInstance<RunBlock.Spec>()` in `DocumentSurfacePage.kt`'s hot paths (the 3-second `refreshBlocks` polling and the `press` handler).
🎯 **Why**: `filterIsInstance` greedily allocates and populates a new `ArrayList` before continuing iteration. Doing this inside a repeating 3-second JS interval (`refreshBlocks`) or a UI event handler creates unnecessary GC pressure and object allocations in the browser.
📊 **Impact**: Reduces short-lived object allocations per poll interval from O(N) (creating a list of matching blocks) to O(1) (zero allocations, direct iteration/lookup).
🔬 **Measurement**: Inspect memory profiling in the browser during document idle polling. The number of garbage collections triggered by the 3000ms loop will decrease since no intermediate lists are created.

---
*PR created automatically by Jules for task [16892719778966065280](https://jules.google.com/task/16892719778966065280) started by @jnorthrup*