### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to icon-only buttons

### DIFF
--- a/src/commonMain/resources/web/harness.html
+++ b/src/commonMain/resources/web/harness.html
@@ -45,8 +45,8 @@
   <button id="sheetsBtn" title="every territory as grid-in-cell sheets (CursorSheet) — a container cell drills in, the crumb climbs out">▤ sheets</button>
   <button id="exportBtn">export</button>
   <button id="importBtn">import</button>
-  <button id="undoBtn" title="undo ⌘Z" disabled>↶</button>
-  <button id="redoBtn" title="redo ⇧⌘Z" disabled>↷</button>
+  <button id="undoBtn" title="undo ⌘Z" aria-label="Undo" disabled>↶</button>
+  <button id="redoBtn" title="redo ⇧⌘Z" aria-label="Redo" disabled>↷</button>
   <button id="clearBtn">clear</button>
   <button id="qsBtn" aria-label="Run quickstart" title="run the quickstart in anger" style="border-color:#3ddc84;color:#3ddc84">⚡</button>
   <button id="fbBtn" aria-label="Provide feedback" title="open a GitHub issue prefilled with this construction's coordinates" style="border-color:var(--warn);color:var(--warn)">⚑</button>

--- a/src/commonMain/resources/web/kanban.html
+++ b/src/commonMain/resources/web/kanban.html
@@ -563,7 +563,7 @@ function cardEl(it, tree, lane) {
   el.innerHTML = `<div class="t">${escapeHtml(it.title || it.id)}</div>
     ${tags}${deps}${chip}${tally}
     <div class="meta">${owner}${heat}<span>r${it.revision}</span></div>
-    <button class="archive" title="Archive this card">×</button>`;
+    <button class="archive" title="Archive this card" aria-label="Archive this card">×</button>`;
   el.querySelector(".archive").addEventListener("click", () => archiveCard(it));
   // A live flash survives the rebuild: resume the animation at phase.
   const fl = flashes.get(it.id);

--- a/src/commonMain/resources/web/panels.html
+++ b/src/commonMain/resources/web/panels.html
@@ -404,8 +404,8 @@ button{border-radius:6px;padding:4px 12px;transition:border-color .12s,color .12
   <button id="keysBtn" title="keymux endpoints — names & addresses; key values never cross">⚿ keys</button>
   <button id="exportBtn">export</button>
   <button id="importBtn">import</button>
-  <button id="undoBtn" title="undo ⌘Z" disabled>↶</button>
-  <button id="redoBtn" title="redo ⇧⌘Z" disabled>↷</button>
+  <button id="undoBtn" title="undo ⌘Z" aria-label="Undo" disabled>↶</button>
+  <button id="redoBtn" title="redo ⇧⌘Z" aria-label="Redo" disabled>↷</button>
   <button id="clearBtn">clear</button>
   <button id="qsBtn" aria-label="Run quickstart" title="run the quickstart in anger" style="border-color:#3ddc84;color:#3ddc84">⚡</button>
   <button id="fbBtn" aria-label="Provide feedback" title="open a GitHub issue prefilled with this construction's coordinates" style="border-color:var(--warn);color:var(--warn)">⚑</button>


### PR DESCRIPTION
**💡 What:** Added `aria-label` attributes to icon-only buttons across the frontend (Undo, Redo, and Archive buttons).
**🎯 Why:** Screen readers could not announce the purpose of these buttons because they only contained icons (`↶`, `↷`, and `×`). Adding explicit `aria-label`s makes these actions accessible to visually impaired users.
**📸 Before/After:** N/A (non-visual change)
**♿ Accessibility:** Improves screen reader compatibility by explicitly labelling icon-only buttons that previously lacked descriptive text or labels.

---
*PR created automatically by Jules for task [14699588800147343872](https://jules.google.com/task/14699588800147343872) started by @jnorthrup*