### PR TITLE
⚡ Bolt: [performance improvement] Avoid filterIsInstance for Collection Performance

### DIFF
--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/CcekNodes.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/CcekNodes.kt
@@ -576,7 +576,16 @@ object CcekNodes {
         else -> emptyMap()
     }
     private fun rows(value: Any?): List<Map<String, Any?>> = when (value) {
-        is List<*> -> value.filterIsInstance<Map<*, *>>().map { m -> m.entries.associate { (k, v) -> k.toString() to v } }
+        is List<*> -> {
+            // Bolt: Avoid filterIsInstance for Collection Performance
+            val list = ArrayList<Map<String, Any?>>()
+            for (m in value) {
+                if (m is Map<*, *>) {
+                    list.add(m.entries.associate { (k, v) -> k.toString() to v })
+                }
+            }
+            list
+        }
         is String -> if (value.isBlank()) emptyList() else rows(JsonSupport.parse(value))
         else -> emptyList()
     }


### PR DESCRIPTION
💡 **What:** Replaced `value.filterIsInstance<Map<*, *>>().map { ... }` in `CcekNodes.kt`'s `rows()` function with a single `for` loop.

🎯 **Why:** Chaining standard Kotlin iterable operations like `filterIsInstance` followed by `map` creates temporary intermediate `ArrayList`s under the hood. For frequently called mapping operations during parsing, skipping this intermediate collection allocation saves memory and CPU cycles that would otherwise be spent constructing and garbage collecting the temporary lists.

📊 **Impact:** Reduces O(N) memory allocations for intermediate list structures when evaluating LCNC node schemas or processing data payloads holding nested lists of dictionaries.

🔬 **Measurement:** Verify successful test suite run by calling `./gradlew :jvmTest --tests 'borg.trikeshed.lcnc.CcekNodesTest' --no-daemon`. Profiling JVM memory allocations should show fewer `ArrayList` creations during graph evaluation.

---
*PR created automatically by Jules for task [14145893956970178896](https://jules.google.com/task/14145893956970178896) started by @jnorthrup*