### PR TITLE
⚡ Bolt: Optimize LcncKanbanExperience Series mappings

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-20 - Avoid filterIsInstance for Collection Performance
 **Learning:** Chaining `.filterIsInstance<T>()` and `.map { ... }` on iterables in Kotlin creates unnecessary intermediate `ArrayList` allocations.
 **Action:** Use a single `for` loop with a type-check `if (item is T)` or `is T` to construct the final list directly, avoiding intermediate allocations.
+## 2024-09-12 - Series Iteration Allocations
+**Learning:** In TrikeShed, calling .toList() on collections (like maps/collections) or custom Series before operations like map or sortedBy causes unnecessary O(N) intermediate List allocations.
+**Action:** For map on standard collections, avoid toList(); for operations like sortedBy on Series, use .view instead of .toList().

--- a/src/commonMain/kotlin/borg/trikeshed/lcnc/LcncKanbanExperience.kt
+++ b/src/commonMain/kotlin/borg/trikeshed/lcnc/LcncKanbanExperience.kt
@@ -12,6 +12,7 @@ import borg.trikeshed.parse.confix.confixDoc
 import borg.trikeshed.parse.json.JsonSupport
 import kotlinx.coroutines.CompletableDeferred
 import borg.trikeshed.lib.toList
+import borg.trikeshed.lib.view
 
 /**
  * The LCNC-only Kanban surface. It owns no shadow board state: commands enter
@@ -78,8 +79,9 @@ class LcncKanbanExperience(
             "byPriority" to LcncOperationalSheets.byPriority(store).map(SheetSeed::toLcncMap),
             "boardView" to board.toBoardMap(store.lastSequence, "Kanban board (live)"),
             "orchestration" to orchestrationMap,
-            "laneOrder" to orchestration.lanes.toList().sortedBy { it.order }.map { it.id },
-            "conditions" to orchestration.edges.toList().mapNotNull { it.condition?.let { c -> mapOf("edge" to it.id, "predicate" to c.predicate, "parameters" to c.parameters) } },
+            // Bolt: Avoid intermediate O(N) list allocations by replacing .toList() with .view
+            "laneOrder" to orchestration.lanes.view.sortedBy { it.order }.map { it.id },
+            "conditions" to orchestration.edges.view.mapNotNull { it.condition?.let { c -> mapOf("edge" to it.id, "predicate" to c.predicate, "parameters" to c.parameters) } },
         )
     }
 

--- a/src/jvmMain/kotlin/borg/trikeshed/lcnc/PromptStore.kt
+++ b/src/jvmMain/kotlin/borg/trikeshed/lcnc/PromptStore.kt
@@ -78,7 +78,8 @@ class PromptStore(
         return doc
     }
 
-    override fun heads(): List<PromptHead> = heads.values.toList().map {
+    // Bolt: Avoid intermediate O(N) list allocations by using native map
+    override fun heads(): List<PromptHead> = heads.values.map {
         PromptHead(it.name, it.cid, it.previousCid, it.role, it.variables, it.tags, it.text.length, savedAt[it.name] ?: 0L)
     }
 


### PR DESCRIPTION
💡 What: Replaced `.toList().sortedBy` and `.toList().mapNotNull` on Series with `.view.sortedBy` and `.view.mapNotNull`. Replaced `Map.values.toList().map` with `Map.values.map`.
🎯 Why: Avoid intermediate O(N) List allocations before standard iterable extensions.
📊 Impact: Reduced memory overhead during `LcncKanbanExperience` orchestration construction and `PromptStore` head generation.
🔬 Measurement: Local unit testing and visual review.

---
*PR created automatically by Jules for task [8058665127711536942](https://jules.google.com/task/8058665127711536942) started by @jnorthrup*