### PR TITLE
⚡ Bolt: [performance improvement] Avoid intermediate List allocations in DocumentSurfacePage

### DIFF
--- a/src/jsMain/kotlin/borg/trikeshed/docs/DocumentSurfacePage.kt
+++ b/src/jsMain/kotlin/borg/trikeshed/docs/DocumentSurfacePage.kt
@@ -138,7 +138,9 @@ object DocumentSurfacePage {
      * exactly as they are using it.
      */
     private suspend fun refreshBlocks() {
-        for (spec in blocks.filterIsInstance<RunBlock.Spec>()) {
+        // Bolt: avoid intermediate List/Sequence allocation from filterIsInstance
+        for (spec in blocks) {
+            if (spec !is RunBlock.Spec) continue
             val state = RunBlock.state(getJson(headUrl(spec))) ?: continue
             if (runStates.put(spec.ordinal, state) != state) repaint(spec, state)
         }
@@ -161,7 +163,8 @@ object DocumentSurfacePage {
      * resolves; another tab reads the same run off the board.
      */
     private suspend fun press(ordinal: Int?, rebuild: Boolean) {
-        val spec = blocks.filterIsInstance<RunBlock.Spec>().firstOrNull { it.ordinal == ordinal } ?: return
+        // Bolt: avoid intermediate List/Sequence allocation from filterIsInstance
+        val spec = blocks.firstOrNull { it is RunBlock.Spec && it.ordinal == ordinal } as? RunBlock.Spec ?: return
         val prior = runStates[spec.ordinal]
         val (url, body) = if (rebuild) (RunBlock.rebuildRequest(prior) ?: return) else RunBlock.buildRequest(spec)
         val pending = RunBlock.pending(prior)


### PR DESCRIPTION
💡 What: Replaced `.filterIsInstance<T>()` chained calls with direct inline type checking and `firstOrNull` condition combinations in `DocumentSurfacePage.kt`.
🎯 Why: Chaining `.filterIsInstance<T>()` before iterating or searching allocates an intermediate `ArrayList` containing the filtered elements. Since `refreshBlocks` is polled repeatedly on an interval and `press` handles user interactions, this causes unnecessary garbage collection pressure and wastes cycles iterating twice.
📊 Impact: Eliminates O(N) intermediate List allocations on each poll/press cycle when checking block types.
🔬 Measurement: Verify tests run successfully (ignoring existing commonMain build failures) and observe zero intermediate allocations in heap profiles during document auto-poll operations.

---
*PR created automatically by Jules for task [14733174020479214249](https://jules.google.com/task/14733174020479214249) started by @jnorthrup*